### PR TITLE
Improve schedule UX with recap, autocomplete, and jump navigation

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -234,9 +234,15 @@
                                     </label>
                                     <label class="small stack">
                                         Title
-                                        <input v-model="newDayTitle" placeholder="Workout title">
+                                        <input v-model="newDayTitle" placeholder="Workout title" list="day-title-options">
                                     </label>
                                 </div>
+                                <datalist id="day-title-options">
+                                    <option v-for="title in dayTitleSuggestions" :key="title" :value="title"></option>
+                                </datalist>
+                                <datalist id="day-code-options">
+                                    <option v-for="code in dayCodeOptions" :key="code" :value="code"></option>
+                                </datalist>
                                 <div class="stack">
                                     <span class="small">Quick day pick</span>
                                     <div class="day-code-picker">
@@ -256,11 +262,66 @@
                             </form>
                         </div>
 
+                        <div class="card schedule-summary">
+                            <div class="schedule-summary-header">
+                                <div class="stack">
+                                    <h3 style="margin:0">Schedule recap</h3>
+                                    <span class="muted small">Quick snapshot of what has been added.</span>
+                                </div>
+                                <button class="small" type="button" @click="loadDays" :disabled="addingDay || addingExercise">Refresh</button>
+                            </div>
+                            <div class="summary-grid">
+                                <div class="summary-item">
+                                    <span class="summary-label">Weeks</span>
+                                    <strong>{{ scheduleSummary.weeks }}</strong>
+                                </div>
+                                <div class="summary-item">
+                                    <span class="summary-label">Days</span>
+                                    <strong>{{ scheduleSummary.days }}</strong>
+                                </div>
+                                <div class="summary-item">
+                                    <span class="summary-label">Exercises</span>
+                                    <strong>{{ scheduleSummary.exercises }}</strong>
+                                </div>
+                                <div class="summary-item">
+                                    <span class="summary-label">Days w/ exercises</span>
+                                    <strong>{{ scheduleSummary.daysWithExercises }}</strong>
+                                </div>
+                            </div>
+                            <div v-if="scheduleSummary.highlights.length" class="summary-highlights">
+                                <span class="summary-label">Highlights</span>
+                                <div class="summary-chips">
+                                    <span class="chip" v-for="item in scheduleSummary.highlights" :key="item.id">
+                                        {{ item.label }} • {{ item.exercises }} ex
+                                    </span>
+                                </div>
+                            </div>
+                            <div v-else class="muted small">Add a day to start building the recap.</div>
+                        </div>
+
+                        <div class="card schedule-nav">
+                            <h3 style="margin-top:0">Jump to day</h3>
+                            <div class="muted small">Move fast between days and auto-expand the one you need.</div>
+                            <div v-if="dayNavigation.length" class="jump-list">
+                                <button
+                                    v-for="item in dayNavigation"
+                                    :key="item.id"
+                                    class="small jump-button"
+                                    type="button"
+                                    @click="jumpToDay(item)"
+                                >
+                                    <span>{{ item.label }}</span>
+                                    <span class="muted">{{ item.exercises }} ex</span>
+                                </button>
+                            </div>
+                            <div v-else class="muted small">No days yet.</div>
+                        </div>
+
                         <div class="card">
                             <h3 style="margin-top:0">Days & Exercises</h3>
                             <div v-if="days.length===0">No days yet.</div>
-                            <div v-else class="day-list scroll-area">
-                                <div v-for="d in days" :key="d.id" class="day-card">
+                            <div v-else class="day-list">
+                                <div v-for="d in days" :key="d.id" class="day-card" :id="'day-'+d.id">
                                     <div class="day-header">
                                         <div class="stack">
                                             <div class="meta">
@@ -278,21 +339,21 @@
                                         </div>
                                     </div>
 
