### PR TITLE
Add payment status toggle for trainees in admin portal

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -102,6 +102,21 @@
                                 </div>
                             </div>
                             <div class="muted small" v-else>No progress logged yet.</div>
+                            <div class="payment-row">
+                                <span class="pill" :class="u.paid ? 'paid' : 'overdue'">
+                                    {{ u.paid ? 'Payments on time' : 'Payment overdue' }}
+                                </span>
+                                <label class="payment-toggle small">
+                                    <input
+                                        type="checkbox"
+                                        :checked="u.paid"
+                                        :disabled="paymentSaving[u.id]"
+                                        @change="togglePayment(u, $event)"
+                                    />
+                                    <span>On time</span>
+                                </label>
+                            </div>
+                            <div class="muted small" v-if="paymentSaving[u.id]">Updating payment status…</div>
                             <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
                                 <button class="btn" @click="selectUser(u); activeSection='schedule'">Open schedule</button>
                                 <button class="btn" @click="loadDays(u); activeSection='schedule'">Load days</button>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -61,6 +61,11 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .progress-bar{flex:1;height:6px;border-radius:999px;background:#11131a;overflow:hidden;border:1px solid var(--line)}
 .progress-bar span{display:block;height:100%;background:var(--accent)}
 .progress-meta{display:flex;gap:6px;align-items:center}
+.payment-row{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-top:10px;flex-wrap:wrap}
+.payment-toggle{display:flex;align-items:center;gap:6px}
+.payment-toggle input{margin:0}
+.pill.paid{border-color:#1c2b23;background:#0e1a14;color:#b7f5d8}
+.pill.overdue{border-color:#3b0f10;background:#1a0b0c;color:#fca5a5}
 .day-form-card{display:flex;flex-direction:column;gap:10px}
 .day-form-header{display:flex;justify-content:space-between;gap:8px;align-items:center;flex-wrap:wrap}
 .day-code-picker{display:flex;gap:6px;flex-wrap:wrap}


### PR DESCRIPTION
### Motivation
- Provide admins a quick way to view and update whether a trainee is up-to-date with payments from the Trainees list.

### Description
- Added a payment status row and checkbox toggle to each trainee card in `backend/admin/index.html` and a saving indicator while updates are in-flight.
- Loaded the `paid` flag in `loadUsers()` by selecting `id, name, paid`, added a `paymentSaving` `ref` and implemented `togglePayment(u, event)` in `backend/admin/app.js` with optimistic UI updates, Supabase `.update()` persistence, and rollback on error.
- Exported the `paymentSaving` state and `togglePayment` handler from the Vue `setup()` return object and added CSS rules in `backend/admin/styles.css` for `.payment-row`, `.payment-toggle`, and `.pill.paid/.pill.overdue` states.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script to open `http://127.0.0.1:8000/index.html` and capture a screenshot, which completed successfully and produced `artifacts/trainee-payment.png`.
- No unit tests were added or run; the UI smoke-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a67108cb88333b2c7dd31fe8769e1)