### PR TITLE
Add profile edit bottom sheet

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -110,6 +110,27 @@
   "profileUnitSystem": "Unit system",
   "profileEdit": "Edit profile",
   "profileComingSoon": "Coming soon",
+  "profileEditSubtitle": "Update your personal details",
+  "profileEditTitle": "Edit profile",
+  "profileEditFullNameLabel": "Full name",
+  "profileEditFullNameHint": "How should we call you?",
+  "profileEditTimezoneLabel": "Time zone",
+  "profileEditTimezoneHint": "Example: Europe/Rome",
+  "profileEditUnitSystemLabel": "Preferred unit system",
+  "profileEditUnitSystemNotSet": "Not specified",
+  "profileEditUnitSystemMetric": "Metric (kg, cm)",
+  "profileEditUnitSystemImperial": "Imperial (lb, in)",
+  "profileEditCancel": "Cancel",
+  "profileEditSave": "Save changes",
+  "profileEditSuccess": "Profile updated successfully",
+  "profileEditError": "Unable to update profile: {error}",
+  "@profileEditError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
   "featureUnavailable": "Feature not available yet.",
   "logout": "Log out",
   "redirectError": "Error during redirect: {error}",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -110,6 +110,27 @@
   "profileUnitSystem": "Unità di misura",
   "profileEdit": "Modifica profilo",
   "profileComingSoon": "Presto disponibile",
+  "profileEditSubtitle": "Aggiorna le tue informazioni personali",
+  "profileEditTitle": "Modifica profilo",
+  "profileEditFullNameLabel": "Nome completo",
+  "profileEditFullNameHint": "Come vuoi essere chiamato?",
+  "profileEditTimezoneLabel": "Fuso orario",
+  "profileEditTimezoneHint": "Esempio: Europe/Rome",
+  "profileEditUnitSystemLabel": "Unità di misura preferita",
+  "profileEditUnitSystemNotSet": "Non specificato",
+  "profileEditUnitSystemMetric": "Metrico (kg, cm)",
+  "profileEditUnitSystemImperial": "Imperiale (lb, in)",
+  "profileEditCancel": "Annulla",
+  "profileEditSave": "Salva modifiche",
+  "profileEditSuccess": "Profilo aggiornato correttamente",
+  "profileEditError": "Impossibile aggiornare il profilo: {error}",
+  "@profileEditError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
   "featureUnavailable": "Funzionalità non ancora disponibile.",
   "logout": "Logout",
   "redirectError": "Errore durante il reindirizzamento: {error}",


### PR DESCRIPTION
## Summary
- convert the profile page to a stateful widget so profile data can be refreshed after edits
- add a bottom sheet form that updates the Supabase profile with name, timezone, and unit system changes
- localize the new profile editing workflow strings in English and Italian

## Testing
- Not run (Flutter SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f561f29e408333b37e8a9a2e195c96