### PR TITLE
Add left-aligned AppBar menu to access Profile

### DIFF
--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -116,8 +116,22 @@ class _HomePageState extends State<HomePage> {
     return Scaffold(
       extendBody: true,
       appBar: AppBar(
-        centerTitle: true,
+        centerTitle: false,
         elevation: 0,
+        leading: PopupMenuButton<int>(
+          icon: const Icon(Icons.menu),
+          onSelected: (index) {
+            setState(() {
+              selectedIndex = index;
+            });
+          },
+          itemBuilder: (context) => [
+            PopupMenuItem<int>(
+              value: 2,
+              child: Text(l10n.navProfile),
+            ),
+          ],
+        ),
         title: Text(
           widget.title,
           style: theme.textTheme.titleLarge?.copyWith(
@@ -274,4 +288,3 @@ class _GradientIcon extends StatelessWidget {
     );
   }
 }
-


### PR DESCRIPTION
### Motivation
- Provide a top menu button so the user can open the profile from the app bar. 
- Align the app bar title to the left to accommodate the new menu button. 

### Description
- Added a `leading` `PopupMenuButton<int>` to the `AppBar` that includes a menu item for the profile and sets `selectedIndex` when chosen. 
- Changed `centerTitle` to `false` so the title is left-aligned with the menu. 
- Changes applied in `lib/pages/main.dart` to wire the menu to the existing navigation system. 

### Testing
- No automated tests were executed for this change. 
- No test failures reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ed51f76c833390af2c901b43db2d)