### PR TITLE
Exercise list: remove resets, use icon actions, and force single-line layout

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -50,7 +50,6 @@
                         </label>
                         <div style="display:flex;gap:8px;flex-wrap:wrap">
                             <button class="btn small" type="submit" :disabled="savingExercise">Add exercise</button>
-                            <button class="small" type="button" @click="resetExerciseForm" :disabled="savingExercise">Reset</button>
                         </div>
                         <div v-if="savingExercise" class="muted small">Saving exercise…</div>
                     </form>
@@ -65,9 +64,8 @@
                                 <span class="pill">#{{ ex.id.slice(0,4) }}</span>
                             </div>
                             <div class="exercise-actions">
-                                <button class="btn small" @click="updateExercise(ex)" :disabled="savingExercise">Save</button>
-                                <button class="small" type="button" @click="resetExerciseEdit(ex)" :disabled="savingExercise">Reset</button>
-                                <button class="small" type="button" @click="deleteExercise(ex)" :disabled="savingExercise" style="color:#fca5a5;border-color:#3b0f10;background:#1a0b0c">Delete</button>
+                                <button class="btn small icon-button" @click="updateExercise(ex)" :disabled="savingExercise" title="Save" aria-label="Save">💾</button>
+                                <button class="small icon-button danger" type="button" @click="deleteExercise(ex)" :disabled="savingExercise" title="Delete" aria-label="Delete">🗑️</button>
                             </div>
                         </div>
                     </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -43,16 +43,18 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .day-body{display:flex;flex-direction:column;gap:10px;margin-top:10px}
 .inline-actions{display:flex;gap:6px;flex-wrap:wrap;align-items:center}
 .exercise-list{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:8px}
-.exercise-item{border:1px solid var(--line);border-radius:12px;background:#0f1118;padding:10px;display:flex;flex-direction:column;gap:6px}
-.exercise-head{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.exercise-item{border:1px solid var(--line);border-radius:12px;background:#0f1118;padding:10px;display:flex;align-items:center;gap:8px}
+.exercise-head{display:flex;gap:8px;align-items:center;flex-wrap:nowrap;flex:1}
 .exercise-head input{flex:1 1 160px;min-width:0}
-.exercise-actions{display:flex;gap:6px;flex-wrap:wrap;justify-content:flex-end}
+.exercise-actions{display:flex;gap:6px;flex-wrap:nowrap;justify-content:flex-end}
+.exercise-actions .icon-button{min-width:auto;padding:6px 8px}
+.exercise-actions .icon-button.danger{color:#fca5a5;border-color:#3b0f10;background:#1a0b0c}
 .exercise-panel h2{margin:12px 0 6px}
 .exercise-panel .row{gap:12px}
 .exercise-panel form{gap:6px}
 .exercise-panel input{padding:6px 8px}
 .exercise-panel .exercise-list{grid-template-columns:repeat(auto-fill,minmax(220px,1fr))}
-.exercise-panel .exercise-item{padding:8px;gap:4px}
+.exercise-panel .exercise-item{padding:8px;gap:6px}
 .exercise-panel .exercise-head{gap:6px}
 .exercise-panel .exercise-actions{gap:4px;justify-content:flex-start}
 .exercise-panel .btn.small,


### PR DESCRIPTION
### Motivation
- Clean up the Exercises admin UI by removing duplicate "Reset" controls and replacing verbose Save/Delete buttons with compact icons to reduce visual clutter.
- Ensure each exercise row stays on a single line for denser, easier-to-scan lists.

### Description
- Removed the `Reset` button from the add-exercise form in `backend/admin/index.html`.
- Replaced the text `Save` and `Delete` buttons for each exercise with icon-only buttons (disk and trash emoji) and added `title`/`aria-label` attributes for accessibility in `backend/admin/index.html`.
- Updated `backend/admin/styles.css` to render exercise items in a single row by changing `.exercise-item`/`.exercise-head`/`.exercise-actions` flex rules, and added `.icon-button` and `.icon-button.danger` styling to support the new icon actions.

### Testing
- Started a local static server with `python -m http.server 8000` and loaded the admin page, which succeeded.
- Ran a Playwright script that navigated to `http://127.0.0.1:8000/index.html` and captured a screenshot (`artifacts/exercises-admin.png`), which succeeded.
- No unit or integration test suite was run for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a653784c08333840735d1a494b64c)