### PR TITLE
Add additional exercise guides

### DIFF
--- a/lib/pages/exercise_guides.dart
+++ b/lib/pages/exercise_guides.dart
@@ -49,6 +49,27 @@ class ExerciseGuidesPage extends StatelessWidget {
       accent: Colors.purple,
     ),
     _ExerciseGuide(
+      name: 'Muscle-up',
+      difficulty: 'Advanced',
+      focus: 'Lats, chest, triceps, transition strength',
+      tip:
+          'Pull high to your upper chest and keep the bar close to reduce the swing.',
+      description:
+          'From a controlled hang, explode into a high pull, transition the wrists over the bar, and press to lockout.',
+      videoUrl: 'https://youtu.be/4NnU1YuZzUE',
+      accent: Colors.teal,
+    ),
+    _ExerciseGuide(
+      name: 'Straight bar dip',
+      difficulty: 'Intermediate',
+      focus: 'Chest, triceps, shoulders',
+      tip: 'Keep elbows tucked and press down while leaning slightly forward.',
+      description:
+          'Start on top of the bar with locked elbows, lower under control until shoulders dip below elbows, then drive back up.',
+      videoUrl: 'https://youtu.be/2z8JmcrW-As',
+      accent: Colors.deepOrange,
+    ),
+    _ExerciseGuide(
       name: 'Dips',
       difficulty: 'Intermediate',
       focus: 'Chest, triceps, shoulders',
@@ -57,6 +78,27 @@ class ExerciseGuidesPage extends StatelessWidget {
           'Start locked out on parallel bars, lower until shoulders dip below elbows, then press back to a strong lockout.',
       videoUrl: 'https://youtu.be/2z8JmcrW-As',
       accent: Colors.red,
+    ),
+    _ExerciseGuide(
+      name: 'Australian row',
+      difficulty: 'Beginner',
+      focus: 'Upper back, biceps, core',
+      tip: 'Brace your core and keep a straight line from shoulders to heels.',
+      description:
+          'Set the bar at waist height, hang underneath, and row your chest to the bar with elbows tight.',
+      videoUrl: 'https://youtu.be/9efgcAjQe7E',
+      accent: Colors.indigo,
+    ),
+    _ExerciseGuide(
+      name: 'Pike push-up',
+      difficulty: 'Intermediate',
+      focus: 'Shoulders, triceps, core',
+      tip:
+          'Keep hips high and lower your head to a spot just in front of your hands.',
+      description:
+          'From a pike position, bend elbows to bring the head down, then press back to a strong lockout.',
+      videoUrl: 'https://youtu.be/0wDEO1i2bFM',
+      accent: Colors.amber,
     ),
   ];
 


### PR DESCRIPTION
### Motivation
- Expand the built-in exercise guide list to include more movements requested by users (e.g. muscle-up, straight bar dip).
- Provide short coaching tips, descriptions and example videos for each added exercise to improve the learning resources.
- Keep the guides page a single source of reference for common calisthenics movements.

### Description
- Added four new `_ExerciseGuide` entries to `lib/pages/exercise_guides.dart`:
  - `Muscle-up` (Advanced)
  - `Straight bar dip` (Intermediate)
  - `Australian row` (Beginner)
  - `Pike push-up` (Intermediate)
- Each entry includes `name`, `difficulty`, `focus`, `tip`, `description`, `videoUrl`, and `accent` color attributes.
- Left existing guides intact (e.g. `Dips`) and appended new guides into the `_guides` list.
- File modified: `lib/pages/exercise_guides.dart` (changes committed).

### Testing
- Attempted to validate toolchain with `flutter --version` but the `flutter` command is not available in the environment (command not found), so no Flutter build or UI tests were executed.
- No automated unit/widget tests were run from this environment due to missing Flutter tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945167beee48333b96837d842c73b65)