### PR TITLE
Compact admin exercises view

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -38,7 +38,7 @@
             </div>
         </div>
 
-        <div class="card section-panel" :class="{active: activeSection==='exercises'}">
+        <div class="card section-panel exercise-panel" :class="{active: activeSection==='exercises'}">
             <h2 style="display:flex;justify-content:space-between;align-items:center;gap:8px">Exercises <span class="pill">{{ exerciseOptions.length }} total</span></h2>
             <div class="row">
                 <div class="col">

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -47,6 +47,16 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .exercise-head{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 .exercise-head input{flex:1 1 160px;min-width:0}
 .exercise-actions{display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end}
+.exercise-panel h2{margin:12px 0 6px}
+.exercise-panel .row{gap:12px}
+.exercise-panel form{gap:6px}
+.exercise-panel input{padding:6px 8px}
+.exercise-panel .exercise-list{grid-template-columns:repeat(auto-fill,minmax(220px,1fr))}
+.exercise-panel .exercise-item{padding:8px;gap:4px}
+.exercise-panel .exercise-head{gap:6px}
+.exercise-panel .exercise-actions{gap:4px;justify-content:flex-start}
+.exercise-panel .btn.small,
+.exercise-panel button.small{padding:6px 10px}
 .progress-row{display:flex;align-items:center;gap:8px;margin-top:8px}
 .progress-bar{flex:1;height:6px;border-radius:999px;background:#11131a;overflow:hidden;border:1px solid var(--line)}
 .progress-bar span{display:block;height:100%;background:var(--accent)}


### PR DESCRIPTION
### Motivation
- Reduce vertical spacing and tighten the exercises section so more items are visible at once in the admin UI.
- Scope layout tweaks to just the exercises panel to avoid affecting other admin sections.

### Description
- Added an `exercise-panel` class to the exercises section wrapper in `backend/admin/index.html`.
- Scoped style adjustments in `backend/admin/styles.css` to make the exercises list more compact: reduced paddings/gaps, tighter input padding, increased grid density (`minmax(220px,1fr)`), and smaller action button spacing.
- Changes only affect the exercises panel so other sections keep their current layout.

### Testing
- Launched a local static server with `python -m http.server 8000` and exercised the admin page `index.html`.
- Ran a Playwright script to render the page and capture a visual check screenshot; the script completed and produced a screenshot artifact (visual verification).
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694537e898d88333a963465e76d7f6e2)