### PR TITLE
Show exercise notes in dialog on training cards

### DIFF
--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -318,6 +318,26 @@ class _ExerciseCard extends StatelessWidget {
     required this.onToggleCompletion,
   });
 
+  void _showExerciseNotes(
+    BuildContext context,
+    String exerciseName,
+    String notes,
+  ) {
+    showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(exerciseName),
+        content: Text(notes),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(MaterialLocalizations.of(context).closeButtonLabel),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -377,19 +397,21 @@ class _ExerciseCard extends StatelessWidget {
             const SizedBox(height: 4),
             if ((exercise.notes ?? '').trim().isNotEmpty) ...[
               const SizedBox(height: 8),
-              Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(10),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: Text(
-                  exercise.notes!.trim(),
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyMedium
-                      ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: OutlinedButton.icon(
+                  onPressed: () => _showExerciseNotes(
+                    context,
+                    exerciseName,
+                    exercise.notes!.trim(),
+                  ),
+                  icon: const Icon(Icons.sticky_note_2_outlined, size: 18),
+                  label: Text(l10n.trainingNotesLabel),
+                  style: OutlinedButton.styleFrom(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    visualDensity: VisualDensity.compact,
+                  ),
                 ),
               ),
             ],


### PR DESCRIPTION
### Motivation
- Exercise notes were consuming a lot of vertical space in each training card and needed a more compact, discoverable UI.

### Description
- Replace the inline full-width notes container in `lib/pages/training.dart` with a compact `OutlinedButton.icon` labeled via `l10n.trainingNotesLabel`.
- Add a `_showExerciseNotes` helper that opens an `AlertDialog` to display the full exercise note when the button is tapped.
- Use `VisualDensity.compact` and adjusted padding for the button to keep exercise cards tighter and reduce visual clutter.
- All changes are contained in `lib/pages/training.dart`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69492bf9d3bc83338cb3c098a303109e)