### PR TITLE
Make exercise notes read-only and add trainee notes

### DIFF
--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -5,12 +5,14 @@ class WorkoutExercise {
   final String? id;
   final String? name;
   final String? notes;
+  final String? traineeNotes;
   final int? position;
 
   const WorkoutExercise({
     this.name,
     this.id,
     this.notes,
+    this.traineeNotes,
     this.position,
   });
 }

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -218,7 +218,7 @@ class _HomeContentState extends State<HomeContent> {
         .select('''
             id, week, day_code, title, notes, completed,
             day_exercises (
-              id, position, notes,
+              id, position, notes, trainee_notes,
               exercises ( id, name )
             )
           ''')
@@ -242,6 +242,7 @@ class _HomeContentState extends State<HomeContent> {
           name: exerciseDetails['name'] as String?,
           position: (exercise['position'] as num?)?.toInt(),
           notes: exercise['notes'] as String?,
+          traineeNotes: exercise['trainee_notes'] as String?,
         );
       }).toList();
 


### PR DESCRIPTION
## Summary
- show coach-provided exercise notes as read-only guidance while keeping the card layout compact
- add per-exercise trainee notes with inline saving and Supabase persistence
- load trainee notes alongside exercises for each workout day

## Testing
- Not run (Flutter SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69426dde25cc8333a0fa5464f391cb15)