### PR TITLE
Group workout days by plan and highlight latest

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -76,6 +76,16 @@
   "retry": "Retry",
   "homeEmptyTitle": "No workouts available",
   "homeEmptyDescription": "Contact your coach to receive a new plan.",
+  "homePlanDefaultTitle": "Workout plan",
+  "homePlanLatestLabel": "Latest plan",
+  "homePlanStartedLabel": "Started {date}",
+  "@homePlanStartedLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "unauthenticated": "User not authenticated",
   "defaultExerciseName": "Exercise",
   "generalNotes": "General notes",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -76,6 +76,16 @@
   "retry": "Riprova",
   "homeEmptyTitle": "Nessun allenamento disponibile",
   "homeEmptyDescription": "Contatta il tuo coach per ricevere una nuova scheda.",
+  "homePlanDefaultTitle": "Piano di allenamento",
+  "homePlanLatestLabel": "Ultimo piano",
+  "homePlanStartedLabel": "Iniziato il {date}",
+  "@homePlanStartedLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "unauthenticated": "Utente non autenticato",
   "defaultExerciseName": "Esercizio",
   "generalNotes": "Note generali",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -374,6 +374,24 @@ abstract class AppLocalizations {
   /// **'Contatta il tuo coach per ricevere una nuova scheda.'**
   String get homeEmptyDescription;
 
+  /// No description provided for @homePlanDefaultTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Piano di allenamento'**
+  String get homePlanDefaultTitle;
+
+  /// No description provided for @homePlanLatestLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Ultimo piano'**
+  String get homePlanLatestLabel;
+
+  /// No description provided for @homePlanStartedLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Iniziato il {date}'**
+  String homePlanStartedLabel(String date);
+
   /// No description provided for @unauthenticated.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -188,6 +188,17 @@ class AppLocalizationsEn extends AppLocalizations {
       'Contact your coach to receive a new plan.';
 
   @override
+  String get homePlanDefaultTitle => 'Workout plan';
+
+  @override
+  String get homePlanLatestLabel => 'Latest plan';
+
+  @override
+  String homePlanStartedLabel(String date) {
+    return 'Started $date';
+  }
+
+  @override
   String get unauthenticated => 'User not authenticated';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -189,6 +189,17 @@ class AppLocalizationsIt extends AppLocalizations {
       'Contatta il tuo coach per ricevere una nuova scheda.';
 
   @override
+  String get homePlanDefaultTitle => 'Piano di allenamento';
+
+  @override
+  String get homePlanLatestLabel => 'Ultimo piano';
+
+  @override
+  String homePlanStartedLabel(String date) {
+    return 'Iniziato il $date';
+  }
+
+  @override
   String get unauthenticated => 'Utente non autenticato';
 
   @override

--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -24,6 +24,10 @@ class WorkoutDay {
   final String? title;
   final String? notes;
   final bool isCompleted;
+  final String? planId;
+  final String? planName;
+  final DateTime? planStartedAt;
+  final DateTime? createdAt;
   final List<WorkoutExercise> exercises;
 
   const WorkoutDay({
@@ -34,6 +38,10 @@ class WorkoutDay {
     this.title,
     this.notes,
     this.isCompleted = false,
+    this.planId,
+    this.planName,
+    this.planStartedAt,
+    this.createdAt,
   });
 
   String formattedTitle(AppLocalizations l10n, {String? fallback}) {


### PR DESCRIPTION
## Summary
- group workout days into workout plan sections and surface plan metadata
- highlight the latest plan while keeping past plans accessible via expansion
- add localization and model support for plan information

## Testing
- Not run (dart/flutter not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69426f4aba748333b0203ebc3ad0a424)