### PR TITLE
Add EMOM tracker with configurable countdown

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -269,6 +269,45 @@
     }
   },
   "resetReps": "Reset reps",
+  "emomTrackerTitle": "EMOM tracker",
+  "emomTrackerSubtitle": "Guided every-minute sets with prep countdown.",
+  "emomTrackerDescription": "Configure sets, reps, and intervals to stay on pace each minute.",
+  "emomSetsLabel": "Total sets",
+  "emomRepsLabel": "Reps per set",
+  "emomIntervalLabel": "Interval (seconds)",
+  "emomStartButton": "Start EMOM",
+  "emomResetButton": "Reset session",
+  "emomSessionComplete": "EMOM complete",
+  "emomCurrentSet": "Set {current} of {total}",
+  "@emomCurrentSet": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "emomRepsPerSet": "{count} reps per set",
+  "@emomRepsPerSet": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "emomFinishedMessage": "Nice work! You hit every minute.",
+  "emomTimeRemainingLabel": "Time remaining this minute",
+  "emomPrepHeadline": "Get ready for set {set}",
+  "@emomPrepHeadline": {
+    "placeholders": {
+      "set": {
+        "type": "int"
+      }
+    }
+  },
+  "emomPrepSubhead": "The next set starts after this countdown.",
   "timerTitle": "Timer",
   "weekdayMonday": "Monday",
   "weekdayTuesday": "Tuesday",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -269,6 +269,45 @@
     }
   },
   "resetReps": "Azzera ripetizioni",
