### PR TITLE
Show date range and Y-axis labels on admin max test charts

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -93,6 +93,12 @@
             const minValue = values.length ? Math.min(...values) : 0;
             const minDate = sorted[0]?.timestamp || Date.now();
             const maxDate = sorted[sorted.length - 1]?.timestamp || minDate;
+            const minDateLabel = sorted[0]?.recorded_at
+              ? formatDate(sorted[0].recorded_at)
+              : '';
+            const maxDateLabel = sorted[sorted.length - 1]?.recorded_at
+              ? formatDate(sorted[sorted.length - 1].recorded_at)
+              : '';
             const range = maxValue - minValue || 1;
             const timeRange = maxDate - minDate || 1;
             const chartWidth = 260;
@@ -124,6 +130,8 @@
               maxValue,
               bestValue: maxValue,
               latestLabel: latest ? formatDate(latest.recorded_at) : '',
+              minDateLabel,
+              maxDateLabel,
               chartWidth,
               chartHeight,
               points,

--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -378,25 +378,31 @@
                                 </div>
                                 <span class="pill">{{ entry.latestLabel }}</span>
                             </div>
-                            <svg
-                                class="history-chart"
-                                :viewBox="`0 0 ${entry.chartWidth} ${entry.chartHeight}`"
-                                role="img"
-                                :aria-label="`Max test history for ${entry.exercise}`"
-                            >
-                                <polyline :points="entry.polyline" class="history-line"></polyline>
-                                <circle
-                                    v-for="(point, idx) in entry.points"
-                                    :key="idx"
-                                    :cx="point.x"
-                                    :cy="point.y"
-                                    class="history-point"
-                                    :class="{ latest: idx === entry.points.length - 1 }"
-                                ></circle>
-                            </svg>
+                            <div class="history-chart-wrap">
+                                <div class="history-y-axis small">
+                                    <span>{{ formatTestValue(entry.maxValue) }} {{ entry.unit }}</span>
+                                    <span>{{ formatTestValue(entry.minValue) }} {{ entry.unit }}</span>
+                                </div>
+                                <svg
+                                    class="history-chart"
+                                    :viewBox="`0 0 ${entry.chartWidth} ${entry.chartHeight}`"
+                                    role="img"
+                                    :aria-label="`Max test history for ${entry.exercise}`"
+                                >
+                                    <polyline :points="entry.polyline" class="history-line"></polyline>
+                                    <circle
+                                        v-for="(point, idx) in entry.points"
+                                        :key="idx"
+                                        :cx="point.x"
+                                        :cy="point.y"
+                                        class="history-point"
+                                        :class="{ latest: idx === entry.points.length - 1 }"
+                                    ></circle>
+                                </svg>
+                            </div>
                             <div class="history-meta small">
-                                <span>{{ formatTestValue(entry.minValue) }} {{ entry.unit }}</span>
-                                <span>{{ formatTestValue(entry.maxValue) }} {{ entry.unit }}</span>
+                                <span>{{ entry.minDateLabel }}</span>
+                                <span>{{ entry.maxDateLabel }}</span>
                             </div>
                         </div>
                     </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -71,7 +71,9 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .history-card{display:flex;flex-direction:column;gap:10px}
 .history-header{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px;margin-bottom:8px}
 .history-card-head{display:flex;justify-content:space-between;align-items:flex-start;flex-wrap:wrap;gap:8px}
-.history-chart{width:100%;height:100px;background:#0e111a;border-radius:12px;border:1px solid var(--line);padding:6px;box-sizing:border-box}
+.history-chart-wrap{display:flex;gap:8px;align-items:stretch}
+.history-y-axis{display:flex;flex-direction:column;justify-content:space-between;min-width:56px;text-align:right}
+.history-chart{width:100%;height:100px;background:#0e111a;border-radius:12px;border:1px solid var(--line);padding:6px;box-sizing:border-box;flex:1}
 .history-line{fill:none;stroke:var(--accent);stroke-width:2}
 .history-point{fill:#9aa0a6;stroke:#0e111a;stroke-width:2;r:3}
 .history-point.latest{fill:var(--accent)}


### PR DESCRIPTION
### Motivation
- History charts in the admin UI were hard to read: there was no explicit Y axis for reps and no clear X-axis date range shown for each exercise.
- Improve readability of max test history cards by surfacing min/max rep labels and the recorded date range.

### Description
- Compute `minDateLabel` and `maxDateLabel` in the `maxTestHistory` computed value in `backend/admin/app.js` and include them on each history `entry`.
- Update `backend/admin/index.html` to render a left Y-axis showing max/min rep labels, keep the SVG chart as-is, and show the X-axis date range using `entry.minDateLabel` and `entry.maxDateLabel` in the card footer.
- Add layout styles in `backend/admin/styles.css` (`.history-chart-wrap`, `.history-y-axis`, adjust `.history-chart`) to accommodate the axis labels without breaking existing chart rendering.
- Files changed: `backend/admin/app.js`, `backend/admin/index.html`, `backend/admin/styles.css`.

### Testing
- Launched a local static server with `python -m http.server 8000` and loaded `index.html` in a headless browser via Playwright; a screenshot was captured at `artifacts/admin-login.png` (visual smoke test — charts require an authenticated trainee to display real data).
- No automated unit tests were added or executed for this change.
- Manual/visual inspection is recommended after authenticating and selecting a trainee to confirm labels align correctly with rendered charts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694560bcd7a08333a2d96aa067e8159e)