### PR TITLE
Expand EMOM prep overlay to full screen

### DIFF
--- a/lib/pages/emom_tracker.dart
+++ b/lib/pages/emom_tracker.dart
@@ -141,11 +141,11 @@ class _EmomTrackerPageState extends State<EmomTrackerPage> {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    return Scaffold(
-      appBar: AppBar(title: Text(l10n.emomTrackerTitle)),
-      body: Stack(
-        children: [
-          SingleChildScrollView(
+    return Stack(
+      children: [
+        Scaffold(
+          appBar: AppBar(title: Text(l10n.emomTrackerTitle)),
+          body: SingleChildScrollView(
             padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -311,43 +311,43 @@ class _EmomTrackerPageState extends State<EmomTrackerPage> {
               ],
             ),
           ),
-          if (_prepSecondsLeft != null)
-            Positioned.fill(
-              child: Container(
-                color: Colors.black.withValues(alpha: 0.75),
-                child: Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        l10n.emomPrepHeadline(_currentSet),
-                        style: theme.textTheme.titleLarge?.copyWith(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                        ),
+        ),
+        if (_prepSecondsLeft != null)
+          Positioned.fill(
+            child: Container(
+              color: Colors.black.withValues(alpha: 0.75),
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      l10n.emomPrepHeadline(_currentSet),
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
                       ),
-                      const SizedBox(height: 24),
-                      Text(
-                        '${_prepSecondsLeft ?? 0}',
-                        style: theme.textTheme.displayLarge?.copyWith(
-                          color: Colors.white,
-                          fontWeight: FontWeight.w800,
-                        ),
+                    ),
+                    const SizedBox(height: 24),
+                    Text(
+                      '${_prepSecondsLeft ?? 0}',
+                      style: theme.textTheme.displayLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w800,
                       ),
-                      const SizedBox(height: 12),
-                      Text(
-                        l10n.emomPrepSubhead,
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          color: Colors.white70,
-                        ),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      l10n.emomPrepSubhead,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: Colors.white70,
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             ),
-        ],
-      ),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- wrap the EMOM tracker in an outer stack so the prep countdown overlay covers the full activity
- move the countdown container outside the scrollable content for consistent full-screen coverage

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694187b2c86c8333b53145dbcde5ca43)