### PR TITLE
Limit max test lists to recent attempts

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -217,6 +217,8 @@
   },
   "profileMaxTestsDefaultUnit": "reps",
   "profileMaxTestsBestLabel": "Personal best",
+  "profileMaxTestsShowMore": "Show all attempts",
+  "profileMaxTestsShowLess": "Show fewer attempts",
   "profileEdit": "Edit profile",
   "profileComingSoon": "Coming soon",
   "profileEditSubtitle": "Update your personal details",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -217,6 +217,8 @@
   },
   "profileMaxTestsDefaultUnit": "ripetizioni",
   "profileMaxTestsBestLabel": "Miglior risultato",
+  "profileMaxTestsShowMore": "Mostra tutti i tentativi",
+  "profileMaxTestsShowLess": "Mostra meno tentativi",
   "profileEdit": "Modifica profilo",
   "profileComingSoon": "Presto disponibile",
   "profileEditSubtitle": "Aggiorna le tue informazioni personali",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -842,6 +842,18 @@ abstract class AppLocalizations {
   /// **'Miglior risultato'**
   String get profileMaxTestsBestLabel;
 
+  /// No description provided for @profileMaxTestsShowMore.
+  ///
+  /// In it, this message translates to:
+  /// **'Mostra tutti i tentativi'**
+  String get profileMaxTestsShowMore;
+
+  /// No description provided for @profileMaxTestsShowLess.
+  ///
+  /// In it, this message translates to:
+  /// **'Mostra meno tentativi'**
+  String get profileMaxTestsShowLess;
+
   /// No description provided for @profileEdit.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -447,6 +447,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileMaxTestsBestLabel => 'Personal best';
 
   @override
+  String get profileMaxTestsShowMore => 'Show all attempts';
+
+  @override
+  String get profileMaxTestsShowLess => 'Show fewer attempts';
+
+  @override
   String get profileEdit => 'Edit profile';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -450,6 +450,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileMaxTestsBestLabel => 'Miglior risultato';
 
   @override
+  String get profileMaxTestsShowMore => 'Mostra tutti i tentativi';
+
+  @override
+  String get profileMaxTestsShowLess => 'Mostra meno tentativi';
+
+  @override
   String get profileEdit => 'Modifica profilo';
 
   @override

--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -211,7 +211,7 @@ class _MaxTestsPageState extends State<MaxTestsPage> {
   }
 }
 
-class _ExerciseGroupCard extends StatelessWidget {
+class _ExerciseGroupCard extends StatefulWidget {
   const _ExerciseGroupCard({
     required this.exercise,
     required this.tests,
@@ -223,10 +223,22 @@ class _ExerciseGroupCard extends StatelessWidget {
   final double bestValue;
 
   @override
+  State<_ExerciseGroupCard> createState() => _ExerciseGroupCardState();
+}
+
+class _ExerciseGroupCardState extends State<_ExerciseGroupCard> {
+  static const int _collapsedCount = 3;
+  bool _isExpanded = false;
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final l10n = AppLocalizations.of(context)!;
+    final tests = widget.tests;
+    final showToggle = tests.length > _collapsedCount;
+    final visibleTests =
+        _isExpanded ? tests : tests.take(_collapsedCount).toList();
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -242,23 +254,35 @@ class _ExerciseGroupCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              exercise,
+              widget.exercise,
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.w700,
               ),
             ),
             const SizedBox(height: 12),
-            for (final test in tests)
+            for (final test in visibleTests)
               _MaxTestTile(
                 test: test,
-                isBest: test.value == bestValue,
+                isBest: test.value == widget.bestValue,
+              ),
+            if (showToggle)
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton(
+                  onPressed: () => setState(() => _isExpanded = !_isExpanded),
+                  child: Text(
+                    _isExpanded
+                        ? l10n.profileMaxTestsShowLess
+                        : l10n.profileMaxTestsShowMore,
+                  ),
+                ),
               ),
             if (tests.isNotEmpty)
               Padding(
                 padding: const EdgeInsets.only(top: 4),
                 child: Text(
                   '${l10n.profileMaxTestsBestLabel}: '
-                  '${bestValue.toStringAsFixed(bestValue.truncateToDouble() == bestValue ? 0 : 1)} '
+                  '${widget.bestValue.toStringAsFixed(widget.bestValue.truncateToDouble() == widget.bestValue ? 0 : 1)} '
                   '${tests.first.unit}'.trim(),
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: colorScheme.onSurfaceVariant,


### PR DESCRIPTION
### Motivation
- Reduce the length of per-exercise max test lists to improve readability by default.
- Let users still access full history when needed via an explicit toggle.

### Description
- Converted `_ExerciseGroupCard` from a `StatelessWidget` to a `StatefulWidget` and added an `_isExpanded` flag with a `_collapsedCount` of `3` to show only the most recent attempts by default.
- Render now uses `visibleTests = _isExpanded ? tests : tests.take(_collapsedCount).toList()` and a `TextButton` toggles between `l10n.profileMaxTestsShowMore` and `l10n.profileMaxTestsShowLess`.
- Added new localization keys to `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb` and updated the generated localization classes in `lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, and `lib/l10n/app_localizations_it.dart`.
- Adjusted a few references to use `widget.bestValue` and limited displayed tests to `visibleTests`.

### Testing
- No automated tests were executed for this change.
- Manual/visual verification was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694923be26cc83339351aead9b216d48)