### PR TITLE
Refactor workout day title helpers

### DIFF
--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -29,6 +29,16 @@ class WorkoutDay {
   final String? notes;
   final List<WorkoutExercise> exercises;
 
+  static const Map<int, String> _dowLabels = {
+    1: 'Lunedì',
+    2: 'Martedì',
+    3: 'Mercoledì',
+    4: 'Giovedì',
+    5: 'Venerdì',
+    6: 'Sabato',
+    7: 'Domenica',
+  };
+
   const WorkoutDay({
     required this.week,
     required this.dow,
@@ -37,4 +47,21 @@ class WorkoutDay {
     this.name,
     this.notes,
   });
+
+  String? get dowLabel => _dowLabels[dow];
+
+  String formattedTitle({String fallback = 'Allenamento'}) {
+    final parts = <String>[];
+    if (week > 0) {
+      parts.add('Settimana $week');
+    }
+    final dowName = dowLabel;
+    if (dowName != null) {
+      parts.add(dowName);
+    }
+    if (name != null && name!.isNotEmpty) {
+      parts.add(name!);
+    }
+    return parts.isEmpty ? fallback : parts.join(' · ');
+  }
 }

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -126,9 +126,8 @@ class _HomeContentState extends State<HomeContent> {
                 }
 
                 final day = days[index];
-                final title = _formatDayTitle(day);
                 return SelectionCard(
-                  title: title,
+                  title: day.formattedTitle(),
                   icon: Icons.calendar_today,
                   onTap: () {
                     Navigator.push(
@@ -229,31 +228,4 @@ class _HomeContentState extends State<HomeContent> {
     }).toList();
   }
 
-  String _formatDayTitle(WorkoutDay day) {
-    final parts = <String>[];
-    if (day.week > 0) {
-      parts.add('Settimana ${day.week}');
-    }
-    final dowName = _dowLabel(day.dow);
-    if (dowName != null) {
-      parts.add(dowName);
-    }
-    if (day.name != null && day.name!.isNotEmpty) {
-      parts.add(day.name!);
-    }
-    return parts.isEmpty ? 'Allenamento' : parts.join(' · ');
-  }
-
-  String? _dowLabel(int dow) {
-    const labels = {
-      1: 'Lunedì',
-      2: 'Martedì',
-      3: 'Mercoledì',
-      4: 'Giovedì',
-      5: 'Venerdì',
-      6: 'Sabato',
-      7: 'Domenica',
-    };
-    return labels[dow];
-  }
 }

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -23,7 +23,7 @@ class Training extends StatelessWidget {
     ];
 
     return Scaffold(
-      appBar: AppBar(title: Text(_buildTitle())),
+      appBar: AppBar(title: Text(day.formattedTitle())),
       body: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Padding(
@@ -117,21 +117,6 @@ class Training extends StatelessWidget {
     );
   }
 
-  String _buildTitle() {
-    final parts = <String>[];
-    if (day.week > 0) {
-      parts.add('Settimana ${day.week}');
-    }
-    final dowName = _dowLabel(day.dow);
-    if (dowName != null) {
-      parts.add(dowName);
-    }
-    if (day.name != null && day.name!.isNotEmpty) {
-      parts.add(day.name!);
-    }
-    return parts.isEmpty ? 'Allenamento' : parts.join(' · ');
-  }
-
   void _openTools(BuildContext context, WorkoutExercise exercise) {
     final restDuration = exercise.restDuration;
     final reps = exercise.reps;
@@ -195,18 +180,5 @@ class Training extends StatelessWidget {
       return '${minutes}m';
     }
     return '${seconds}s';
-  }
-
-  String? _dowLabel(int dow) {
-    const labels = {
-      1: 'Lunedì',
-      2: 'Martedì',
-      3: 'Mercoledì',
-      4: 'Giovedì',
-      5: 'Venerdì',
-      6: 'Sabato',
-      7: 'Domenica',
-    };
-    return labels[dow];
   }
 }


### PR DESCRIPTION
## Summary
- add reusable title formatting helpers to the WorkoutDay model
- reuse the shared helpers across home and training pages to remove duplicated day-label code

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f5005272ec8333a25cab3384ef1aaf