-                                    <div class="day-body" v-show="isDayOpen(d)">
-                                        <div class="grid" style="grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:8px">
-                                            <label class="small stack">
-                                                Week
-                                                <input type="number" min="1" v-model.number="dayEdits[d.id].week" />
-                                            </label>
-                                            <label class="small stack">
-                                                Day code
-                                                <input v-model="dayEdits[d.id].day_code" />
-                                            </label>
-                                            <label class="small stack">
-                                                Title
-                                                <input v-model="dayEdits[d.id].title" />
-                                            </label>
-                                        </div>
+                                        <div class="day-body" v-show="isDayOpen(d)">
+                                            <div class="grid" style="grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:8px">
+                                                <label class="small stack">
+                                                    Week
+                                                    <input type="number" min="1" v-model.number="dayEdits[d.id].week" />
+                                                </label>
+                                                <label class="small stack">
+                                                    Day code
+                                                    <input v-model="dayEdits[d.id].day_code" list="day-code-options" />
+                                                </label>
+                                                <label class="small stack">
+                                                    Title
+                                                    <input v-model="dayEdits[d.id].title" list="day-title-options" />
+                                                </label>
+                                            </div>
                                         <label class="small stack">
                                             Notes
                                             <textarea v-model="dayEdits[d.id].notes" placeholder="Optional notes"></textarea>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -67,6 +67,15 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .day-code-picker button{border-radius:999px;padding:6px 12px;border:1px solid var(--line);background:transparent;color:var(--ink)}
 .day-code-picker button.active{background:var(--accent);color:#04120c;border-color:transparent}
 .helper-text{font-size:12px;color:var(--muted)}
+.schedule-summary-header{display:flex;justify-content:space-between;align-items:flex-start;gap:10px;flex-wrap:wrap}
+.summary-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:10px;margin-top:10px}
+.summary-item{background:#0f1118;border:1px solid var(--line);border-radius:12px;padding:10px;display:flex;flex-direction:column;gap:4px}
+.summary-label{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
+.summary-highlights{margin-top:12px;display:flex;flex-direction:column;gap:6px}
+.summary-chips{display:flex;flex-wrap:wrap;gap:6px}
+.jump-list{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}
+.jump-button{display:flex;align-items:center;justify-content:space-between;gap:10px;border-radius:999px;padding:6px 12px;border:1px solid var(--line);background:#0f1118;color:var(--ink)}
+.jump-button:hover{border-color:var(--accent);color:var(--accent)}
 .history-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px;margin-top:12px}
 .history-card{display:flex;flex-direction:column;gap:10px}
 .history-header{display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:8px;margin-bottom:8px}


### PR DESCRIPTION
### Motivation
- Make the admin schedule editor easier to scan and use without relying on an internal scrolling list. 
- Provide quick navigation between days and a concise recap so admins can understand what has been added at a glance. 
- Add simple autocompletion for day titles and day codes to speed up entry and reduce typos.

### Description
- Reworked the schedule area in `backend/admin/index.html` to remove the scrollable days panel and add a `Schedule recap` card, a `Jump to day` navigation card, and `datalist`-backed autocompletion for day title and day code inputs. 
- Added computed properties in `backend/admin/app.js`: `dayTitleSuggestions`, `scheduleSummary`, and `dayNavigation` to power suggestions, recap metrics, highlights, and an ordered jump list. 
- Implemented `jumpToDay(item)` in `backend/admin/app.js` which expands the target day and scrolls it into view, and exposed the new properties and method to the template. 
- Added styling for the recap and navigation UI in `backend/admin/styles.css` and adjusted markup to attach `id="day-<id>"` to day cards.

### Testing
- Served the admin folder with `python -m http.server 8000` and ran a Playwright script to load `http://127.0.0.1:8000/` and capture a screenshot of the page, which completed successfully. 
- No unit or integration test suite was executed for these changes. 
- Manual UI verification was exercised via the browser screenshot run; no automated regressions failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a5e0115288333b59d8a5b0566c869)