### PR TITLE
Add password recovery flow via email

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -170,6 +170,23 @@
   "signupButton": "Sign up",
   "noAccountPrompt": "Don't have an account? Sign up",
   "existingAccountPrompt": "Already have an account? Sign in",
+  "forgotPasswordLink": "Forgot your password?",
+  "passwordResetEmailSent": "Password reset link sent to {email}. Check your inbox.",
+  "@passwordResetEmailSent": {
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "passwordResetEmailMissing": "Enter your email to receive a reset link.",
+  "passwordResetDialogTitle": "Choose a new password",
+  "passwordResetDialogDescription": "Enter a new password to secure your account.",
+  "passwordResetNewPasswordLabel": "New password",
+  "passwordResetConfirmPasswordLabel": "Confirm new password",
+  "passwordResetMismatch": "Passwords do not match.",
+  "passwordResetSuccess": "Password updated successfully. You can continue using the app.",
+  "passwordResetSubmit": "Update password",
   "exerciseAddDialogTitle": "Add exercise",
   "exerciseNameLabel": "Exercise name",
   "quickAddValuesLabel": "Quick add values",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -170,6 +170,23 @@
   "signupButton": "Registrati",
   "noAccountPrompt": "Non hai un account? Registrati",
   "existingAccountPrompt": "Hai già un account? Accedi",
+  "forgotPasswordLink": "Forgot your password?",
+  "passwordResetEmailSent": "Link per reimpostare la password inviato a {email}. Controlla la posta.",
+  "@passwordResetEmailSent": {
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "passwordResetEmailMissing": "Inserisci la tua email per ricevere il link di reimpostazione.",
+  "passwordResetDialogTitle": "Scegli una nuova password",
+  "passwordResetDialogDescription": "Inserisci una nuova password per mettere al sicuro il tuo account.",
+  "passwordResetNewPasswordLabel": "Nuova password",
+  "passwordResetConfirmPasswordLabel": "Conferma nuova password",
+  "passwordResetMismatch": "Le password non coincidono.",
+  "passwordResetSuccess": "Password aggiornata con successo. Puoi continuare a usare l'app.",
+  "passwordResetSubmit": "Aggiorna password",
   "exerciseAddDialogTitle": "Aggiungi esercizio",
   "exerciseNameLabel": "Nome esercizio",
   "quickAddValuesLabel": "Valori rapidi",


### PR DESCRIPTION
## Summary
- add a forgot password action on the login form that triggers a Supabase password-reset email
- show a password update dialog when the recovery link is opened and update the user's password
- localize the new messaging for both English and Italian

## Testing
- not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f547f8c4988333900122ae8df2cff8