### PR TITLE
Fix bottom navigation bar visibility

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,13 @@ class CalisthenicsApp extends StatelessWidget {
           foregroundColor: Colors.white,
         ),
         primaryColor: Colors.black,
+        bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+          backgroundColor: Colors.black,
+          selectedItemColor: Colors.blue,
+          unselectedItemColor: Colors.white70,
+          showUnselectedLabels: true,
+          type: BottomNavigationBarType.fixed,
+        ),
         colorScheme: ColorScheme.fromSeed(
           seedColor: Colors.black,
           brightness: Brightness.dark,

--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -80,6 +80,7 @@ class _HomePageState extends State<HomePage> {
       body: pages[selectedIndex],
 
       bottomNavigationBar: BottomNavigationBar(
+        type: BottomNavigationBarType.fixed,
         currentIndex: selectedIndex,
         onTap: (int index) {
           setState(() {


### PR DESCRIPTION
## Summary
- theme the bottom navigation bar so it uses contrasting colors
- force the navigation bar into the fixed layout to keep all destinations visible

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f4f92feae88333a3d1e06765bd1b26