### PR TITLE
Add GitHub Pages deployment workflow for admin site

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -1,0 +1,41 @@
+name: Deploy admin to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/admin/**"
+      - ".github/workflows/deploy-admin.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload admin site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: backend/admin
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Publish the static admin UI located in `backend/admin` to GitHub Pages automatically when changes are merged to `main` or via manual dispatch.

### Description
- Add `.github/workflows/deploy-admin.yml` which triggers on `push` to `main` for `backend/admin/**` and on `workflow_dispatch`.
- Configure permissions `contents: read`, `pages: write`, and `id-token: write` and a concurrency group named `pages`.
- Add a `deploy` job that runs on `ubuntu-latest` and uses `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3` with `path: backend/admin`, and `actions/deploy-pages@v4`.

### Testing
- No automated tests were executed because this change only adds a CI workflow file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964dcf2d9b08333ab650d6953456ab2)