### PR TITLE
Handle coach portal athlete loading without FK joins

### DIFF
--- a/docs/admin.html
+++ b/docs/admin.html
@@ -203,12 +203,27 @@
           async function loadAthletes(){
             const uid = (await supabase.auth.getUser()).data.user?.id;
             if(!uid) return;
-            const { data, error } = await supabase
+            const { data: shareRows, error } = await supabase
               .from('shares')
-              .select('owner, role, owner:profiles( id, full_name )')
+              .select('owner, role')
               .eq('target_user', uid);
             if(error){ console.error(error); alert('Failed to load athletes: '+error.message); return; }
-            athletes.value = data || [];
+
+            const owners = Array.from(new Set((shareRows||[]).map(s => s.owner).filter(Boolean)));
+            let profilesById = {};
+            if(owners.length){
+              const { data: profileRows, error: profileError } = await supabase
+                .from('profiles')
+                .select('id, full_name')
+                .in('id', owners);
+              if(profileError){ console.error(profileError); alert('Failed to load athlete profiles: '+profileError.message); return; }
+              profilesById = Object.fromEntries((profileRows||[]).map(p => [p.id, p]));
+            }
+
+            athletes.value = (shareRows || []).map(row => ({
+              ...row,
+              profiles: profilesById[row.owner] || null,
+            }));
           }
 
           function selectAthlete(a){ current.value = a; plan.value=null; planItems.value=[]; sessions.value=[]; }


### PR DESCRIPTION
## Summary
- load share rows first and fetch related profiles in a separate query
- prevent PostgREST from throwing relationship errors when the shares table lacks a foreign key to profiles

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68f5ed84f7cc8333b7e4274a5c675265