### PR TITLE
Add exercise tracker shortcut for empty workout plans

### DIFF
--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -104,6 +104,19 @@ class _HomeContentState extends State<HomeContent> {
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
+                  const SizedBox(height: 24),
+                  SelectionCard(
+                    title: l10n.exerciseTrackerTitle,
+                    icon: Icons.checklist,
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => const ExerciseTrackerPage(),
+                        ),
+                      );
+                    },
+                  ),
                 ],
               );
             }


### PR DESCRIPTION
## Summary
- show exercise tracker selection when no workout plan is available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694182b95b7c8333962cd1caf589d6d0)