### PR TITLE
Align workout model and API with minimal schema

### DIFF
--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -4,75 +4,44 @@ import '../l10n/app_localizations.dart';
 class WorkoutExercise {
   final String? id;
   final String? name;
-  final int? sets;
-  final int? reps;
-  final int? restSeconds;
-  final String? intensity;
   final String? notes;
+  final int? position;
 
   const WorkoutExercise({
     this.name,
     this.id,
-    this.sets,
-    this.reps,
-    this.restSeconds,
-    this.intensity,
     this.notes,
+    this.position,
   });
-
-  Duration? get restDuration =>
-      restSeconds != null ? Duration(seconds: restSeconds!) : null;
 }
 
 class WorkoutDay {
   final String? id;
   final int week;
-  final int dow;
-  final String? name;
+  final String dayCode;
+  final String? title;
   final String? notes;
   final List<WorkoutExercise> exercises;
 
   const WorkoutDay({
     required this.week,
-    required this.dow,
+    required this.dayCode,
     required this.exercises,
     this.id,
-    this.name,
+    this.title,
     this.notes,
   });
-
-  String? dowLabel(AppLocalizations l10n) {
-    switch (dow) {
-      case 1:
-        return l10n.weekdayMonday;
-      case 2:
-        return l10n.weekdayTuesday;
-      case 3:
-        return l10n.weekdayWednesday;
-      case 4:
-        return l10n.weekdayThursday;
-      case 5:
-        return l10n.weekdayFriday;
-      case 6:
-        return l10n.weekdaySaturday;
-      case 7:
-        return l10n.weekdaySunday;
-      default:
-        return null;
-    }
-  }
 
   String formattedTitle(AppLocalizations l10n, {String? fallback}) {
     final parts = <String>[];
     if (week > 0) {
       parts.add(l10n.weekNumber(week));
     }
-    final dowName = dowLabel(l10n);
-    if (dowName != null) {
-      parts.add(dowName);
+    if (dayCode.isNotEmpty) {
+      parts.add(dayCode.toUpperCase());
     }
-    if (name != null && name!.isNotEmpty) {
-      parts.add(name!);
+    if (title != null && title!.isNotEmpty) {
+      parts.add(title!);
     }
     final resolvedFallback = fallback ?? l10n.defaultWorkoutTitle;
     return parts.isEmpty ? resolvedFallback : parts.join(' · ');

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -15,10 +15,6 @@ class Training extends StatelessWidget {
     final l10n = AppLocalizations.of(context)!;
     final headers = [
       l10n.trainingHeaderExercise,
-      l10n.trainingHeaderSets,
-      l10n.trainingHeaderReps,
-      l10n.trainingHeaderRest,
-      l10n.trainingHeaderIntensity,
       l10n.trainingHeaderNotes,
     ];
 
@@ -93,10 +89,6 @@ class Training extends StatelessWidget {
                           exerciseName,
                           onTap: () => _openTools(context, exercise),
                         ),
-                        _cell(context, exercise.sets?.toString() ?? '-'),
-                        _cell(context, exercise.reps?.toString() ?? '-'),
-                        _cell(context, _formatRest(exercise)),
-                        _cell(context, exercise.intensity ?? '-'),
                         _cell(context, exercise.notes ?? day.notes ?? ''),
                       ],
                     );
@@ -115,13 +107,7 @@ class Training extends StatelessWidget {
     final exerciseName = exercise.name?.trim().isEmpty ?? true
         ? l10n.defaultExerciseName
         : exercise.name!;
-    final restDuration = exercise.restDuration;
-    final reps = exercise.reps;
-    final sets = exercise.sets;
     final quickAdds = <int>{1};
-    if (reps != null && reps > 0) {
-      quickAdds.add(reps);
-    }
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => ExerciseTrackerPage(
@@ -132,8 +118,6 @@ class Training extends StatelessWidget {
               color: Theme.of(context).colorScheme.primary,
               icon: Icons.fitness_center,
               quickAddValues: quickAdds.toList()..sort(),
-              restDuration: restDuration,
-              targetReps: reps != null && sets != null ? reps * sets : reps,
             ),
           ],
         ),
@@ -155,21 +139,5 @@ class Training extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  String _formatRest(WorkoutExercise exercise) {
-    final restSeconds = exercise.restSeconds;
-    if (restSeconds == null || restSeconds <= 0) {
-      return '-';
-    }
-    final minutes = restSeconds ~/ 60;
-    final seconds = restSeconds % 60;
-    if (minutes > 0 && seconds > 0) {
-      return '${minutes}m ${seconds}s';
-    }
-    if (minutes > 0) {
-      return '${minutes}m';
-    }
-    return '${seconds}s';
   }
 }


### PR DESCRIPTION
## Summary
- simplify workout models to reflect the trimmed days/day_exercises schema
- load workout data directly from the new tables for the authenticated trainee
- streamline the training screen to show exercise names and notes from the minimal data set

## Testing
- Not run (flutter not installed in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414c875c78833392759ca71dbe908d)