### PR TITLE
Add workout plan to navigation menu

### DIFF
--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -8,6 +8,7 @@ import '../l10n/app_localizations.dart';
 import 'exercise_guides.dart';
 import 'home_content.dart';
 import 'login.dart';
+import 'workout_plan_page.dart';
 
 class AuthGate extends StatelessWidget {
   const AuthGate({super.key});
@@ -79,7 +80,8 @@ class _HomePageState extends State<HomePage> {
       const HomeContent(),
       const ExerciseGuidesPage(),
       const ProfilePage(),
-      const TerminologiaPage()
+      const TerminologiaPage(),
+      const WorkoutPlanPage(),
     ];
 
     return Scaffold(
@@ -170,6 +172,17 @@ class _HomePageState extends State<HomePage> {
                 onTap: () {
                   setState(() {
                     selectedIndex = 3;
+                  });
+                  Navigator.pop(context);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.event_note),
+                title: Text(l10n.workoutPlanTitle),
+                selected: selectedIndex == 4,
+                onTap: () {
+                  setState(() {
+                    selectedIndex = 4;
                   });
                   Navigator.pop(context);
                 },


### PR DESCRIPTION
### Motivation
- Make the `WorkoutPlanPage` directly accessible from the app drawer so users can open their workout plan from main navigation.
- Keep navigation consistent by exposing the page in the same place as other top-level pages.

### Description
- Import `workout_plan_page.dart` and append `const WorkoutPlanPage()` to the `pages` list used by the main navigator.
- Add a `ListTile` with `Icons.event_note` and `title: l10n.workoutPlanTitle` to the drawer that sets `selectedIndex` to `4` when tapped.
- Changes are contained in `lib/pages/main.dart` and wire the drawer item to show the workout plan via the existing `pages[selectedIndex]` switcher.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696504d0745483339146ed8c8fd0a0c4)