### PR TITLE
Add highlighted coach tip card to Home screen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -135,6 +135,8 @@
   "homeWorkoutPlanSubtitle": "Review your assigned plan and upcoming sessions.",
   "homeTraineeFeedbackTitle": "Trainee feedback",
   "homeTraineeFeedbackSubtitle": "Share updates with your coach after sessions.",
+  "homeCoachTipTitle": "Coach tip",
+  "homeCoachTipPlaceholder": "Your coach's latest tip will appear here.",
   "workoutPlanTitle": "Workout plan",
   "traineeFeedbackTitle": "Trainee feedback",
   "traineeFeedbackSubtitle": "Tell your coach how you're feeling and how the plan is going.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -135,6 +135,8 @@
   "homeWorkoutPlanSubtitle": "Rivedi il piano assegnato e le prossime sessioni.",
   "homeTraineeFeedbackTitle": "Feedback atleta",
   "homeTraineeFeedbackSubtitle": "Condividi aggiornamenti con il tuo coach dopo le sessioni.",
+  "homeCoachTipTitle": "Consiglio del coach",
+  "homeCoachTipPlaceholder": "Qui troverai l'ultimo consiglio del tuo coach.",
   "workoutPlanTitle": "Piano di allenamento",
   "traineeFeedbackTitle": "Feedback atleta",
   "traineeFeedbackSubtitle": "Racconta al tuo coach come ti senti e come procede il piano.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -728,6 +728,18 @@ abstract class AppLocalizations {
   /// **'Condividi aggiornamenti con il tuo coach dopo le sessioni.'**
   String get homeTraineeFeedbackSubtitle;
 
+  /// No description provided for @homeCoachTipTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Consiglio del coach'**
+  String get homeCoachTipTitle;
+
+  /// No description provided for @homeCoachTipPlaceholder.
+  ///
+  /// In it, this message translates to:
+  /// **'Qui troverai l'ultimo consiglio del tuo coach.'**
+  String get homeCoachTipPlaceholder;
+
   /// No description provided for @workoutPlanTitle.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -388,6 +388,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Share updates with your coach after sessions.';
 
   @override
+  String get homeCoachTipTitle => 'Coach tip';
+
+  @override
+  String get homeCoachTipPlaceholder =>
+      'Your coach\'s latest tip will appear here.';
+
+  @override
   String get workoutPlanTitle => 'Workout plan';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -392,6 +392,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Condividi aggiornamenti con il tuo coach dopo le sessioni.';
 
   @override
+  String get homeCoachTipTitle => 'Consiglio del coach';
+
+  @override
+  String get homeCoachTipPlaceholder =>
+      'Qui troverai l\'ultimo consiglio del tuo coach.';
+
+  @override
   String get workoutPlanTitle => 'Piano di allenamento';
 
   @override

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -97,6 +97,8 @@ class _HomeContentState extends State<HomeContent> {
                 _TraineeFeedbackLinkSection(
                   onOpenFeedback: _openTraineeFeedback,
                 ),
+                const SizedBox(height: 16),
+                const _CoachTipSection(),
               ],
             );
           },
@@ -489,6 +491,51 @@ class _TraineeFeedbackLinkSection extends StatelessWidget {
         ),
         trailing: const Icon(Icons.arrow_forward_ios),
         onTap: onOpenFeedback,
+      ),
+    );
+  }
+}
+
+class _CoachTipSection extends StatelessWidget {
+  const _CoachTipSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+
+    return Card(
+      color: theme.colorScheme.secondaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.tips_and_updates,
+                  color: theme.colorScheme.onSecondaryContainer,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  l10n.homeCoachTipTitle,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                    color: theme.colorScheme.onSecondaryContainer,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.homeCoachTipPlaceholder,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSecondaryContainer,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Motivation

- Surface the coach's latest tip on the Home screen so trainees can quickly see guidance after sessions.
- Provide a visually distinct, highlighted area that fits the existing Material theming system.

### Description

- Added a new `_CoachTipSection` widget to `lib/pages/home_content.dart` and appended it to the Home `ListView` below the trainee feedback link using `Card` with `theme.colorScheme.secondaryContainer` for emphasis.
- Introduced two new localization keys `homeCoachTipTitle` and `homeCoachTipPlaceholder` in `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb` and wired them into `lib/l10n/app_localizations.dart` and the generated `app_localizations_en.dart` and `app_localizations_it.dart` files.
- The coach tip uses `AppLocalizations` for text and respects theme colors via `theme.colorScheme.onSecondaryContainer`.

### Testing

- No automated tests were executed for this change.
- Basic compile-time checks were not run in this environment (UI rendering and integration were not exercised).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696543df1a988333a9820e2e188e167f)