### PR TITLE
Add maximal test tracking to trainee profile

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -177,6 +177,46 @@
       }
     }
   },
+  "profileMaxTestsTitle": "Max test tracking",
+  "profileMaxTestsDescription": "Log your best attempts to see how your strength evolves over time.",
+  "profileMaxTestsAdd": "Add max test",
+  "profileMaxTestsRefresh": "Refresh",
+  "profileMaxTestsEmpty": "No max tests recorded yet. Add your first attempt to start tracking progress.",
+  "profileMaxTestsError": "Unable to load max tests: {error}",
+  "@profileMaxTestsError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsExerciseLabel": "Exercise",
+  "profileMaxTestsExerciseHint": "e.g. Pull ups or Push ups",
+  "profileMaxTestsValueLabel": "Result",
+  "profileMaxTestsValueHint": "Enter a positive value",
+  "profileMaxTestsUnitLabel": "Unit",
+  "profileMaxTestsUnitHint": "e.g. reps, kg, sec",
+  "profileMaxTestsDateLabel": "Recorded on {date}",
+  "@profileMaxTestsDateLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsCancel": "Cancel",
+  "profileMaxTestsSave": "Save test",
+  "profileMaxTestsSaveSuccess": "Max test saved",
+  "profileMaxTestsSaveError": "Unable to save test: {error}",
+  "@profileMaxTestsSaveError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsDefaultUnit": "reps",
+  "profileMaxTestsBestLabel": "Personal best",
   "profileEdit": "Edit profile",
   "profileComingSoon": "Coming soon",
   "profileEditSubtitle": "Update your personal details",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -177,6 +177,46 @@
       }
     }
   },