+  "emomTrackerTitle": "Tracker EMOM",
+  "emomTrackerSubtitle": "Serie ogni minuto con conto alla rovescia.",
+  "emomTrackerDescription": "Configura serie, ripetizioni e intervalli per restare sul ritmo ogni minuto.",
+  "emomSetsLabel": "Serie totali",
+  "emomRepsLabel": "Ripetizioni per serie",
+  "emomIntervalLabel": "Intervallo (secondi)",
+  "emomStartButton": "Avvia EMOM",
+  "emomResetButton": "Reimposta sessione",
+  "emomSessionComplete": "EMOM completato",
+  "emomCurrentSet": "Serie {current} di {total}",
+  "@emomCurrentSet": {
+    "placeholders": {
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "emomRepsPerSet": "{count} ripetizioni per serie",
+  "@emomRepsPerSet": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "emomFinishedMessage": "Ottimo lavoro! Hai rispettato ogni minuto.",
+  "emomTimeRemainingLabel": "Tempo rimanente in questo minuto",
+  "emomPrepHeadline": "Preparati per la serie {set}",
+  "@emomPrepHeadline": {
+    "placeholders": {
+      "set": {
+        "type": "int"
+      }
+    }
+  },
+  "emomPrepSubhead": "La prossima serie parte alla fine del conto alla rovescia.",
   "timerTitle": "Timer",
   "weekdayMonday": "Lunedì",
   "weekdayTuesday": "Martedì",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1010,6 +1010,96 @@ abstract class AppLocalizations {
   /// **'Azzera ripetizioni'**
   String get resetReps;
 
+  /// No description provided for @emomTrackerTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Tracker EMOM'**
+  String get emomTrackerTitle;
+
+  /// No description provided for @emomTrackerSubtitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Serie ogni minuto con conto alla rovescia.'**
+  String get emomTrackerSubtitle;
+
+  /// No description provided for @emomTrackerDescription.
+  ///
+  /// In it, this message translates to:
+  /// **'Configura serie, ripetizioni e intervalli per restare sul ritmo ogni minuto.'**
+  String get emomTrackerDescription;
+
+  /// No description provided for @emomSetsLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Serie totali'**
+  String get emomSetsLabel;
+
+  /// No description provided for @emomRepsLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Ripetizioni per serie'**
+  String get emomRepsLabel;
+
+  /// No description provided for @emomIntervalLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Intervallo (secondi)'**
+  String get emomIntervalLabel;
+
+  /// No description provided for @emomStartButton.
+  ///
+  /// In it, this message translates to:
+  /// **'Avvia EMOM'**
+  String get emomStartButton;
+
+  /// No description provided for @emomResetButton.
+  ///
+  /// In it, this message translates to:
+  /// **'Reimposta sessione'**
+  String get emomResetButton;
+
+  /// No description provided for @emomSessionComplete.
+  ///
+  /// In it, this message translates to:
+  /// **'EMOM completato'**
+  String get emomSessionComplete;
+
+  /// No description provided for @emomCurrentSet.
+  ///
+  /// In it, this message translates to:
+  /// **'Serie {current} di {total}'**
+  String emomCurrentSet(int current, int total);
+
+  /// No description provided for @emomRepsPerSet.
+  ///
+  /// In it, this message translates to:
+  /// **'{count} ripetizioni per serie'**
+  String emomRepsPerSet(int count);
+
+  /// No description provided for @emomFinishedMessage.
+  ///
+  /// In it, this message translates to:
+  /// **'Ottimo lavoro! Hai rispettato ogni minuto.'**
+  String get emomFinishedMessage;
+
+  /// No description provided for @emomTimeRemainingLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Tempo rimanente in questo minuto'**
+  String get emomTimeRemainingLabel;
+
+  /// No description provided for @emomPrepHeadline.
+  ///
+  /// In it, this message translates to:
+  /// **'Preparati per la serie {set}'**
+  String emomPrepHeadline(int set);
+
+  /// No description provided for @emomPrepSubhead.
+  ///
+  /// In it, this message translates to:
+  /// **'La prossima serie parte alla fine del conto alla rovescia.'**
+  String get emomPrepSubhead;
+
   /// No description provided for @timerTitle.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -536,6 +536,59 @@ class AppLocalizationsEn extends AppLocalizations {
   String get resetReps => 'Reset reps';
 
   @override
+  String get emomTrackerTitle => 'EMOM tracker';
+
+  @override
+  String get emomTrackerSubtitle =>
+      'Guided every-minute sets with prep countdown.';
+
+  @override
+  String get emomTrackerDescription =>
+      'Configure sets, reps, and intervals to stay on pace each minute.';
+
+  @override
+  String get emomSetsLabel => 'Total sets';
+
+  @override
+  String get emomRepsLabel => 'Reps per set';
+
+  @override
+  String get emomIntervalLabel => 'Interval (seconds)';
+
+  @override
+  String get emomStartButton => 'Start EMOM';
+
+  @override
+  String get emomResetButton => 'Reset session';
+
+  @override
+  String get emomSessionComplete => 'EMOM complete';
+
+  @override
+  String emomCurrentSet(int current, int total) {
+    return 'Set $current of $total';
+  }
+
+  @override
+  String emomRepsPerSet(int count) {
+    return '$count reps per set';
+  }
+
+  @override
+  String get emomFinishedMessage => 'Nice work! You hit every minute.';
+
+  @override
+  String get emomTimeRemainingLabel => 'Time remaining this minute';
+
+  @override
+  String emomPrepHeadline(int set) {
+    return 'Get ready for set $set';
+  }
+
+  @override
+  String get emomPrepSubhead => 'The next set starts after this countdown.';
+
+  @override
   String get timerTitle => 'Timer';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -541,6 +541,60 @@ class AppLocalizationsIt extends AppLocalizations {
   String get resetReps => 'Azzera ripetizioni';
 
   @override
+  String get emomTrackerTitle => 'Tracker EMOM';
+
+  @override
+  String get emomTrackerSubtitle =>
+      'Serie ogni minuto con conto alla rovescia.';
+
+  @override
+  String get emomTrackerDescription =>
+      'Configura serie, ripetizioni e intervalli per restare sul ritmo ogni minuto.';
+
+  @override
+  String get emomSetsLabel => 'Serie totali';
+
+  @override
+  String get emomRepsLabel => 'Ripetizioni per serie';
+
+  @override
+  String get emomIntervalLabel => 'Intervallo (secondi)';
+
+  @override
+  String get emomStartButton => 'Avvia EMOM';
+
+  @override
+  String get emomResetButton => 'Reimposta sessione';
+
+  @override
+  String get emomSessionComplete => 'EMOM completato';
+
+  @override
+  String emomCurrentSet(int current, int total) {
+    return 'Serie $current di $total';
+  }
+
+  @override
+  String emomRepsPerSet(int count) {
+    return '$count ripetizioni per serie';
+  }
+
+  @override
+  String get emomFinishedMessage => 'Ottimo lavoro! Hai rispettato ogni minuto.';
+
+  @override
+  String get emomTimeRemainingLabel => 'Tempo rimanente in questo minuto';
+
+  @override
+  String emomPrepHeadline(int set) {
+    return 'Preparati per la serie $set';
+  }
+
+  @override
+  String get emomPrepSubhead =>
+      'La prossima serie parte alla fine del conto alla rovescia.';
+
+  @override
   String get timerTitle => 'Timer';
 
   @override

--- a/lib/pages/emom_tracker.dart
+++ b/lib/pages/emom_tracker.dart
@@ -1,0 +1,353 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import '../l10n/app_localizations.dart';
+
+class EmomTrackerPage extends StatefulWidget {
+  const EmomTrackerPage({super.key});
+
+  @override
+  State<EmomTrackerPage> createState() => _EmomTrackerPageState();
+}
+
+class _EmomTrackerPageState extends State<EmomTrackerPage> {
+  static const _prepSeconds = 5;
+
+  final _setsController = TextEditingController(text: '10');
+  final _repsController = TextEditingController(text: '10');
+  final _intervalController = TextEditingController(text: '60');
+
+  int _totalSets = 10;
+  int _repsPerSet = 10;
+  int _intervalSeconds = 60;
+
+  int _currentSet = 0;
+  Duration _intervalRemaining = Duration.zero;
+  int? _prepSecondsLeft;
+  bool _sessionCompleted = false;
+
+  Timer? _intervalTimer;
+  Timer? _prepTimer;
+
+  @override
+  void dispose() {
+    _intervalTimer?.cancel();
+    _prepTimer?.cancel();
+    _setsController.dispose();
+    _repsController.dispose();
+    _intervalController.dispose();
+    super.dispose();
+  }
+
+  void _startSession() {
+    if (_totalSets <= 0 || _repsPerSet <= 0 || _intervalSeconds <= 0) {
+      return;
+    }
+
+    _intervalTimer?.cancel();
+    _prepTimer?.cancel();
+
+    setState(() {
+      _sessionCompleted = false;
+      _currentSet = 1;
+      _intervalRemaining = Duration(seconds: _intervalSeconds);
+    });
+
+    _beginPrepCountdown();
+  }
+
+  void _beginPrepCountdown() {
+    setState(() {
+      _prepSecondsLeft = _prepSeconds;
+    });
+
+    _prepTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      setState(() {
+        if (_prepSecondsLeft != null && _prepSecondsLeft! > 1) {
+          _prepSecondsLeft = _prepSecondsLeft! - 1;
+        } else {
+          _prepSecondsLeft = null;
+          timer.cancel();
+          _startIntervalTimer();
+        }
+      });
+    });
+  }
+
+  void _startIntervalTimer() {
+    _intervalTimer?.cancel();
+    setState(() {
+      _intervalRemaining = Duration(seconds: _intervalSeconds);
+    });
+
+    _intervalTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_intervalRemaining.inSeconds <= 1) {
+        timer.cancel();
+        _handleSetCompletion();
+      } else {
+        setState(() {
+          _intervalRemaining -= const Duration(seconds: 1);
+        });
+      }
+    });
+  }
+
+  void _handleSetCompletion() {
+    if (_currentSet >= _totalSets) {
+      setState(() {
+        _sessionCompleted = true;
+        _currentSet = 0;
+      });
+      return;
+    }
+
+    setState(() {
+      _currentSet += 1;
+      _intervalRemaining = Duration(seconds: _intervalSeconds);
+    });
+
+    _beginPrepCountdown();
+  }
+
+  void _resetSession() {
+    _intervalTimer?.cancel();
+    _prepTimer?.cancel();
+    setState(() {
+      _currentSet = 0;
+      _intervalRemaining = Duration.zero;
+      _prepSecondsLeft = null;
+      _sessionCompleted = false;
+    });
+  }
+
+  void _updateIntValue(String value, void Function(int) onValid) {
+    final parsed = int.tryParse(value);
+    if (parsed != null && parsed > 0) {
+      onValid(parsed);
+    }
+  }
+
+  String _formatDuration(Duration duration) {
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+    return '$minutes:$seconds';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.emomTrackerTitle)),
+      body: Stack(
+        children: [
+          SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n.emomTrackerTitle,
+                          style: theme.textTheme.titleLarge
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          l10n.emomTrackerDescription,
+                          style: theme.textTheme.bodyMedium
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
+                        ),
+                        const SizedBox(height: 16),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: TextField(
+                                controller: _setsController,
+                                keyboardType: TextInputType.number,
+                                decoration: InputDecoration(
+                                  labelText: l10n.emomSetsLabel,
+                                ),
+                                onChanged: (value) =>
+                                    setState(() => _updateIntValue(value, (v) {
+                                          _totalSets = v;
+                                        })),
+                                enabled: _currentSet == 0,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: TextField(
+                                controller: _repsController,
+                                keyboardType: TextInputType.number,
+                                decoration: InputDecoration(
+                                  labelText: l10n.emomRepsLabel,
+                                ),
+                                onChanged: (value) =>
+                                    setState(() => _updateIntValue(value, (v) {
+                                          _repsPerSet = v;
+                                        })),
+                                enabled: _currentSet == 0,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        TextField(
+                          controller: _intervalController,
+                          keyboardType: TextInputType.number,
+                          decoration: InputDecoration(
+                            labelText: l10n.emomIntervalLabel,
+                          ),
+                          onChanged: (value) =>
+                              setState(() => _updateIntValue(value, (v) {
+                                    _intervalSeconds = v;
+                                  })),
+                          enabled: _currentSet == 0,
+                        ),
+                        const SizedBox(height: 16),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: FilledButton.icon(
+                                onPressed:
+                                    _currentSet == 0 ? _startSession : null,
+                                icon: const Icon(Icons.play_arrow),
+                                label: Text(l10n.emomStartButton),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: OutlinedButton.icon(
+                                onPressed:
+                                    _currentSet > 0 || _sessionCompleted
+                                        ? _resetSession
+                                        : null,
+                                icon: const Icon(Icons.restart_alt),
+                                label: Text(l10n.emomResetButton),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                if (_currentSet > 0 || _sessionCompleted)
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                _sessionCompleted
+                                    ? l10n.emomSessionComplete
+                                    : l10n.emomCurrentSet(
+                                        _currentSet, _totalSets),
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              if (!_sessionCompleted)
+                                Chip(
+                                  label: Text(l10n.emomRepsPerSet(_repsPerSet)),
+                                ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          if (_sessionCompleted)
+                            Text(
+                              l10n.emomFinishedMessage,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            )
+                          else ...[
+                            Text(
+                              l10n.emomTimeRemainingLabel,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: LinearProgressIndicator(
+                                    value: _intervalRemaining.inSeconds /
+                                        _intervalSeconds,
+                                  ),
+                                ),
+                                const SizedBox(width: 12),
+                                Text(
+                                  _formatDuration(_intervalRemaining),
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontFeatures: const [
+                                      FontFeature.tabularFigures(),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (_prepSecondsLeft != null)
+            Positioned.fill(
+              child: Container(
+                color: Colors.black.withValues(alpha: 0.75),
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        l10n.emomPrepHeadline(_currentSet),
+                        style: theme.textTheme.titleLarge?.copyWith(
+                          color: Colors.white,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        '${_prepSecondsLeft ?? 0}',
+                        style: theme.textTheme.displayLarge?.copyWith(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        l10n.emomPrepSubhead,
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          color: Colors.white70,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -1,6 +1,7 @@
 import 'package:calisync/model/workout_day.dart';
 import 'package:calisync/pages/exercise_tracker.dart';
 import 'package:calisync/components/cards/selection_card.dart';
+import 'package:calisync/pages/emom_tracker.dart';
 import 'package:calisync/pages/training.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -26,6 +27,33 @@ class _HomeContentState extends State<HomeContent> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+    final extraTools = [
+      SelectionCard(
+        title: l10n.exerciseTrackerTitle,
+        icon: Icons.checklist,
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const ExerciseTrackerPage(),
+            ),
+          );
+        },
+      ),
+      SelectionCard(
+        title: l10n.emomTrackerTitle,
+        subtitle: l10n.emomTrackerSubtitle,
+        icon: Icons.timer,
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const EmomTrackerPage(),
+            ),
+          );
+        },
+      ),
+    ];
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: RefreshIndicator(
@@ -105,40 +133,18 @@ class _HomeContentState extends State<HomeContent> {
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 24),
-                  SelectionCard(
-                    title: l10n.exerciseTrackerTitle,
-                    icon: Icons.checklist,
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const ExerciseTrackerPage(),
-                        ),
-                      );
-                    },
-                  ),
+                  ...extraTools,
                 ],
               );
             }
 
             return ListView.separated(
               physics: const AlwaysScrollableScrollPhysics(),
-              itemCount: days.length + 1,
+              itemCount: days.length + extraTools.length,
               separatorBuilder: (_, __) => const SizedBox(height: 16),
               itemBuilder: (context, index) {
-                if (index == days.length) {
-                  return SelectionCard(
-                    title: l10n.exerciseTrackerTitle,
-                    icon: Icons.checklist,
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const ExerciseTrackerPage(),
-                        ),
-                      );
-                    },
-                  );
+                if (index >= days.length) {
+                  return extraTools[index - days.length];
                 }
 
                 final day = days[index];


### PR DESCRIPTION
## Summary
- add an EMOM tracker screen with configurable sets, reps, and intervals plus a full-screen prep countdown
- surface the tracker from the home page alongside existing training tools
- extend localization strings for the new EMOM controls

## Testing
- not run (Flutter tooling not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69418478103083338238351b0f947440)