### PR TITLE
Add workout completion controls

### DIFF
--- a/lib/components/cards/selection_card.dart
+++ b/lib/components/cards/selection_card.dart
@@ -7,12 +7,18 @@ class SelectionCard extends StatelessWidget {
     required this.icon,
     this.onTap,
     this.subtitle,
+    this.iconColor,
+    this.tileColor,
+    this.trailing,
   });
 
   final String title;
   final IconData icon;
   final VoidCallback? onTap;
   final String? subtitle;
+  final Color? iconColor;
+  final Color? tileColor;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -27,12 +33,14 @@ class SelectionCard extends StatelessWidget {
       child: ListTile(
         leading: Icon(
           icon,
-          color: theme.colorScheme.primary,
+          color: iconColor ?? theme.colorScheme.primary,
         ),
         title: Text(title),
         subtitle: subtitle != null ? Text(subtitle!) : null,
-        trailing: onTap != null ? const Icon(Icons.arrow_forward_ios) : null,
+        trailing:
+            trailing ?? (onTap != null ? const Icon(Icons.arrow_forward_ios) : null),
         onTap: onTap,
+        tileColor: tileColor,
         contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
       ),
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -98,6 +98,18 @@
   },
   "trainingNotesUnavailable": "Cannot update notes for this exercise.",
   "trainingOpenTracker": "Open tracker",
+  "trainingMarkComplete": "Mark day as complete",
+  "trainingMarkIncomplete": "Mark day as incomplete",
+  "trainingCompletionSaved": "Workout day updated",
+  "trainingCompletionError": "Unable to update workout: {error}",
+  "@trainingCompletionError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "trainingCompletionUnavailable": "Cannot update this workout day.",
   "logoutError": "Error while logging out: {error}",
   "@logoutError": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -98,6 +98,18 @@
   },
   "trainingNotesUnavailable": "Impossibile aggiornare le note per questo esercizio.",
   "trainingOpenTracker": "Apri tracker",
+  "trainingMarkComplete": "Segna giorno come completato",
+  "trainingMarkIncomplete": "Segna giorno come incompleto",
+  "trainingCompletionSaved": "Allenamento aggiornato",
+  "trainingCompletionError": "Impossibile aggiornare l'allenamento: {error}",
+  "@trainingCompletionError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "trainingCompletionUnavailable": "Impossibile aggiornare questo giorno di allenamento.",
   "logoutError": "Errore durante il logout: {error}",
   "@logoutError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -464,6 +464,36 @@ abstract class AppLocalizations {
   /// **'Open tracker'**
   String get trainingOpenTracker;
 
+  /// No description provided for @trainingMarkComplete.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark day as complete'**
+  String get trainingMarkComplete;
+
+  /// No description provided for @trainingMarkIncomplete.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark day as incomplete'**
+  String get trainingMarkIncomplete;
+
+  /// No description provided for @trainingCompletionSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Workout day updated'**
+  String get trainingCompletionSaved;
+
+  /// No description provided for @trainingCompletionError.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to update workout: {error}'**
+  String trainingCompletionError(Object error);
+
+  /// No description provided for @trainingCompletionUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Cannot update this workout day.'**
+  String get trainingCompletionUnavailable;
+
   /// No description provided for @logoutError.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -235,6 +235,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trainingOpenTracker => 'Open tracker';
 
   @override
+  String get trainingMarkComplete => 'Mark day as complete';
+
+  @override
+  String get trainingMarkIncomplete => 'Mark day as incomplete';
+
+  @override
+  String get trainingCompletionSaved => 'Workout day updated';
+
+  @override
+  String trainingCompletionError(Object error) {
+    return 'Unable to update workout: $error';
+  }
+
+  @override
+  String get trainingCompletionUnavailable => 'Cannot update this workout day.';
+
+  @override
   String logoutError(Object error) {
     return 'Error while logging out: $error';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -237,6 +237,24 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trainingOpenTracker => 'Apri tracker';
 
   @override
+  String get trainingMarkComplete => 'Segna giorno come completato';
+
+  @override
+  String get trainingMarkIncomplete => 'Segna giorno come incompleto';
+
+  @override
+  String get trainingCompletionSaved => 'Allenamento aggiornato';
+
+  @override
+  String trainingCompletionError(Object error) {
+    return "Impossibile aggiornare l'allenamento: $error";
+  }
+
+  @override
+  String get trainingCompletionUnavailable =>
+      'Impossibile aggiornare questo giorno di allenamento.';
+
+  @override
   String logoutError(Object error) {
     return 'Errore durante il logout: $error';
   }

--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -21,6 +21,7 @@ class WorkoutDay {
   final String dayCode;
   final String? title;
   final String? notes;
+  final bool isCompleted;
   final List<WorkoutExercise> exercises;
 
   const WorkoutDay({
@@ -30,6 +31,7 @@ class WorkoutDay {
     this.id,
     this.title,
     this.notes,
+    this.isCompleted = false,
   });
 
   String formattedTitle(AppLocalizations l10n, {String? fallback}) {


### PR DESCRIPTION
## Summary
- add ability to toggle workout day completion from the training page and return completion updates
- sort and visually distinguish completed workout days on the home screen
- extend workout day model and localizations to support completion state

## Testing
- Not run (environment missing Dart/Flutter)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941f763b6f48333b02ea138dbb37315)