+  "profileMaxTestsTitle": "Test massimali",
+  "profileMaxTestsDescription": "Tieni traccia dei tuoi massimali per vedere come progredisci nel tempo.",
+  "profileMaxTestsAdd": "Aggiungi test massimale",
+  "profileMaxTestsRefresh": "Aggiorna",
+  "profileMaxTestsEmpty": "Nessun test massimale registrato. Aggiungi il primo per iniziare a tracciare i progressi.",
+  "profileMaxTestsError": "Impossibile caricare i test massimali: {error}",
+  "@profileMaxTestsError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsExerciseLabel": "Esercizio",
+  "profileMaxTestsExerciseHint": "es. trazioni o piegamenti",
+  "profileMaxTestsValueLabel": "Risultato",
+  "profileMaxTestsValueHint": "Inserisci un valore positivo",
+  "profileMaxTestsUnitLabel": "Unità",
+  "profileMaxTestsUnitHint": "es. rip, kg, sec",
+  "profileMaxTestsDateLabel": "Registrato il {date}",
+  "@profileMaxTestsDateLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsCancel": "Annulla",
+  "profileMaxTestsSave": "Salva test",
+  "profileMaxTestsSaveSuccess": "Test massimale salvato",
+  "profileMaxTestsSaveError": "Impossibile salvare il test: {error}",
+  "@profileMaxTestsSaveError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsDefaultUnit": "ripetizioni",
+  "profileMaxTestsBestLabel": "Miglior risultato",
   "profileEdit": "Modifica profilo",
   "profileComingSoon": "Presto disponibile",
   "profileEditSubtitle": "Aggiorna le tue informazioni personali",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -728,6 +728,120 @@ abstract class AppLocalizations {
   /// **'{weight} kg'**
   String profileWeightValue(String weight);
 
+  /// No description provided for @profileMaxTestsTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Test massimali'**
+  String get profileMaxTestsTitle;
+
+  /// No description provided for @profileMaxTestsDescription.
+  ///
+  /// In it, this message translates to:
+  /// **'Tieni traccia dei tuoi massimali per vedere come progredisci nel tempo.'**
+  String get profileMaxTestsDescription;
+
+  /// No description provided for @profileMaxTestsAdd.
+  ///
+  /// In it, this message translates to:
+  /// **'Aggiungi test massimale'**
+  String get profileMaxTestsAdd;
+
+  /// No description provided for @profileMaxTestsRefresh.
+  ///
+  /// In it, this message translates to:
+  /// **'Aggiorna'**
+  String get profileMaxTestsRefresh;
+
+  /// No description provided for @profileMaxTestsEmpty.
+  ///
+  /// In it, this message translates to:
+  /// **'Nessun test massimale registrato. Aggiungi il primo per iniziare a tracciare i progressi.'**
+  String get profileMaxTestsEmpty;
+
+  /// No description provided for @profileMaxTestsError.
+  ///
+  /// In it, this message translates to:
+  /// **'Impossibile caricare i test massimali: {error}'**
+  String profileMaxTestsError(Object error);
+
+  /// No description provided for @profileMaxTestsExerciseLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Esercizio'**
+  String get profileMaxTestsExerciseLabel;
+
+  /// No description provided for @profileMaxTestsExerciseHint.
+  ///
+  /// In it, this message translates to:
+  /// **'es. trazioni o piegamenti'**
+  String get profileMaxTestsExerciseHint;
+
+  /// No description provided for @profileMaxTestsValueLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Risultato'**
+  String get profileMaxTestsValueLabel;
+
+  /// No description provided for @profileMaxTestsValueHint.
+  ///
+  /// In it, this message translates to:
+  /// **'Inserisci un valore positivo'**
+  String get profileMaxTestsValueHint;
+
+  /// No description provided for @profileMaxTestsUnitLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Unità'**
+  String get profileMaxTestsUnitLabel;
+
+  /// No description provided for @profileMaxTestsUnitHint.
+  ///
+  /// In it, this message translates to:
+  /// **'es. rip, kg, sec'**
+  String get profileMaxTestsUnitHint;
+
+  /// No description provided for @profileMaxTestsDateLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Registrato il {date}'**
+  String profileMaxTestsDateLabel(String date);
+
+  /// No description provided for @profileMaxTestsCancel.
+  ///
+  /// In it, this message translates to:
+  /// **'Annulla'**
+  String get profileMaxTestsCancel;
+
+  /// No description provided for @profileMaxTestsSave.
+  ///
+  /// In it, this message translates to:
+  /// **'Salva test'**
+  String get profileMaxTestsSave;
+
+  /// No description provided for @profileMaxTestsSaveSuccess.
+  ///
+  /// In it, this message translates to:
+  /// **'Test massimale salvato'**
+  String get profileMaxTestsSaveSuccess;
+
+  /// No description provided for @profileMaxTestsSaveError.
+  ///
+  /// In it, this message translates to:
+  /// **'Impossibile salvare il test: {error}'**
+  String profileMaxTestsSaveError(Object error);
+
+  /// No description provided for @profileMaxTestsDefaultUnit.
+  ///
+  /// In it, this message translates to:
+  /// **'ripetizioni'**
+  String get profileMaxTestsDefaultUnit;
+
+  /// No description provided for @profileMaxTestsBestLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Miglior risultato'**
+  String get profileMaxTestsBestLabel;
+
   /// No description provided for @profileEdit.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -382,6 +382,71 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get profileMaxTestsTitle => 'Max test tracking';
+
+  @override
+  String get profileMaxTestsDescription =>
+      'Log your best attempts to see how your strength evolves over time.';
+
+  @override
+  String get profileMaxTestsAdd => 'Add max test';
+
+  @override
+  String get profileMaxTestsRefresh => 'Refresh';
+
+  @override
+  String get profileMaxTestsEmpty =>
+      'No max tests recorded yet. Add your first attempt to start tracking progress.';
+
+  @override
+  String profileMaxTestsError(Object error) {
+    return 'Unable to load max tests: $error';
+  }
+
+  @override
+  String get profileMaxTestsExerciseLabel => 'Exercise';
+
+  @override
+  String get profileMaxTestsExerciseHint => 'e.g. Pull ups or Push ups';
+
+  @override
+  String get profileMaxTestsValueLabel => 'Result';
+
+  @override
+  String get profileMaxTestsValueHint => 'Enter a positive value';
+
+  @override
+  String get profileMaxTestsUnitLabel => 'Unit';
+
+  @override
+  String get profileMaxTestsUnitHint => 'e.g. reps, kg, sec';
+
+  @override
+  String profileMaxTestsDateLabel(String date) {
+    return 'Recorded on $date';
+  }
+
+  @override
+  String get profileMaxTestsCancel => 'Cancel';
+
+  @override
+  String get profileMaxTestsSave => 'Save test';
+
+  @override
+  String get profileMaxTestsSaveSuccess => 'Max test saved';
+
+  @override
+  String profileMaxTestsSaveError(Object error) {
+    return 'Unable to save test: $error';
+  }
+
+  @override
+  String get profileMaxTestsDefaultUnit => 'reps';
+
+  @override
+  String get profileMaxTestsBestLabel => 'Personal best';
+
+  @override
   String get profileEdit => 'Edit profile';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -385,6 +385,71 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get profileMaxTestsTitle => 'Test massimali';
+
+  @override
+  String get profileMaxTestsDescription =>
+      'Tieni traccia dei tuoi massimali per vedere come progredisci nel tempo.';
+
+  @override
+  String get profileMaxTestsAdd => 'Aggiungi test massimale';
+
+  @override
+  String get profileMaxTestsRefresh => 'Aggiorna';
+
+  @override
+  String get profileMaxTestsEmpty =>
+      'Nessun test massimale registrato. Aggiungi il primo per iniziare a tracciare i progressi.';
+
+  @override
+  String profileMaxTestsError(Object error) {
+    return 'Impossibile caricare i test massimali: $error';
+  }
+
+  @override
+  String get profileMaxTestsExerciseLabel => 'Esercizio';
+
+  @override
+  String get profileMaxTestsExerciseHint => 'es. trazioni o piegamenti';
+
+  @override
+  String get profileMaxTestsValueLabel => 'Risultato';
+
+  @override
+  String get profileMaxTestsValueHint => 'Inserisci un valore positivo';
+
+  @override
+  String get profileMaxTestsUnitLabel => 'Unità';
+
+  @override
+  String get profileMaxTestsUnitHint => 'es. rip, kg, sec';
+
+  @override
+  String profileMaxTestsDateLabel(String date) {
+    return 'Registrato il $date';
+  }
+
+  @override
+  String get profileMaxTestsCancel => 'Annulla';
+
+  @override
+  String get profileMaxTestsSave => 'Salva test';
+
+  @override
+  String get profileMaxTestsSaveSuccess => 'Test massimale salvato';
+
+  @override
+  String profileMaxTestsSaveError(Object error) {
+    return 'Impossibile salvare il test: $error';
+  }
+
+  @override
+  String get profileMaxTestsDefaultUnit => 'ripetizioni';
+
+  @override
+  String get profileMaxTestsBestLabel => 'Miglior risultato';
+
+  @override
   String get profileEdit => 'Modifica profilo';
 
   @override

--- a/lib/model/max_test.dart
+++ b/lib/model/max_test.dart
@@ -1,0 +1,36 @@
+class MaxTest {
+  final String id;
+  final String exercise;
+  final double value;
+  final String unit;
+  final DateTime recordedAt;
+
+  const MaxTest({
+    required this.id,
+    required this.exercise,
+    required this.value,
+    required this.unit,
+    required this.recordedAt,
+  });
+
+  factory MaxTest.fromMap(Map<String, dynamic> map) {
+    return MaxTest(
+      id: map['id'] as String,
+      exercise: map['exercise'] as String? ?? '',
+      value: (map['value'] as num?)?.toDouble() ?? 0,
+      unit: map['unit'] as String? ?? '',
+      recordedAt: DateTime.tryParse(map['recorded_at'] as String? ?? '') ??
+          DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'exercise': exercise,
+      'value': value,
+      'unit': unit,
+      'recorded_at': recordedAt.toIso8601String(),
+    };
+  }
+}

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -2,9 +2,11 @@
 import 'package:calisync/model/trainee.dart';
 import 'package:calisync/theme/app_theme.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
+import '../model/max_test.dart';
 import 'login.dart';
 
 final supabase = Supabase.instance.client;
@@ -109,6 +111,7 @@ class ProfilePage extends StatefulWidget {
 
 class _ProfilePageState extends State<ProfilePage> {
   late Future<UserProfileData> _profileFuture;
+  Future<List<MaxTest>>? _maxTestsFuture;
 
   @override
   void initState() {
@@ -119,6 +122,13 @@ class _ProfilePageState extends State<ProfilePage> {
   void _refreshProfile() {
     setState(() {
       _profileFuture = getUserData();
+      _maxTestsFuture = null;
+    });
+  }
+
+  void _refreshMaxTests(String userId) {
+    setState(() {
+      _maxTestsFuture = _loadMaxTests(userId);
     });
   }
 
@@ -133,6 +143,31 @@ class _ProfilePageState extends State<ProfilePage> {
       _refreshProfile();
       ScaffoldMessenger.of(context)
           .showSnackBar(SnackBar(content: Text(l10n.profileEditSuccess)));
+    }
+  }
+
+  Future<List<MaxTest>> _loadMaxTests(String userId) async {
+    final response = await supabase
+        .from('max_tests')
+        .select('id, exercise, value, unit, recorded_at')
+        .eq('trainee_id', userId)
+        .order('recorded_at', ascending: false);
+
+    final items = (response as List?)?.cast<Map<String, dynamic>>() ?? [];
+    return items.map(MaxTest.fromMap).toList();
+  }
+
+  Future<void> _showAddMaxTest(String userId) async {
+    final l10n = AppLocalizations.of(context)!;
+    final saved = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => _MaxTestBottomSheet(userId: userId),
+    );
+    if (saved == true && mounted) {
+      _refreshMaxTests(userId);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(l10n.profileMaxTestsSaveSuccess)));
     }
   }
 
@@ -182,6 +217,7 @@ class _ProfilePageState extends State<ProfilePage> {
               return Center(child: Text(l10n.profileNoData));
             }
 
+            _maxTestsFuture ??= _loadMaxTests(data.userId);
             final theme = Theme.of(context);
             final colorScheme = theme.colorScheme;
             final appColors = theme.extension<AppColors>()!;
@@ -261,6 +297,12 @@ class _ProfilePageState extends State<ProfilePage> {
                         ),
                       ],
                     ),
