### PR TITLE
Add trainee notes display in training cards

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -120,6 +120,7 @@
   "trainingHeaderIntensity": "Intensity",
   "trainingHeaderNotes": "Notes",
   "trainingNotesLabel": "Exercise notes",
+  "trainingTraineeNotesLabel": "Trainee notes",
   "trainingNotesSave": "Save notes",
   "trainingNotesSaved": "Notes saved",
   "trainingNotesError": "Unable to save notes: {error}",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -120,6 +120,7 @@
   "trainingHeaderIntensity": "Intensità",
   "trainingHeaderNotes": "Note",
   "trainingNotesLabel": "Note dell'esercizio",
+  "trainingTraineeNotesLabel": "Note del tirocinante",
   "trainingNotesSave": "Salva note",
   "trainingNotesSaved": "Note salvate",
   "trainingNotesError": "Impossibile salvare le note: {error}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -596,6 +596,12 @@ abstract class AppLocalizations {
   /// **'Note dell\'esercizio'**
   String get trainingNotesLabel;
 
+  /// No description provided for @trainingTraineeNotesLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Note del tirocinante'**
+  String get trainingTraineeNotesLabel;
+
   /// No description provided for @trainingNotesSave.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -307,6 +307,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trainingNotesLabel => 'Exercise notes';
 
   @override
+  String get trainingTraineeNotesLabel => 'Trainee notes';
+
+  @override
   String get trainingNotesSave => 'Save notes';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -309,6 +309,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trainingNotesLabel => 'Note dell\'esercizio';
 
   @override
+  String get trainingTraineeNotesLabel => 'Note del tirocinante';
+
+  @override
   String get trainingNotesSave => 'Salva note';
 
   @override

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -415,12 +415,32 @@ class _ExerciseCard extends StatelessWidget {
                 ),
               ),
             ],
+            if ((exercise.traineeNotes ?? '').trim().isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: OutlinedButton.icon(
+                  onPressed: () => _showExerciseNotes(
+                    context,
+                    exerciseName,
+                    exercise.traineeNotes!.trim(),
+                  ),
+                  icon: const Icon(Icons.notes_outlined, size: 18),
+                  label: Text(l10n.trainingTraineeNotesLabel),
+                  style: OutlinedButton.styleFrom(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+              ),
+            ],
             const SizedBox(height: 8),
             TextField(
               controller: traineeNotesController,
               maxLines: null,
               decoration: InputDecoration(
-                labelText: l10n.trainingNotesLabel,
+                labelText: l10n.trainingTraineeNotesLabel,
                 hintText: l10n.trainingHeaderNotes,
                 border: const OutlineInputBorder(),
                 contentPadding:


### PR DESCRIPTION
### Motivation
- Surface trainee-entered notes alongside coach notes in the exercise UI so trainees can view their own saved notes in the training detail view.
- Distinguish the trainee notes input from coach `exercise.notes` by adding a separate label and localized string.

### Description
- Show a new button in each exercise card to view saved trainee notes when `exercise.traineeNotes` is present and reuse `_showExerciseNotes` for the dialog.
- Change the trainee notes `TextField` label to use `l10n.trainingTraineeNotesLabel` instead of the exercise notes label.
- Add localization key `trainingTraineeNotesLabel` to `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb` and update generated/localization files `lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, and `lib/l10n/app_localizations_it.dart`.
- Modified file list: `lib/pages/training.dart`, `lib/l10n/app_en.arb`, `lib/l10n/app_it.arb`, `lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, and `lib/l10n/app_localizations_it.dart`.

### Testing
- No automated tests were run as part of this change.
- Changes were compiled and committed locally (manual verification of diffs performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694961259afc8333810628c783b7c577)