### PR TITLE
Add History tab with per-exercise max-test charts to admin

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -31,6 +31,7 @@
                 <button :class="{active: activeSection==='trainees'}" @click="activeSection='trainees'">Trainees</button>
                 <button :class="{active: activeSection==='plans'}" @click="activeSection='plans'" :disabled="!current">Plans</button>
                 <button :class="{active: activeSection==='schedule'}" @click="activeSection='schedule'" :disabled="!current">Schedule</button>
+                <button :class="{active: activeSection==='history'}" @click="activeSection='history'" :disabled="!current">History</button>
             </div>
             <div class="toolbar-secondary">
                 <input v-model="search" placeholder="Search trainees..." style="min-width:200px" />
@@ -340,6 +341,62 @@
                                         </div>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row section-panel" :class="{active: activeSection==='history'}">
+            <div class="col" v-if="!current">
+                <div class="card">
+                    <h2>Max test history</h2>
+                    <p class="muted">Select a trainee from the Trainees tab to review their max test history.</p>
+                </div>
+            </div>
+
+            <div class="col" v-else>
+                <div class="card">
+                    <div class="history-header">
+                        <h2 style="margin:0">Max test history • {{ current.displayName || shortId(current.id) }}</h2>
+                        <div class="inline-actions">
+                            <span class="pill">{{ maxTests.length }} tests</span>
+                            <button class="small" type="button" @click="loadMaxTests" :disabled="loadingMaxTests">Refresh</button>
+                        </div>
+                    </div>
+                    <p class="muted small">Each chart shows how max attempts evolve over time for a single exercise.</p>
+                    <div v-if="loadingMaxTests" class="muted small">Loading max tests…</div>
+                    <div v-else-if="maxTestsError" class="muted small">{{ maxTestsError }}</div>
+                    <div v-else-if="maxTests.length===0" class="muted small">No max tests logged yet.</div>
+                    <div v-else class="history-grid">
+                        <div v-for="entry in maxTestHistory" :key="entry.exercise" class="card history-card">
+                            <div class="history-card-head">
+                                <div class="stack">
+                                    <strong>{{ entry.exercise }}</strong>
+                                    <span class="muted small">{{ entry.count }} tests • best {{ formatTestValue(entry.bestValue) }} {{ entry.unit }}</span>
+                                </div>
+                                <span class="pill">{{ entry.latestLabel }}</span>
+                            </div>
+                            <svg
+                                class="history-chart"
+                                :viewBox="`0 0 ${entry.chartWidth} ${entry.chartHeight}`"
+                                role="img"
+                                :aria-label="`Max test history for ${entry.exercise}`"
+                            >
+                                <polyline :points="entry.polyline" class="history-line"></polyline>
+                                <circle
+                                    v-for="(point, idx) in entry.points"
+                                    :key="idx"
+                                    :cx="point.x"
+                                    :cy="point.y"
+                                    class="history-point"
+                                    :class="{ latest: idx === entry.points.length - 1 }"
+                                ></circle>
+                            </svg>
+                            <div class="history-meta small">
+                                <span>{{ formatTestValue(entry.minValue) }} {{ entry.unit }}</span>
+                                <span>{{ formatTestValue(entry.maxValue) }} {{ entry.unit }}</span>
                             </div>
                         </div>
                     </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -57,3 +57,12 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .day-code-picker button{border-radius:999px;padding:6px 12px;border:1px solid var(--line);background:transparent;color:var(--ink)}
 .day-code-picker button.active{background:var(--accent);color:#04120c;border-color:transparent}
 .helper-text{font-size:12px;color:var(--muted)}
+.history-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px;margin-top:12px}
+.history-card{display:flex;flex-direction:column;gap:10px}
+.history-header{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px;margin-bottom:8px}
+.history-card-head{display:flex;justify-content:space-between;align-items:flex-start;flex-wrap:wrap;gap:8px}
+.history-chart{width:100%;height:100px;background:#0e111a;border-radius:12px;border:1px solid var(--line);padding:6px;box-sizing:border-box}
+.history-line{fill:none;stroke:var(--accent);stroke-width:2}
+.history-point{fill:#9aa0a6;stroke:#0e111a;stroke-width:2;r:3}
+.history-point.latest{fill:var(--accent)}
+.history-meta{display:flex;justify-content:space-between;align-items:center;color:var(--muted)}


### PR DESCRIPTION
### Motivation

- Provide per‑trainee historical view of recorded max tests so admins can see how an exercise max evolves over time.
- Surface best/min/latest values and a small trend chart per exercise directly in the admin UI.

### Description

- Added reactive state and loaders: `maxTests`, `loadingMaxTests`, `maxTestsError` in `backend/admin/app.js`.
- Implemented `loadMaxTests(u)` to fetch `max_tests` from Supabase and `maxTestHistory` (computed) to group tests by exercise and build chart points / SVG polyline data; added helper formatters `formatTestValue` and `formatDate`.
- Wire up `selectUser` to load max tests for the selected trainee and adjusted `bootstrap` to `await selectUser(...)` so history is loaded on initial boot.
- UI: added a new `History` button and section in `backend/admin/index.html` that renders per‑exercise cards with SVG polylines and points; styled cards and charts in `backend/admin/styles.css`.

Files modified: `backend/admin/app.js`, `backend/admin/index.html`, `backend/admin/styles.css`.

### Testing

- Launched a local static server for `backend/admin` and verified `index.html` is reachable with `curl` (HTTP/1.0 200 OK) — succeeded.
- Attempted an automated Playwright screenshot of the admin page to validate rendering, but the browser run failed to connect (`net::ERR_CONNECTION_REFUSED`) — failed.
- No unit or integration test suite was executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945330b33dc83338c83be7eb417dcae)