### PR TITLE
Add `trainee_feedbacks` table

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -47,6 +47,15 @@ CREATE TABLE public.trainees (
   weight numeric,
   CONSTRAINT trainees_pkey PRIMARY KEY (id)
 );
+CREATE TABLE public.trainee_feedbacks (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  trainee_id uuid NOT NULL,
+  message text NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  read_at timestamp with time zone,
+  CONSTRAINT trainee_feedbacks_pkey PRIMARY KEY (id),
+  CONSTRAINT trainee_feedbacks_trainee_id_fkey FOREIGN KEY (trainee_id) REFERENCES public.trainees(id)
+);
 CREATE TABLE public.workout_plan_days (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   plan_id uuid NOT NULL,


### PR DESCRIPTION
### Motivation
- Allow trainees to submit feedback from the app so messages can be captured in the database.
- Enable backend/admin users to read and manage trainee feedback.
- Record when feedback was created and when it was read to support basic tracking and workflows.

### Description
- Added a new `trainee_feedbacks` table to `db/database.sql`.
- The table includes `id` (UUID, default `gen_random_uuid()`), `trainee_id` (UUID, not null), `message` (text, not null), `created_at` (timestamp with time zone, default `now()`), and `read_at` (timestamp with time zone).
- Declares a primary key on `id` and a foreign key constraint `trainee_feedbacks_trainee_id_fkey` referencing `trainees(id)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ffed2afc8333b45091880cc0909c)