### PR TITLE
Revamp training page with exercise notes editing

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -85,6 +85,19 @@
   "trainingHeaderRest": "Rest",
   "trainingHeaderIntensity": "Intensity",
   "trainingHeaderNotes": "Notes",
+  "trainingNotesLabel": "Exercise notes",
+  "trainingNotesSave": "Save notes",
+  "trainingNotesSaved": "Notes saved",
+  "trainingNotesError": "Unable to save notes: {error}",
+  "@trainingNotesError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "trainingNotesUnavailable": "Cannot update notes for this exercise.",
+  "trainingOpenTracker": "Open tracker",
   "logoutError": "Error while logging out: {error}",
   "@logoutError": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -85,6 +85,19 @@
   "trainingHeaderRest": "Recupero",
   "trainingHeaderIntensity": "Intensità",
   "trainingHeaderNotes": "Note",
+  "trainingNotesLabel": "Note dell'esercizio",
+  "trainingNotesSave": "Salva note",
+  "trainingNotesSaved": "Note salvate",
+  "trainingNotesError": "Impossibile salvare le note: {error}",
+  "@trainingNotesError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "trainingNotesUnavailable": "Impossibile aggiornare le note per questo esercizio.",
+  "trainingOpenTracker": "Apri tracker",
   "logoutError": "Errore durante il logout: {error}",
   "@logoutError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -428,6 +428,42 @@ abstract class AppLocalizations {
   /// **'Note'**
   String get trainingHeaderNotes;
 
+  /// No description provided for @trainingNotesLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Exercise notes'**
+  String get trainingNotesLabel;
+
+  /// No description provided for @trainingNotesSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save notes'**
+  String get trainingNotesSave;
+
+  /// No description provided for @trainingNotesSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Notes saved'**
+  String get trainingNotesSaved;
+
+  /// No description provided for @trainingNotesError.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to save notes: {error}'**
+  String trainingNotesError(Object error);
+
+  /// No description provided for @trainingNotesUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot update notes for this exercise.'**
+  String get trainingNotesUnavailable;
+
+  /// No description provided for @trainingOpenTracker.
+  ///
+  /// In en, this message translates to:
+  /// **'Open tracker'**
+  String get trainingOpenTracker;
+
   /// No description provided for @logoutError.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -215,6 +215,26 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trainingHeaderNotes => 'Notes';
 
   @override
+  String get trainingNotesLabel => 'Exercise notes';
+
+  @override
+  String get trainingNotesSave => 'Save notes';
+
+  @override
+  String get trainingNotesSaved => 'Notes saved';
+
+  @override
+  String trainingNotesError(Object error) {
+    return 'Unable to save notes: $error';
+  }
+
+  @override
+  String get trainingNotesUnavailable => 'Cannot update notes for this exercise.';
+
+  @override
+  String get trainingOpenTracker => 'Open tracker';
+
+  @override
   String logoutError(Object error) {
     return 'Error while logging out: $error';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -216,6 +216,27 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trainingHeaderNotes => 'Note';
 
   @override
+  String get trainingNotesLabel => "Note dell'esercizio";
+
+  @override
+  String get trainingNotesSave => 'Salva note';
+
+  @override
+  String get trainingNotesSaved => 'Note salvate';
+
+  @override
+  String trainingNotesError(Object error) {
+    return 'Impossibile salvare le note: $error';
+  }
+
+  @override
+  String get trainingNotesUnavailable =>
+      'Impossibile aggiornare le note per questo esercizio.';
+
+  @override
+  String get trainingOpenTracker => 'Apri tracker';
+
+  @override
   String logoutError(Object error) {
     return 'Errore durante il logout: $error';
   }


### PR DESCRIPTION
## Summary
- redesign the training page with card-based styling similar to the terminology page
- add inline note fields for each exercise and save updates back to Supabase
- expand localization strings for the new training experience in English and Italian

## Testing
- not run (Flutter/Dart tooling not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941ebdda788833389e4f25cad84b2a9)