### PR TITLE
Defer Navigator.pop in Training pop callback to avoid locked navigator

### DIFF
--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -40,8 +40,14 @@ class _TrainingState extends State<Training> {
     return PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, result) async {
-        Navigator.of(context).pop(_completionChanged);
-        return;
+        if (didPop) {
+          return;
+        }
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            Navigator.of(context).pop(_completionChanged);
+          }
+        });
       },
       child: Scaffold(
         appBar: AppBar(title: Text(widget.day.formattedTitle(l10n))),


### PR DESCRIPTION
### Motivation
- Prevent the Flutter navigator assertion `!_debugLocked` triggered by calling `Navigator.of(context).pop(...)` directly inside the pop callback.
- Avoid attempting a double-pop when the system already handled the pop (`didPop`).
- Ensure navigation result is returned only after the current pop callback completes and the framework is safe to modify navigation state.

### Description
- Updated `lib/pages/training.dart` to check `if (didPop) return;` inside `onPopInvokedWithResult` to skip duplicate pops.
- Deferred the navigation result pop using `WidgetsBinding.instance.addPostFrameCallback(...)` instead of popping synchronously.
- Added a `mounted` guard before calling `Navigator.of(context).pop(_completionChanged)` to avoid acting on a disposed state.

### Testing
- No automated tests were run for this change.
- (No additional CI or unit test results available.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694960bd908483339c07b4867b48b23d)