### PR TITLE
Use app logo asset for empty home state

### DIFF
--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -94,10 +94,10 @@ class _HomeContentState extends State<HomeContent> {
                 physics: const AlwaysScrollableScrollPhysics(),
                 children: [
                   const SizedBox(height: 32),
-                  Icon(
-                    Icons.fitness_center,
-                    size: 56,
-                    color: Theme.of(context).colorScheme.primary,
+                  Image.asset(
+                    'assets/logo.png',
+                    height: 56,
+                    width: 56,
                   ),
                   const SizedBox(height: 16),
                   Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,8 @@ flutter:
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
+  assets:
+    - assets/logo.png
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
### Motivation
- Replace the default material `fitness_center` icon on the home page with the app logo so the main page reflects branding.
- Ensure the app bundles the logo as a Flutter asset so it can be displayed at runtime.
- The logo should be rendered with a transparent background to blend with the app UI.

### Description
- Replaced `Icons.fitness_center` with `Image.asset('assets/logo.png')` in `lib/pages/home_content.dart` and set `height` and `width` to `56` to match the previous icon size.
- Added `assets/logo.png` to the `flutter.assets` section in `pubspec.yaml` so the image is included in the app bundle.

### Testing
- No automated tests were run for this change.
- No CI checks or `flutter test` were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e8ab49b0833387706ae24df71403)