### PR TITLE
Block interactions when workout plan is expired

### DIFF
--- a/lib/components/plan_expired_gate.dart
+++ b/lib/components/plan_expired_gate.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../l10n/app_localizations.dart';
+
+class PlanExpiredGate extends StatefulWidget {
+  final Widget child;
+  final bool useOverlay;
+
+  const PlanExpiredGate({
+    super.key,
+    required this.child,
+    this.useOverlay = false,
+  });
+
+  @override
+  State<PlanExpiredGate> createState() => _PlanExpiredGateState();
+}
+
+class _PlanExpiredGateState extends State<PlanExpiredGate> {
+  late Future<bool> _expiredFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _expiredFuture = _fetchLatestPlanExpired();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<bool>(
+      future: _expiredFuture,
+      builder: (context, snapshot) {
+        final isWaiting = snapshot.connectionState == ConnectionState.waiting;
+        final isExpired = snapshot.data == true;
+        if (widget.useOverlay) {
+          return Stack(
+            children: [
+              AbsorbPointer(
+                absorbing: isWaiting || isExpired,
+                child: widget.child,
+              ),
+              if (isWaiting)
+                const Positioned.fill(
+                  child: ColoredBox(
+                    color: Color(0x88000000),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                ),
+              if (!isWaiting && isExpired)
+                Positioned.fill(
+                  child: _ExpiredPlanCover(
+                    title: AppLocalizations.of(context)!.profilePlanExpired,
+                    description: AppLocalizations.of(context)!.homeEmptyDescription,
+                  ),
+                ),
+            ],
+          );
+        }
+
+        if (isWaiting) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (isExpired) {
+          return _ExpiredPlanScreen(
+            title: AppLocalizations.of(context)!.profilePlanExpired,
+            description: AppLocalizations.of(context)!.homeEmptyDescription,
+          );
+        }
+
+        return widget.child;
+      },
+    );
+  }
+
+  Future<bool> _fetchLatestPlanExpired() async {
+    final client = Supabase.instance.client;
+    final userId = client.auth.currentUser?.id;
+    if (userId == null) return false;
+
+    final response = await client
+        .from('workout_plans')
+        .select('status, starts_on, created_at')
+        .eq('trainee_id', userId)
+        .order('starts_on', ascending: false)
+        .order('created_at', ascending: false)
+        .limit(1);
+
+    final data = (response as List<dynamic>? ?? []).cast<Map<String, dynamic>>();
+    if (data.isEmpty) return false;
+
+    final status = (data.first['status'] as String? ?? '').trim().toLowerCase();
+    return status == 'expired';
+  }
+}
+
+class _ExpiredPlanScreen extends StatelessWidget {
+  final String title;
+  final String description;
+
+  const _ExpiredPlanScreen({
+    required this.title,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: _ExpiredPlanContent(
+        title: title,
+        description: description,
+      ),
+    );
+  }
+}
+
+class _ExpiredPlanCover extends StatelessWidget {
+  final String title;
+  final String description;
+
+  const _ExpiredPlanCover({
+    required this.title,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ColoredBox(
+      color: theme.colorScheme.surface.withValues(alpha: 0.9),
+      child: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 360),
+            child: Card(
+              margin: const EdgeInsets.all(24),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: _ExpiredPlanContent(
+                  title: title,
+                  description: description,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ExpiredPlanContent extends StatelessWidget {
+  final String title;
+  final String description;
+
+  const _ExpiredPlanContent({
+    required this.title,
+    required this.description,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          Icons.assignment_late_outlined,
+          size: 64,
+          color: theme.colorScheme.error,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          description,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:calisync/pages/profile.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../components/plan_expired_gate.dart';
 import '../l10n/app_localizations.dart';
 import 'exercise_guides.dart';
 import 'home_content.dart';
@@ -84,7 +85,7 @@ class _HomePageState extends State<HomePage> {
       const WorkoutPlanPage(),
     ];
 
-    return Scaffold(
+    final scaffold = Scaffold(
       extendBody: true,
       appBar: AppBar(
         centerTitle: false,
@@ -243,6 +244,11 @@ class _HomePageState extends State<HomePage> {
           ),
         ),
       ),
+    );
+
+    return PlanExpiredGate(
+      useOverlay: true,
+      child: scaffold,
     );
   }
 }

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -2,6 +2,7 @@ import 'package:calisync/model/workout_day.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../components/plan_expired_gate.dart';
 import '../l10n/app_localizations.dart';
 
 class Training extends StatefulWidget {
@@ -59,69 +60,72 @@ class _TrainingState extends State<Training> {
           }
         });
       },
-      child: Scaffold(
-        appBar: AppBar(title: Text(widget.day.formattedTitle(l10n))),
-        body: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            if ((widget.day.notes ?? '').trim().isNotEmpty)
-              Card(
-                margin: const EdgeInsets.symmetric(vertical: 8),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                elevation: 3,
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l10n.generalNotes,
-                        style: Theme.of(context)
-                            .textTheme
-                            .titleMedium
-                            ?.copyWith(fontWeight: FontWeight.bold),
-                      ),
-                      const SizedBox(height: 8),
-                      Text(widget.day.notes!.trim()),
-                    ],
+      child: PlanExpiredGate(
+        child: Scaffold(
+          appBar: AppBar(title: Text(widget.day.formattedTitle(l10n))),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if ((widget.day.notes ?? '').trim().isNotEmpty)
+                Card(
+                  margin: const EdgeInsets.symmetric(vertical: 8),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  elevation: 3,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n.generalNotes,
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleMedium
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(widget.day.notes!.trim()),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            for (int index = 0; index < _exercises.length; index++)
-              _ExerciseCard(
-                exercise: _exercises[index],
-                traineeNotesController: _personalNoteControllers.putIfAbsent(
-                  _controllerKey(_exercises[index], index),
-                  () =>
-                      TextEditingController(text: _exercises[index].traineeNotes ?? ''),
-                ),
-                saving: _savingNotes.contains(_exercises[index].id),
-                updatingCompletion: _togglingExerciseCompletion
-                    .contains(_exercises[index].id),
-                onSaveNotes: () => _saveNotes(index),
-                onToggleCompletion: () => _toggleExerciseCompletion(index),
-              ),
-            const SizedBox(height: 24),
-            FilledButton.icon(
-              onPressed: _updatingCompletion ? null : _toggleCompletion,
-              icon: _updatingCompletion
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : Icon(
-                      _isCompleted ? Icons.undo : Icons.check_circle_outline,
+              for (int index = 0; index < _exercises.length; index++)
+                _ExerciseCard(
+                  exercise: _exercises[index],
+                  traineeNotesController: _personalNoteControllers.putIfAbsent(
+                    _controllerKey(_exercises[index], index),
+                    () => TextEditingController(
+                      text: _exercises[index].traineeNotes ?? '',
                     ),
-              label: Text(
-                _isCompleted
-                    ? l10n.trainingMarkIncomplete
-                    : l10n.trainingMarkComplete,
+                  ),
+                  saving: _savingNotes.contains(_exercises[index].id),
+                  updatingCompletion: _togglingExerciseCompletion
+                      .contains(_exercises[index].id),
+                  onSaveNotes: () => _saveNotes(index),
+                  onToggleCompletion: () => _toggleExerciseCompletion(index),
+                ),
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                onPressed: _updatingCompletion ? null : _toggleCompletion,
+                icon: _updatingCompletion
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(
+                        _isCompleted ? Icons.undo : Icons.check_circle_outline,
+                      ),
+                label: Text(
+                  _isCompleted
+                      ? l10n.trainingMarkIncomplete
+                      : l10n.trainingMarkComplete,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### Motivation
- Prevent users from performing actions in the app when their latest workout plan is expired by detecting the plan status and blocking interaction. 
- Provide a reusable UI gate that can either show a full screen message or an overlay so the same logic can be applied to multiple screens.

### Description
- Add a new `PlanExpiredGate` component in `lib/components/plan_expired_gate.dart` that fetches the latest plan for the current user and returns a boolean expired state, then either blocks interaction with an overlay or replaces the screen with an expired message. 
- Wrap the main app shell (`HomePage` scaffold) with `PlanExpiredGate(useOverlay: true)` so the top-level navigation/content is disabled and covered when expired. 
- Wrap the `Training` screen with `PlanExpiredGate` to block training interactions when the plan is expired. 
- Adjust imports and return the scaffold from `HomePage.build` to allow embedding in the `PlanExpiredGate` wrapper.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb61a438483338679cbe59a6c56a6)