### PR TITLE
Add localization support and extract UI strings

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,225 @@
+{
+  "appTitle": "Calisync",
+  "authErrorMessage": "Authentication error",
+  "navHome": "Home",
+  "navSettings": "Settings",
+  "navProfile": "Profile",
+  "navTerminology": "Terminology",
+  "settingsComingSoon": "Settings coming soon.",
+  "exerciseTrackerTitle": "Exercise tracker",
+  "poseEstimationTitle": "Pose estimation",
+  "homeLoadErrorTitle": "Unable to load workouts",
+  "retry": "Retry",
+  "homeEmptyTitle": "No workouts available",
+  "homeEmptyDescription": "Contact your coach to receive a new plan.",
+  "unauthenticated": "User not authenticated",
+  "defaultExerciseName": "Exercise",
+  "generalNotes": "General notes",
+  "trainingHeaderExercise": "Exercise",
+  "trainingHeaderSets": "Sets",
+  "trainingHeaderReps": "Repetitions",
+  "trainingHeaderRest": "Rest",
+  "trainingHeaderIntensity": "Intensity",
+  "trainingHeaderNotes": "Notes",
+  "logoutError": "Error while logging out: {error}",
+  "@logoutError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "profileFallbackName": "User",
+  "userNotFound": "User not found in the database",
+  "profileLoadError": "Error loading data",
+  "profileNoData": "No data available",
+  "profileEmailUnavailable": "Email not available",
+  "profileStatusActive": "Active account",
+  "profileStatusInactive": "Inactive account",
+  "profilePlanActive": "Active plan",
+  "profilePlanExpired": "Plan expired",
+  "profileUsername": "Username",
+  "profileLastUpdated": "Last updated",
+  "profileValueUnavailable": "Not available",
+  "profileTimezone": "Time zone",
+  "profileNotSet": "Not set",
+  "profileUnitSystem": "Unit system",
+  "profileEdit": "Edit profile",
+  "profileComingSoon": "Coming soon",
+  "featureUnavailable": "Feature not available yet.",
+  "logout": "Log out",
+  "redirectError": "Error during redirect: {error}",
+  "@redirectError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "linkError": "Link error: {error}",
+  "@linkError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "missingFieldsError": "Please fill out all required fields.",
+  "passwordMismatch": "Passwords do not match.",
+  "invalidCredentials": "Invalid credentials.",
+  "signupEmailCheck": "Sign-up complete! Check your email to confirm your account.",
+  "unexpectedError": "Unexpected error: {error}",
+  "@unexpectedError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "googleSignInFailed": "Google Sign-In failed: {error}",
+  "@googleSignInFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loginGreeting": "Welcome back! Sign in to continue your training.",
+  "signupGreeting": "Create an account to unlock all workouts.",
+  "emailLabel": "Email",
+  "passwordLabel": "Password",
+  "confirmPasswordLabel": "Confirm password",
+  "loginButton": "Sign in",
+  "signupButton": "Sign up",
+  "noAccountPrompt": "Don't have an account? Sign up",
+  "existingAccountPrompt": "Already have an account? Sign in",
+  "orDivider": "or",
+  "connecting": "Connecting...",
+  "continueWithGoogle": "Continue with Google",
+  "exerciseAddDialogTitle": "Add exercise",
+  "exerciseNameLabel": "Exercise name",
+  "quickAddValuesLabel": "Quick add values",
+  "quickAddValuesHelper": "Comma separated repetitions (e.g. 1,5,10)",
+  "cancel": "Cancel",
+  "add": "Add",
+  "exerciseNameMissing": "Please provide a name.",
+  "exerciseTrackerEmpty": "No exercises yet. Tap + to add one!",
+  "exerciseAddButton": "Add exercise",
+  "exercisePushUps": "Push-ups",
+  "exercisePullUps": "Pull-ups",
+  "exerciseChinUps": "Chin-ups",
+  "exerciseTotalReps": "{count} total reps",
+  "@exerciseTotalReps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "undoLastSet": "Undo last set",
+  "custom": "Custom",
+  "reset": "Reset",
+  "logRepsTitle": "Log reps",
+  "repetitionsLabel": "Repetitions",
+  "positiveNumberError": "Enter a positive number.",
+  "repsChip": "{count} reps",
+  "@repsChip": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "goalCount": "Goal: {count}",
+  "@goalCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "repGoalReached": "Rep goal reached!",
+  "pause": "Pause",
+  "start": "Start",
+  "seriesCount": "Sets: {count}",
+  "@seriesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "resetReps": "Reset reps",
+  "timerTitle": "Timer",
+  "weekdayMonday": "Monday",
+  "weekdayTuesday": "Tuesday",
+  "weekdayWednesday": "Wednesday",
+  "weekdayThursday": "Thursday",
+  "weekdayFriday": "Friday",
+  "weekdaySaturday": "Saturday",
+  "weekdaySunday": "Sunday",
+  "weekNumber": "Week {week}",
+  "@weekNumber": {
+    "placeholders": {
+      "week": {
+        "type": "int"
+      }
+    }
+  },
+  "defaultWorkoutTitle": "Workout",
+  "terminologyTitle": "Terminology",
+  "termRepsTitle": "Reps",
+  "termRepsDescription": "Number of times you perform an exercise consecutively.",
+  "termSetTitle": "Set",
+  "termSetDescription": "A group of repetitions. For example: 3 sets of 10 reps means 30 repetitions total divided into 3 groups.",
+  "termRtTitle": "RT",
+  "termRtDescription": "Total Repetitions: perform all the reps with your preferred sets, reps, and tempo (if not specified).",
+  "termAmrapTitle": "AMRAP",
+  "termAmrapDescription": "As Many Reps As Possible: perform as many reps as you can in a given time.",
+  "termEmomTitle": "EMOM",
+  "termEmomDescription": "Every Minute on the Minute: start a set every minute. Rest during the remaining time.",
+  "termRampingTitle": "Ramping",
+  "termRampingDescription": "Method where the load increases with each set.",
+  "termMavTitle": "MAV",
+  "termMavDescription": "Massima Alzata Veloce: perform as many reps as possible with a load while keeping control and good speed.",
+  "termIsocineticiTitle": "Isokinetic",
+  "termIsocineticiDescription": "Exercises performed at a constant speed.",
+  "termTutTitle": "TUT",
+  "termTutDescription": "Indicates how long a repetition should last. You can manage the duration of each phase.",
+  "termIsoTitle": "ISO",
+  "termIsoDescription": "Indicates a pause at a specific point of the repetition.",
+  "termSomTitle": "SOM",
+  "termSomDescription": "Indicates the duration of each phase of the repetition.",
+  "termScaricoTitle": "Deload",
+  "termScaricoDescription": "Last week of the program to prepare for max attempts.",
+  "noCameras": "No cameras available",
+  "cameraInitFailed": "Camera init failed: {error}",
+  "@cameraInitFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "poseDetected": "Pose detected",
+  "processing": "Processing…",
+  "idle": "Idle",
+  "cameraFront": "front",
+  "cameraBack": "back",
+  "hudMetrics": "fps: {fps}  ms: {milliseconds}  lmks: {landmarks}",
+  "@hudMetrics": {
+    "placeholders": {
+      "fps": {
+        "type": "String"
+      },
+      "milliseconds": {
+        "type": "String"
+      },
+      "landmarks": {
+        "type": "int"
+      }
+    }
+  },
+  "hudOrientation": "rot: {rotation}  cam: {camera}  fmt: {format}",
+  "@hudOrientation": {
+    "placeholders": {
+      "rotation": {
+        "type": "String"
+      },
+      "camera": {
+        "type": "String"
+      },
+      "format": {
+        "type": "String"
+      }
+    }
+  }
+}

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,0 +1,225 @@
+{
+  "appTitle": "Calisync",
+  "authErrorMessage": "Errore durante l'autenticazione",
+  "navHome": "Home",
+  "navSettings": "Impostazioni",
+  "navProfile": "Profilo",
+  "navTerminology": "Terminologia",
+  "settingsComingSoon": "Le impostazioni saranno presto disponibili.",
+  "exerciseTrackerTitle": "Tracker esercizi",
+  "poseEstimationTitle": "Stima postura",
+  "homeLoadErrorTitle": "Impossibile caricare gli allenamenti",
+  "retry": "Riprova",
+  "homeEmptyTitle": "Nessun allenamento disponibile",
+  "homeEmptyDescription": "Contatta il tuo coach per ricevere una nuova scheda.",
+  "unauthenticated": "Utente non autenticato",
+  "defaultExerciseName": "Esercizio",
+  "generalNotes": "Note generali",
+  "trainingHeaderExercise": "Esercizio",
+  "trainingHeaderSets": "Serie",
+  "trainingHeaderReps": "Ripetizioni",
+  "trainingHeaderRest": "Recupero",
+  "trainingHeaderIntensity": "Intensità",
+  "trainingHeaderNotes": "Note",
+  "logoutError": "Errore durante il logout: {error}",
+  "@logoutError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "profileFallbackName": "Utente",
+  "userNotFound": "Utente non trovato nel database",
+  "profileLoadError": "Errore nel caricamento dati",
+  "profileNoData": "Nessun dato disponibile",
+  "profileEmailUnavailable": "Email non disponibile",
+  "profileStatusActive": "Account attivo",
+  "profileStatusInactive": "Account inattivo",
+  "profilePlanActive": "Piano attivo",
+  "profilePlanExpired": "Piano scaduto",
+  "profileUsername": "Username",
+  "profileLastUpdated": "Ultimo aggiornamento",
+  "profileValueUnavailable": "Non disponibile",
+  "profileTimezone": "Fuso orario",
+  "profileNotSet": "Non impostato",
+  "profileUnitSystem": "Unità di misura",
+  "profileEdit": "Modifica profilo",
+  "profileComingSoon": "Presto disponibile",
+  "featureUnavailable": "Funzionalità non ancora disponibile.",
+  "logout": "Logout",
+  "redirectError": "Errore durante il reindirizzamento: {error}",
+  "@redirectError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "linkError": "Errore collegamento: {error}",
+  "@linkError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "missingFieldsError": "Compila tutti i campi richiesti.",
+  "passwordMismatch": "Le password non coincidono.",
+  "invalidCredentials": "Credenziali errate.",
+  "signupEmailCheck": "Registrazione completata! Controlla la tua email per confermare l'account.",
+  "unexpectedError": "Errore inatteso: {error}",
+  "@unexpectedError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "googleSignInFailed": "Google Sign-In fallito: {error}",
+  "@googleSignInFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "loginGreeting": "Bentornato! Accedi per continuare il tuo allenamento.",
+  "signupGreeting": "Crea un account per sbloccare tutti gli allenamenti.",
+  "emailLabel": "Email",
+  "passwordLabel": "Password",
+  "confirmPasswordLabel": "Conferma password",
+  "loginButton": "Accedi",
+  "signupButton": "Registrati",
+  "noAccountPrompt": "Non hai un account? Registrati",
+  "existingAccountPrompt": "Hai già un account? Accedi",
+  "orDivider": "oppure",
+  "connecting": "Connessione...",
+  "continueWithGoogle": "Continua con Google",
+  "exerciseAddDialogTitle": "Aggiungi esercizio",
+  "exerciseNameLabel": "Nome esercizio",
+  "quickAddValuesLabel": "Valori rapidi",
+  "quickAddValuesHelper": "Ripetizioni separate da virgola (es. 1,5,10)",
+  "cancel": "Annulla",
+  "add": "Aggiungi",
+  "exerciseNameMissing": "Inserisci un nome.",
+  "exerciseTrackerEmpty": "Ancora nessun esercizio. Tocca + per aggiungerne uno!",
+  "exerciseAddButton": "Aggiungi esercizio",
+  "exercisePushUps": "Push-up",
+  "exercisePullUps": "Trazioni alla sbarra",
+  "exerciseChinUps": "Trazioni a presa inversa",
+  "exerciseTotalReps": "{count} ripetizioni totali",
+  "@exerciseTotalReps": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "undoLastSet": "Annulla ultima serie",
+  "custom": "Personalizzato",
+  "reset": "Reimposta",
+  "logRepsTitle": "Registra ripetizioni",
+  "repetitionsLabel": "Ripetizioni",
+  "positiveNumberError": "Inserisci un numero positivo.",
+  "repsChip": "{count} ripetizioni",
+  "@repsChip": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "goalCount": "Obiettivo: {count}",
+  "@goalCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "repGoalReached": "Obiettivo ripetizioni raggiunto!",
+  "pause": "Pausa",
+  "start": "Avvia",
+  "seriesCount": "Serie: {count}",
+  "@seriesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "resetReps": "Azzera ripetizioni",
+  "timerTitle": "Timer",
+  "weekdayMonday": "Lunedì",
+  "weekdayTuesday": "Martedì",
+  "weekdayWednesday": "Mercoledì",
+  "weekdayThursday": "Giovedì",
+  "weekdayFriday": "Venerdì",
+  "weekdaySaturday": "Sabato",
+  "weekdaySunday": "Domenica",
+  "weekNumber": "Settimana {week}",
+  "@weekNumber": {
+    "placeholders": {
+      "week": {
+        "type": "int"
+      }
+    }
+  },
+  "defaultWorkoutTitle": "Allenamento",
+  "terminologyTitle": "Terminologia",
+  "termRepsTitle": "Reps (Ripetizioni)",
+  "termRepsDescription": "Numero di volte che esegui un esercizio consecutivamente.",
+  "termSetTitle": "Set (Serie)",
+  "termSetDescription": "Un gruppo di ripetizioni. Es: 3 serie da 10 reps significa 30 ripetizioni totali, divise in 3 gruppi.",
+  "termRtTitle": "RT",
+  "termRtDescription": "Ripetizioni Totali: indica che devi fare tutte quelle reps, con libera scelta di serie, ripetizioni e tempo (se non indicato).",
+  "termAmrapTitle": "AMRAP",
+  "termAmrapDescription": "As Many Reps As Possible: esegui quante più ripetizioni possibili in un tempo determinato.",
+  "termEmomTitle": "EMOM",
+  "termEmomDescription": "Every Minute On Minute: inizi un set ogni minuto. Il tempo restante serve per riposare.",
+  "termRampingTitle": "Ramping",
+  "termRampingDescription": "Metodo che prevede un incremento del peso ad ogni serie",
+  "termMavTitle": "MAV",
+  "termMavDescription": "Massima Alzata Veloce: si riferisce a una metodologia in cui si cerca di eseguire il maggior numero di ripetizioni possibili con un carico, mantenendo sempre il controllo del movimento e una buona velocità di esecuzione.",
+  "termIsocineticiTitle": "Isocinetici",
+  "termIsocineticiDescription": "Esercizi svolti a velocità costante.",
+  "termTutTitle": "TUT",
+  "termTutDescription": "Indica quanto deve durare una ripetizione. Puoi gestire tu la durata di ogni fase della rep.",
+  "termIsoTitle": "ISO",
+  "termIsoDescription": "Indica il fermo a un punto specifico dell'esecuzione della rep",
+  "termSomTitle": "SOM",
+  "termSomDescription": "Indica la durata di ogni fase della ripetizione.",
+  "termScaricoTitle": "Scarico",
+  "termScaricoDescription": "Ultima settimana della scheda per prepararsi ai massimali.",
+  "noCameras": "Nessuna fotocamera disponibile",
+  "cameraInitFailed": "Inizializzazione fotocamera fallita: {error}",
+  "@cameraInitFailed": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "poseDetected": "Posa rilevata",
+  "processing": "Elaborazione…",
+  "idle": "In attesa",
+  "cameraFront": "frontale",
+  "cameraBack": "posteriore",
+  "hudMetrics": "fps: {fps}  ms: {milliseconds}  lmks: {landmarks}",
+  "@hudMetrics": {
+    "placeholders": {
+      "fps": {
+        "type": "String"
+      },
+      "milliseconds": {
+        "type": "String"
+      },
+      "landmarks": {
+        "type": "int"
+      }
+    }
+  },
+  "hudOrientation": "rot: {rotation}  cam: {camera}  fmt: {format}",
+  "@hudOrientation": {
+    "placeholders": {
+      "rotation": {
+        "type": "String"
+      },
+      "camera": {
+        "type": "String"
+      },
+      "format": {
+        "type": "String"
+      }
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 import 'package:calisync/pages/main.dart';
 import 'package:calisync/theme/app_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() async {
@@ -20,10 +21,12 @@ class CalisthenicsApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Calisthenics',
+      onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       theme: AppTheme.theme,
       darkTheme: AppTheme.theme,
       themeMode: ThemeMode.dark,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: const AuthGate(),
       debugShowCheckedModeBanner: false,
     );

--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -1,6 +1,8 @@
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 class WorkoutExercise {
   final String? id;
-  final String name;
+  final String? name;
   final int? sets;
   final int? reps;
   final int? restSeconds;
@@ -8,7 +10,7 @@ class WorkoutExercise {
   final String? notes;
 
   const WorkoutExercise({
-    required this.name,
+    this.name,
     this.id,
     this.sets,
     this.reps,
@@ -29,16 +31,6 @@ class WorkoutDay {
   final String? notes;
   final List<WorkoutExercise> exercises;
 
-  static const Map<int, String> _dowLabels = {
-    1: 'Lunedì',
-    2: 'Martedì',
-    3: 'Mercoledì',
-    4: 'Giovedì',
-    5: 'Venerdì',
-    6: 'Sabato',
-    7: 'Domenica',
-  };
-
   const WorkoutDay({
     required this.week,
     required this.dow,
@@ -48,20 +40,40 @@ class WorkoutDay {
     this.notes,
   });
 
-  String? get dowLabel => _dowLabels[dow];
+  String? dowLabel(AppLocalizations l10n) {
+    switch (dow) {
+      case 1:
+        return l10n.weekdayMonday;
+      case 2:
+        return l10n.weekdayTuesday;
+      case 3:
+        return l10n.weekdayWednesday;
+      case 4:
+        return l10n.weekdayThursday;
+      case 5:
+        return l10n.weekdayFriday;
+      case 6:
+        return l10n.weekdaySaturday;
+      case 7:
+        return l10n.weekdaySunday;
+      default:
+        return null;
+    }
+  }
 
-  String formattedTitle({String fallback = 'Allenamento'}) {
+  String formattedTitle(AppLocalizations l10n, {String? fallback}) {
     final parts = <String>[];
     if (week > 0) {
-      parts.add('Settimana $week');
+      parts.add(l10n.weekNumber(week));
     }
-    final dowName = dowLabel;
+    final dowName = dowLabel(l10n);
     if (dowName != null) {
       parts.add(dowName);
     }
     if (name != null && name!.isNotEmpty) {
       parts.add(name!);
     }
-    return parts.isEmpty ? fallback : parts.join(' · ');
+    final resolvedFallback = fallback ?? l10n.defaultWorkoutTitle;
+    return parts.isEmpty ? resolvedFallback : parts.join(' · ');
   }
 }

--- a/lib/pages/exercise_tracker.dart
+++ b/lib/pages/exercise_tracker.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// Definition of a trackable exercise.
 ///
@@ -22,46 +23,51 @@ class ExerciseDefinition {
 }
 
 class ExerciseTrackerPage extends StatefulWidget {
-  const ExerciseTrackerPage({super.key, List<ExerciseDefinition>? initialExercises})
-      : initialExercises = initialExercises ?? const [
-          ExerciseDefinition(
-            name: 'Push ups',
-            icon: Icons.front_hand,
-            color: Colors.orangeAccent,
-            quickAddValues: [1, 5, 10, 15],
-          ),
-          ExerciseDefinition(
-            name: 'Pull ups',
-            icon: Icons.fitness_center,
-            color: Colors.lightBlueAccent,
-            quickAddValues: [1, 3, 5, 8],
-          ),
-          ExerciseDefinition(
-            name: 'Chin ups',
-            icon: Icons.accessibility_new,
-            color: Colors.purpleAccent,
-            quickAddValues: [1, 3, 5, 8],
-          ),
-        ];
+  const ExerciseTrackerPage({super.key, this.initialExercises});
 
-  final List<ExerciseDefinition> initialExercises;
+  final List<ExerciseDefinition>? initialExercises;
 
   @override
   State<ExerciseTrackerPage> createState() => _ExerciseTrackerPageState();
 }
 
 class _ExerciseTrackerPageState extends State<ExerciseTrackerPage> {
-  late final List<_TrackedExercise> _exercises;
+  late List<_TrackedExercise> _exercises;
   int _colorIndex = 0;
+  bool _initialized = false;
 
   @override
-  void initState() {
-    super.initState();
-    _exercises = widget.initialExercises
-        .map((definition) => _TrackedExercise(definition))
-        .toList();
-    _colorIndex = widget.initialExercises.length;
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_initialized) {
+      final l10n = AppLocalizations.of(context)!;
+      final definitions = widget.initialExercises ?? _defaultExercises(l10n);
+      _exercises = definitions.map((definition) => _TrackedExercise(definition)).toList();
+      _colorIndex = definitions.length;
+      _initialized = true;
+    }
   }
+
+  List<ExerciseDefinition> _defaultExercises(AppLocalizations l10n) => [
+        ExerciseDefinition(
+          name: l10n.exercisePushUps,
+          icon: Icons.front_hand,
+          color: Colors.orangeAccent,
+          quickAddValues: const [1, 5, 10, 15],
+        ),
+        ExerciseDefinition(
+          name: l10n.exercisePullUps,
+          icon: Icons.fitness_center,
+          color: Colors.lightBlueAccent,
+          quickAddValues: const [1, 3, 5, 8],
+        ),
+        ExerciseDefinition(
+          name: l10n.exerciseChinUps,
+          icon: Icons.accessibility_new,
+          color: Colors.purpleAccent,
+          quickAddValues: const [1, 3, 5, 8],
+        ),
+      ];
 
   void _addExercise(ExerciseDefinition definition) {
     setState(() {
@@ -72,27 +78,28 @@ class _ExerciseTrackerPageState extends State<ExerciseTrackerPage> {
   void _showAddExerciseDialog() {
     final nameController = TextEditingController();
     final quickAddsController = TextEditingController(text: '1,5,10');
+    final l10n = AppLocalizations.of(context)!;
     showDialog<void>(
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('Add exercise'),
+          title: Text(l10n.exerciseAddDialogTitle),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               TextField(
                 controller: nameController,
                 textCapitalization: TextCapitalization.sentences,
-                decoration: const InputDecoration(
-                  labelText: 'Exercise name',
+                decoration: InputDecoration(
+                  labelText: l10n.exerciseNameLabel,
                 ),
               ),
               const SizedBox(height: 12),
               TextField(
                 controller: quickAddsController,
-                decoration: const InputDecoration(
-                  labelText: 'Quick add values',
-                  helperText: 'Comma separated repetitions (e.g. 1,5,10)',
+                decoration: InputDecoration(
+                  labelText: l10n.quickAddValuesLabel,
+                  helperText: l10n.quickAddValuesHelper,
                 ),
                 keyboardType: TextInputType.number,
               ),
@@ -101,14 +108,14 @@ class _ExerciseTrackerPageState extends State<ExerciseTrackerPage> {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancel'),
+              child: Text(l10n.cancel),
             ),
             ElevatedButton(
               onPressed: () {
                 final name = nameController.text.trim();
                 if (name.isEmpty) {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Please provide a name.')),
+                    SnackBar(content: Text(l10n.exerciseNameMissing)),
                   );
                   return;
                 }
@@ -131,7 +138,7 @@ class _ExerciseTrackerPageState extends State<ExerciseTrackerPage> {
                   ),
                 );
               },
-              child: const Text('Add'),
+              child: Text(l10n.add),
             ),
           ],
         );
@@ -141,13 +148,14 @@ class _ExerciseTrackerPageState extends State<ExerciseTrackerPage> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Exercise tracker'),
+        title: Text(l10n.exerciseTrackerTitle),
       ),
       body: _exercises.isEmpty
-          ? const Center(
-              child: Text('No exercises yet. Tap + to add one!'),
+          ? Center(
+              child: Text(l10n.exerciseTrackerEmpty),
             )
           : ListView.separated(
               padding: const EdgeInsets.all(16),
@@ -161,7 +169,7 @@ class _ExerciseTrackerPageState extends State<ExerciseTrackerPage> {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _showAddExerciseDialog,
         icon: const Icon(Icons.add),
-        label: const Text('Add exercise'),
+        label: Text(l10n.exerciseAddButton),
       ),
     );
   }
@@ -179,6 +187,7 @@ class _ExerciseCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
     final definition = tracked.definition;
     final color = definition.color.withOpacity(0.15);
     return Card(
@@ -208,14 +217,14 @@ class _ExerciseCard extends StatelessWidget {
                         style: theme.textTheme.titleMedium,
                       ),
                       Text(
-                        '${tracked.totalReps} total reps',
+                        l10n.exerciseTotalReps(tracked.totalReps),
                         style: theme.textTheme.bodySmall,
                       ),
                     ],
                   ),
                 ),
                 IconButton(
-                  tooltip: 'Undo last set',
+                  tooltip: l10n.undoLastSet,
                   onPressed: tracked.canUndo
                       ? () {
                           tracked.undoLast();
@@ -248,7 +257,7 @@ class _ExerciseCard extends StatelessWidget {
                     }
                   },
                   icon: const Icon(Icons.more_time),
-                  label: const Text('Custom'),
+                  label: Text(l10n.custom),
                 ),
                 if (tracked.totalReps > 0)
                   OutlinedButton(
@@ -256,7 +265,7 @@ class _ExerciseCard extends StatelessWidget {
                       tracked.reset();
                       onUpdated();
                     },
-                    child: const Text('Reset'),
+                    child: Text(l10n.reset),
                   ),
               ],
             ),
@@ -269,7 +278,7 @@ class _ExerciseCard extends StatelessWidget {
                   for (final set in tracked.sets.reversed)
                     Chip(
                       avatar: const Icon(Icons.check, size: 18),
-                      label: Text('${set.reps} reps'),
+                      label: Text(l10n.repsChip(set.reps)),
                       deleteIcon: const Icon(Icons.close),
                       onDeleted: () {
                         tracked.removeSet(set);
@@ -287,15 +296,16 @@ class _ExerciseCard extends StatelessWidget {
 
   Future<int?> _showCustomRepsDialog(BuildContext context) async {
     final controller = TextEditingController();
+    final l10n = AppLocalizations.of(context)!;
     return showDialog<int>(
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('Log reps'),
+          title: Text(l10n.logRepsTitle),
           content: TextField(
             controller: controller,
-            decoration: const InputDecoration(
-              labelText: 'Repetitions',
+            decoration: InputDecoration(
+              labelText: l10n.repetitionsLabel,
             ),
             keyboardType: TextInputType.number,
             autofocus: true,
@@ -303,20 +313,20 @@ class _ExerciseCard extends StatelessWidget {
           actions: [
             TextButton(
               onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancel'),
+              child: Text(l10n.cancel),
             ),
             ElevatedButton(
               onPressed: () {
                 final value = int.tryParse(controller.text);
                 if (value == null || value <= 0) {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Enter a positive number.')),
+                    SnackBar(content: Text(l10n.positiveNumberError)),
                   );
                   return;
                 }
                 Navigator.of(context).pop(value);
               },
-              child: const Text('Add'),
+              child: Text(l10n.add),
             ),
           ],
         );

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -4,6 +4,7 @@ import 'package:calisync/pages/position_estimation.dart';
 import 'package:calisync/components/cards/selection_card.dart';
 import 'package:calisync/pages/training.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class HomeContent extends StatefulWidget {
@@ -24,6 +25,7 @@ class _HomeContentState extends State<HomeContent> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: RefreshIndicator(
@@ -53,7 +55,7 @@ class _HomeContentState extends State<HomeContent> {
                   ),
                   const SizedBox(height: 16),
                   Text(
-                    'Impossibile caricare gli allenamenti',
+                    l10n.homeLoadErrorTitle,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
@@ -72,7 +74,7 @@ class _HomeContentState extends State<HomeContent> {
                         });
                       },
                       icon: const Icon(Icons.refresh),
-                      label: const Text('Riprova'),
+                      label: Text(l10n.retry),
                     ),
                   ),
                 ],
@@ -92,13 +94,13 @@ class _HomeContentState extends State<HomeContent> {
                   ),
                   const SizedBox(height: 16),
                   Text(
-                    'Nessun allenamento disponibile',
+                    l10n.homeEmptyTitle,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    'Contatta il tuo coach per ricevere una nuova scheda.',
+                    l10n.homeEmptyDescription,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
@@ -113,7 +115,7 @@ class _HomeContentState extends State<HomeContent> {
               itemBuilder: (context, index) {
                 if (index == days.length + 1) {
                   return SelectionCard(
-                    title: 'Exercise tracker',
+                    title: l10n.exerciseTrackerTitle,
                     icon: Icons.checklist,
                     onTap: () {
                       Navigator.push(
@@ -127,7 +129,7 @@ class _HomeContentState extends State<HomeContent> {
                 }
                 if (index == days.length) {
                   return SelectionCard(
-                    title: 'Pose estimation',
+                    title: l10n.poseEstimationTitle,
                     icon: Icons.man,
                     onTap: () {
                       Navigator.push(
@@ -142,7 +144,7 @@ class _HomeContentState extends State<HomeContent> {
 
                 final day = days[index];
                 return SelectionCard(
-                  title: day.formattedTitle(),
+                  title: day.formattedTitle(l10n),
                   icon: Icons.calendar_today,
                   onTap: () {
                     Navigator.push(
@@ -172,7 +174,7 @@ class _HomeContentState extends State<HomeContent> {
     final client = Supabase.instance.client;
     final userId = client.auth.currentUser?.id;
     if (userId == null) {
-      throw Exception('Utente non autenticato');
+      throw Exception(AppLocalizations.of(context)!.unauthenticated);
     }
 
     final plan = await client
@@ -223,7 +225,7 @@ class _HomeContentState extends State<HomeContent> {
             (exercise['exercise_library'] as Map<String, dynamic>?) ?? {};
         return WorkoutExercise(
           id: exercise['id'] as String?,
-          name: (exerciseLibrary['name'] as String?) ?? 'Esercizio',
+          name: exerciseLibrary['name'] as String?,
           sets: (exercise['default_sets'] as num?)?.toInt(),
           reps: (exercise['default_reps'] as num?)?.toInt(),
           restSeconds: (exercise['rest_seconds'] as num?)?.toInt(),

--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -1,6 +1,7 @@
 // lib/main.dart
 import 'package:calisync/pages/terminologia.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:calisync/pages/profile.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -15,12 +16,13 @@ class AuthGate extends StatelessWidget {
     return StreamBuilder<AuthState>(
       stream: Supabase.instance.client.auth.onAuthStateChange,
       builder: (context, snapshot) {
+        final l10n = AppLocalizations.of(context)!;
         final session = snapshot.hasData
             ? snapshot.data!.session
             : Supabase.instance.client.auth.currentSession;
 
         if (session != null) {
-          return const HomePage(title: 'Calisthenics');
+          return HomePage(title: l10n.appTitle);
         }
 
         if (snapshot.connectionState == ConnectionState.waiting) {
@@ -33,7 +35,7 @@ class AuthGate extends StatelessWidget {
           return Scaffold(
             body: Center(
               child: Text(
-                'Errore durante l\'autenticazione',
+                l10n.authErrorMessage,
                 style: Theme.of(context).textTheme.titleMedium,
                 textAlign: TextAlign.center,
               ),
@@ -67,35 +69,36 @@ class _HomePageState extends State<HomePage> {
   }
 
   @override
-  Widget build(BuildContext context) {    
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
 
     final navigationItems = [
       _NavigationItem(
         icon: Icons.home,
-        label: 'Home',
+        label: l10n.navHome,
         gradient: LinearGradient(
           colors: [colorScheme.primary, colorScheme.secondary],
         ),
       ),
       _NavigationItem(
         icon: Icons.settings,
-        label: 'Impostazioni',
+        label: l10n.navSettings,
         gradient: LinearGradient(
           colors: [colorScheme.secondary, colorScheme.tertiary],
         ),
       ),
       _NavigationItem(
         icon: Icons.account_circle,
-        label: 'Profilo',
+        label: l10n.navProfile,
         gradient: LinearGradient(
           colors: [colorScheme.tertiary, colorScheme.primary],
         ),
       ),
       _NavigationItem(
         icon: Icons.book,
-        label: 'Terminologia',
+        label: l10n.navTerminology,
         gradient: LinearGradient(
           colors: [colorScheme.primary, colorScheme.error],
         ),
@@ -103,8 +106,8 @@ class _HomePageState extends State<HomePage> {
     ];
 
     final List<Widget> pages = [
-      HomeContent(),
-      const Center(child: Text('Impostazioni')),
+      const HomeContent(),
+      Center(child: Text(l10n.settingsComingSoon)),
       const ProfilePage(),
       const TerminologiaPage()
     ];

--- a/lib/pages/position_estimation.dart
+++ b/lib/pages/position_estimation.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_mlkit_pose_detection/google_mlkit_pose_detection.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import 'package:calisync/theme/app_theme.dart';
 
@@ -128,8 +129,9 @@ class _PoseCamPageState extends State<PoseCamPage> with WidgetsBindingObserver {
       final cameras = await availableCameras();
       if (cameras.isEmpty) {
         if (mounted) {
+          final l10n = AppLocalizations.of(context)!;
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('No cameras available')),
+            SnackBar(content: Text(l10n.noCameras)),
           );
         }
         return;
@@ -172,8 +174,9 @@ class _PoseCamPageState extends State<PoseCamPage> with WidgetsBindingObserver {
       if (mounted) setState(() {});
     } catch (e) {
       if (mounted) {
+        final l10n = AppLocalizations.of(context)!;
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Camera init failed: $e')),
+          SnackBar(content: Text(l10n.cameraInitFailed('$e'))),
         );
       }
     }
@@ -292,6 +295,7 @@ class _PoseCamPageState extends State<PoseCamPage> with WidgetsBindingObserver {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
 
     final controller = _controller;
     if (controller == null || !controller.value.isInitialized) {
@@ -333,7 +337,7 @@ class _PoseCamPageState extends State<PoseCamPage> with WidgetsBindingObserver {
                     },
                   ),
                 ),
-              _buildHud(context),
+              _buildHud(context, l10n),
             ],
           );
         },
@@ -359,15 +363,24 @@ class _PoseCamPageState extends State<PoseCamPage> with WidgetsBindingObserver {
     );
   }
 
-  Widget _buildHud(BuildContext context) {
+  Widget _buildHud(BuildContext context, AppLocalizations l10n) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final appColors = theme.extension<AppColors>()!;
     final status = _poseDetected
-        ? 'Pose detected'
-        : (_isBusy ? 'Processing…' : 'Idle');
+        ? l10n.poseDetected
+        : (_isBusy ? l10n.processing : l10n.idle);
 
     final landmarks = _lastPose?.landmarks.length ?? 0;
+    final cameraLabel = _useFrontCamera ? l10n.cameraFront : l10n.cameraBack;
+    final rotationLabel = _rotation.toString().split('.').last;
+    final metricsText = l10n.hudMetrics(
+      _fps.toStringAsFixed(1),
+      _avgMs.toStringAsFixed(0),
+      landmarks,
+    );
+    final orientationText =
+        l10n.hudOrientation(rotationLabel, cameraLabel, _fmt);
 
     return SafeArea(
       child: Align(
@@ -396,13 +409,13 @@ class _PoseCamPageState extends State<PoseCamPage> with WidgetsBindingObserver {
                     ),
                   ),
                   Text(
-                    'fps: ${_fps.toStringAsFixed(1)}  ms: ${_avgMs.toStringAsFixed(0)}  lmks: $landmarks',
+                    metricsText,
                     style: theme.textTheme.labelSmall?.copyWith(
                       color: colorScheme.onSurfaceVariant,
                     ),
                   ),
                   Text(
-                    'rot: $_rotation  cam: ${_useFrontCamera ? 'front' : 'back'}  fmt: $_fmt',
+                    orientationText,
                     style: theme.textTheme.labelSmall?.copyWith(
                       color: colorScheme.onSurfaceVariant.withOpacity(0.7),
                       fontSize: 11,

--- a/lib/pages/rep_counter.dart
+++ b/lib/pages/rep_counter.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class RepCounter extends StatefulWidget {
   final String title;
@@ -47,6 +48,7 @@ class _RepCounterState extends State<RepCounter> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
       appBar: AppBar(title: Text(widget.title)),
@@ -65,7 +67,7 @@ class _RepCounterState extends State<RepCounter> {
             ),
             if (widget.targetCount != null)
               Text(
-                'Goal: ${widget.targetCount}',
+                l10n.goalCount(widget.targetCount!),
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: colorScheme.onSurfaceVariant,
                 ),
@@ -85,7 +87,7 @@ class _RepCounterState extends State<RepCounter> {
             const SizedBox(height: 8),
             TextButton(
               onPressed: _reset,
-              child: const Text('Reset'),
+              child: Text(l10n.reset),
             ),
           ],
         ),

--- a/lib/pages/rep_timer.dart
+++ b/lib/pages/rep_timer.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class RepTimerWidget extends StatefulWidget {
   final String title;
@@ -68,7 +69,9 @@ class _RepTimerWidgetState extends State<RepTimerWidget> {
         // Optionally do something on reaching goal
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text('Rep goal reached!')));
+        ).showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context)!.repGoalReached)),
+        );
       }
     });
   }
@@ -100,6 +103,7 @@ class _RepTimerWidgetState extends State<RepTimerWidget> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+    final l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
       appBar: AppBar(
@@ -134,26 +138,26 @@ class _RepTimerWidgetState extends State<RepTimerWidget> {
                     children: [
                       ElevatedButton(
                         onPressed: _isRunning ? _stopTimer : _startTimer,
-                        child: Text(_isRunning ? 'Pause' : 'Start'),
+                        child: Text(_isRunning ? l10n.pause : l10n.start),
                       ),
                       const SizedBox(width: 16),
                       ElevatedButton(
                         onPressed: _resetTimer,
-                        child: const Text('Reset'),
+                        child: Text(l10n.reset),
                       ),
                     ],
                   ),
                   const Divider(height: 40),
                   // Rep counter section
                   Text(
-                    'Serie: $_repCount',
+                    l10n.seriesCount(_repCount),
                     style: theme.textTheme.displaySmall?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),
                   ),
                   if (widget.targetRepCount != null)
                     Text(
-                      'Goal: ${widget.targetRepCount}',
+                      l10n.goalCount(widget.targetRepCount!),
                       style: theme.textTheme.bodyMedium?.copyWith(
                         color: colorScheme.onSurfaceVariant,
                       ),
@@ -177,7 +181,7 @@ class _RepTimerWidgetState extends State<RepTimerWidget> {
                   ),
                   TextButton(
                     onPressed: _resetRep,
-                    child: const Text('Reset Reps'),
+                    child: Text(l10n.resetReps),
                   ),
                 ],
               ),

--- a/lib/pages/terminologia.dart
+++ b/lib/pages/terminologia.dart
@@ -1,63 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class TerminologiaPage extends StatelessWidget {
   const TerminologiaPage({super.key});
 
-  final List<Map<String, String>> termini = const [
-    {
-      'termine': 'Reps (Ripetizioni)',
-      'descrizione': 'Numero di volte che esegui un esercizio consecutivamente.'
-    },
-    {
-      'termine': 'Set (Serie)',
-      'descrizione': 'Un gruppo di ripetizioni. Es: 3 serie da 10 reps significa 30 ripetizioni totali, divise in 3 gruppi.'
-    },
-    {
-      'termine': 'RT',
-      'descrizione': 'Ripetizioni Totali: indica che devi fare tutte quelle reps, con libera scelta di serie, ripetizioni e tempo (se non indicato).'
-    },
-    {
-      'termine': 'AMRAP',
-      'descrizione': 'As Many Reps As Possible: esegui quante più ripetizioni possibili in un tempo determinato.'
-    },
-    {
-      'termine': 'EMOM',
-      'descrizione': 'Every Minute On Minute: inizi un set ogni minuto. Il tempo restante serve per riposare.'
-    },
-    {
-      'termine': 'Ramping',
-      'descrizione': 'Metodo che prevede un incremento del peso ad ogni serie'
-    },
-    {
-      'termine': 'MAV',
-      'descrizione': 'Massima Alzata Veloce: Si riferisce a una metodologia in cui si cerca di eseguire il maggior numero di ripetizioni possibili con un carico, mantenendo sempre il controllo del movimento e una buona velocità di esecuzione.'
-    },
-    {
-      'termine': 'Isocinetici',
-      'descrizione': 'Esercizi svolti a velocità costante.'
-    },
-    {
-      'termine': 'TUT',
-      'descrizione': 'Indica quanto deve durare una ripetizione. Puoi gestire tu la durata di ogni fase della rep.'
-    },
-    {
-      'termine': 'ISO',
-      'descrizione': "Indica il fermo a un punto specifico dell'esecizione della rep"
-    },
-    {
-      'termine': 'SOM',
-      'descrizione': 'Indica la durata di ogni fase della ripetizione.'
-    },
-    {
-      'termine': 'Scarico',
-      'descrizione': 'Ultima settimana della scheda per prepararsi ai massimali.'
-    },
-  ];
-
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final termini = [
+      {'termine': l10n.termRepsTitle, 'descrizione': l10n.termRepsDescription},
+      {'termine': l10n.termSetTitle, 'descrizione': l10n.termSetDescription},
+      {'termine': l10n.termRtTitle, 'descrizione': l10n.termRtDescription},
+      {'termine': l10n.termAmrapTitle, 'descrizione': l10n.termAmrapDescription},
+      {'termine': l10n.termEmomTitle, 'descrizione': l10n.termEmomDescription},
+      {'termine': l10n.termRampingTitle, 'descrizione': l10n.termRampingDescription},
+      {'termine': l10n.termMavTitle, 'descrizione': l10n.termMavDescription},
+      {'termine': l10n.termIsocineticiTitle, 'descrizione': l10n.termIsocineticiDescription},
+      {'termine': l10n.termTutTitle, 'descrizione': l10n.termTutDescription},
+      {'termine': l10n.termIsoTitle, 'descrizione': l10n.termIsoDescription},
+      {'termine': l10n.termSomTitle, 'descrizione': l10n.termSomDescription},
+      {'termine': l10n.termScaricoTitle, 'descrizione': l10n.termScaricoDescription},
+    ];
     return Scaffold(
-      appBar: AppBar(title: const Text('Terminologia')),
+      appBar: AppBar(title: Text(l10n.terminologyTitle)),
       body: ListView.builder(
         padding: const EdgeInsets.all(16),
         itemCount: termini.length,

--- a/lib/pages/timer.dart
+++ b/lib/pages/timer.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class TimerPage extends StatefulWidget {
   final Duration countdownDuration;
@@ -52,8 +53,9 @@ class _TimerPageState extends State<TimerPage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: Text('Timer')),
+      appBar: AppBar(title: Text(l10n.timerTitle)),
       body: Center(
         child: Text(
           _formattedTime,

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -3,6 +3,7 @@ import 'package:calisync/pages/rep_counter.dart';
 import 'package:calisync/pages/rep_timer.dart';
 import 'package:calisync/pages/timer.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class Training extends StatelessWidget {
   final WorkoutDay day;
@@ -12,20 +13,21 @@ class Training extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final exercises = day.exercises;
-    final headers = const [
-      'Esercizio',
-      'Serie',
-      'Ripetizioni',
-      'Recupero',
-      'Intensità',
-      'Note',
+    final l10n = AppLocalizations.of(context)!;
+    final headers = [
+      l10n.trainingHeaderExercise,
+      l10n.trainingHeaderSets,
+      l10n.trainingHeaderReps,
+      l10n.trainingHeaderRest,
+      l10n.trainingHeaderIntensity,
+      l10n.trainingHeaderNotes,
     ];
 
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
     return Scaffold(
-      appBar: AppBar(title: Text(day.formattedTitle())),
+      appBar: AppBar(title: Text(day.formattedTitle(l10n))),
       body: SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Padding(
@@ -45,7 +47,7 @@ class Training extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              'Note generali',
+                              l10n.generalNotes,
                               style: Theme.of(context).textTheme.titleMedium,
                             ),
                             const SizedBox(height: 8),
@@ -81,11 +83,15 @@ class Training extends StatelessWidget {
                     }).toList(),
                   ),
                   ...exercises.map((exercise) {
+                    final exerciseName =
+                        exercise.name?.trim().isEmpty ?? true
+                            ? l10n.defaultExerciseName
+                            : exercise.name!;
                     return TableRow(
                       children: [
                         _cell(
                           context,
-                          exercise.name,
+                          exerciseName,
                           onTap: () => _openTools(context, exercise),
                         ),
                         _cell(context, exercise.sets?.toString() ?? '-'),
@@ -106,13 +112,17 @@ class Training extends StatelessWidget {
   }
 
   void _openTools(BuildContext context, WorkoutExercise exercise) {
+    final l10n = AppLocalizations.of(context)!;
+    final exerciseName = exercise.name?.trim().isEmpty ?? true
+        ? l10n.defaultExerciseName
+        : exercise.name!;
     final restDuration = exercise.restDuration;
     final reps = exercise.reps;
     if (restDuration != null && reps != null) {
       Navigator.of(context).push(
         MaterialPageRoute(
           builder: (_) => RepTimerWidget(
-            title: exercise.name,
+            title: exerciseName,
             countdownDuration: restDuration,
             initialRepCount: 0,
             targetRepCount: reps,
@@ -131,7 +141,7 @@ class Training extends StatelessWidget {
       Navigator.of(context).push(
         MaterialPageRoute(
           builder: (_) => RepCounter(
-            title: exercise.name,
+            title: exerciseName,
             timerType: '',
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -45,6 +47,7 @@ dependencies:
   camera:
   google_mlkit_pose_detection:
   google_mlkit_commons:
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:
@@ -75,6 +78,7 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  generate: true
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- configure Flutter localization generation and add English/Italian message catalogs
- replace hard-coded interface strings across authentication, home, and profile flows with AppLocalizations lookups
- localize workout utilities, pose estimation HUD, and other tools while updating formatting helpers for localized copy

## Testing
- `flutter pub get` *(fails: flutter command is unavailable in the container)*
- `dart format lib` *(fails: dart command is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f508d5b8b883339a048ea7f89b41dc