### PR TITLE
Fix watcher initialization in admin template editor

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -533,13 +533,6 @@
         localStorage.setItem('adminLocale', nextLocale);
         updateDocumentLanguage();
       });
-      watch(templateDayCount, (nextCount) => {
-        programTemplateDays.value = buildTemplateDays(
-          nextCount,
-          templateSlotsPerDay,
-          programTemplateDays.value,
-        );
-      });
       const session = ref(null);
       const user = ref(null);
       const email = ref('');
@@ -591,6 +584,13 @@
       const programTemplateDays = ref(
         buildTemplateDays(templateDayCount.value, templateSlotsPerDay, []),
       );
+      watch(templateDayCount, (nextCount) => {
+        programTemplateDays.value = buildTemplateDays(
+          nextCount,
+          templateSlotsPerDay,
+          programTemplateDays.value,
+        );
+      });
 
       function buildTemplateDays(count, slots, existing) {
         const list = [];


### PR DESCRIPTION
### Motivation
- Fix a runtime `ReferenceError: Cannot access 'templateDayCount' before initialization` caused by registering the `watch(templateDayCount, ...)` before the related refs were declared.

### Description
- Move the `watch(templateDayCount, ...)` call to after the `const templateDayCount = ref(3)` and `programTemplateDays` initialization so the watcher no longer references uninitialized variables.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fae4cb65c8333acb6446efb5fca30)