### PR TITLE
Remove unused change_app_package_name dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,6 @@ dependencies:
   flutter_reactive_ble: ^5.0.2
   provider: ^6.1.1
   fl_chart: ^1.1.1
-  change_app_package_name: ^1.5.0
   app_links: ^6.0.0
   camera:
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- remove the unused change_app_package_name dependency from pubspec.yaml

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415261e4008333a70d147cf8a5b163)