+                  ),
+                  const SizedBox(height: 16),
+                  _MaxTestSection(
+                    maxTestsFuture: _maxTestsFuture!,
+                    onAddTest: () => _showAddMaxTest(data.userId),
+                    onRefresh: () => _refreshMaxTests(data.userId),
                   ),
                   const SizedBox(height: 16),
                   Card(
@@ -455,5 +497,371 @@ class _EditProfileBottomSheetState extends State<_EditProfileBottomSheet> {
         ),
       ),
     );
+  }
+}
+
+class _MaxTestSection extends StatelessWidget {
+  const _MaxTestSection({
+    required this.maxTestsFuture,
+    required this.onAddTest,
+    required this.onRefresh,
+  });
+
+  final Future<List<MaxTest>> maxTestsFuture;
+  final VoidCallback onAddTest;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    l10n.profileMaxTestsTitle,
+                    style: theme.textTheme.titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                ),
+                IconButton(
+                  onPressed: onRefresh,
+                  tooltip: l10n.profileMaxTestsRefresh,
+                  icon: const Icon(Icons.refresh),
+                ),
+                const SizedBox(width: 8),
+                FilledButton.tonalIcon(
+                  onPressed: onAddTest,
+                  icon: const Icon(Icons.add),
+                  label: Text(l10n.profileMaxTestsAdd),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.profileMaxTestsDescription,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: colorScheme.onSurfaceVariant),
+            ),
+            const SizedBox(height: 12),
+            FutureBuilder<List<MaxTest>>(
+              future: maxTestsFuture,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(16),
+                      child: CircularProgressIndicator(),
+                    ),
+                  );
+                }
+
+                if (snapshot.hasError) {
+                  final errorText = snapshot.error.toString();
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Text(
+                      l10n.profileMaxTestsError(errorText),
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  );
+                }
+
+                final tests = snapshot.data ?? const [];
+                if (tests.isEmpty) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.emoji_events_outlined),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            l10n.profileMaxTestsEmpty,
+                            style: theme.textTheme.bodyMedium,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+
+                final bestByExercise = <String, double>{};
+                for (final test in tests) {
+                  final currentBest = bestByExercise[test.exercise];
+                  if (currentBest == null || test.value > currentBest) {
+                    bestByExercise[test.exercise] = test.value;
+                  }
+                }
+
+                return Column(
+                  children: [
+                    for (final test in tests)
+                      _MaxTestTile(
+                        test: test,
+                        isBest:
+                            bestByExercise[test.exercise] == test.value,
+                      ),
+                  ],
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MaxTestTile extends StatelessWidget {
+  const _MaxTestTile({required this.test, required this.isBest});
+
+  final MaxTest test;
+  final bool isBest;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final appColors = theme.extension<AppColors>();
+    final dateText = DateFormat.yMMMd().format(test.recordedAt);
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        backgroundColor:
+            isBest ? appColors?.success ?? Colors.green : Colors.transparent,
+        foregroundColor:
+            isBest ? theme.colorScheme.onPrimary : theme.colorScheme.primary,
+        child: Icon(isBest ? Icons.military_tech : Icons.timeline),
+      ),
+      title: Text(test.exercise),
+      subtitle: Text(
+        '${test.value.toStringAsFixed(test.value.truncateToDouble() == test.value ? 0 : 1)} ${test.unit}'.trim(),
+      ),
+      trailing: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            l10n.profileMaxTestsDateLabel(dateText),
+            style: theme.textTheme.bodySmall,
+          ),
+          if (isBest)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: (appColors?.success ?? theme.colorScheme.secondary)
+                      .withOpacity(0.15),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Text(
+                  l10n.profileMaxTestsBestLabel,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: appColors?.success ?? theme.colorScheme.secondary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MaxTestBottomSheet extends StatefulWidget {
+  const _MaxTestBottomSheet({required this.userId});
+
+  final String userId;
+
+  @override
+  State<_MaxTestBottomSheet> createState() => _MaxTestBottomSheetState();
+}
+
+class _MaxTestBottomSheetState extends State<_MaxTestBottomSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _exerciseController = TextEditingController();
+  final _valueController = TextEditingController();
+  final _unitController = TextEditingController(text: 'reps');
+  DateTime _selectedDate = DateTime.now();
+  bool _isSaving = false;
+
+  @override
+  void dispose() {
+    _exerciseController.dispose();
+    _valueController.dispose();
+    _unitController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 24,
+        bottom: bottomInset + 24,
+      ),
+      child: SafeArea(
+        child: SingleChildScrollView(
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  l10n.profileMaxTestsAdd,
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleLarge
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _exerciseController,
+                  decoration: InputDecoration(
+                    labelText: l10n.profileMaxTestsExerciseLabel,
+                    hintText: l10n.profileMaxTestsExerciseHint,
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return l10n.profileMaxTestsExerciseHint;
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _valueController,
+                  decoration: InputDecoration(
+                    labelText: l10n.profileMaxTestsValueLabel,
+                    hintText: l10n.profileMaxTestsValueHint,
+                  ),
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true),
+                  validator: (value) {
+                    final parsed =
+                        double.tryParse(value?.trim().replaceAll(',', '.') ?? '');
+                    if (parsed == null || parsed <= 0) {
+                      return l10n.profileMaxTestsValueHint;
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _unitController,
+                  decoration: InputDecoration(
+                    labelText: l10n.profileMaxTestsUnitLabel,
+                    hintText: l10n.profileMaxTestsUnitHint,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                OutlinedButton.icon(
+                  onPressed: _isSaving ? null : _pickDate,
+                  icon: const Icon(Icons.event),
+                  label: Text(
+                    l10n.profileMaxTestsDateLabel(
+                      DateFormat.yMMMd().format(_selectedDate),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed:
+                            _isSaving ? null : () => Navigator.of(context).pop(false),
+                        child: Text(l10n.profileMaxTestsCancel),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton(
+                        onPressed: _isSaving ? null : _submit,
+                        child: _isSaving
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : Text(l10n.profileMaxTestsSave),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickDate() async {
+    final pickedDate = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime.now().subtract(const Duration(days: 365)),
+      lastDate: DateTime.now().add(const Duration(days: 30)),
+    );
+
+    if (pickedDate != null) {
+      setState(() => _selectedDate = pickedDate);
+    }
+  }
+
+  Future<void> _submit() async {
+    if (_isSaving) return;
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isSaving = true);
+    final l10n = AppLocalizations.of(context)!;
+
+    final exercise = _exerciseController.text.trim();
+    final value = double.parse(_valueController.text.trim().replaceAll(',', '.'));
+    final unit = _unitController.text.trim().isEmpty
+        ? l10n.profileMaxTestsDefaultUnit
+        : _unitController.text.trim();
+
+    final payload = {
+      'trainee_id': widget.userId,
+      'exercise': exercise,
+      'value': value,
+      'unit': unit,
+      'recorded_at': _selectedDate.toIso8601String(),
+    };
+
+    try {
+      await supabase.from('max_tests').insert(payload);
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+    } catch (error) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.profileMaxTestsSaveError(error.toString()))),
+      );
+      setState(() => _isSaving = false);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a max test data model and profile section fed from Supabase
- allow trainees to record new max test attempts from the profile page
- update localizations for the new max test tracking experience

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69448f8779888333a22a76b0d8078640)