### PR TITLE
Load workout days from Supabase

### DIFF
--- a/lib/model/models.dart
+++ b/lib/model/models.dart
@@ -9,5 +9,6 @@ export './set_logs.dart';
 export './shares.dart';
 export './template_exercises.dart';
 export './training_plans.dart';
+export './workout_day.dart';
 export './workout_sessions.dart';
 export './workout_templates.dart';

--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -1,0 +1,40 @@
+class WorkoutExercise {
+  final String? id;
+  final String name;
+  final int? sets;
+  final int? reps;
+  final int? restSeconds;
+  final String? intensity;
+  final String? notes;
+
+  const WorkoutExercise({
+    required this.name,
+    this.id,
+    this.sets,
+    this.reps,
+    this.restSeconds,
+    this.intensity,
+    this.notes,
+  });
+
+  Duration? get restDuration =>
+      restSeconds != null ? Duration(seconds: restSeconds!) : null;
+}
+
+class WorkoutDay {
+  final String? id;
+  final int week;
+  final int dow;
+  final String? name;
+  final String? notes;
+  final List<WorkoutExercise> exercises;
+
+  const WorkoutDay({
+    required this.week,
+    required this.dow,
+    required this.exercises,
+    this.id,
+    this.name,
+    this.notes,
+  });
+}


### PR DESCRIPTION
## Summary
- fetch the latest training plan and workouts from Supabase in the home page
- render workout day selection dynamically and update the training view to use Supabase exercises
- add a reusable model for workout days and exercises

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f4f94b870c833395ff77495ac3e794