### PR TITLE
Add trainer/admin roles, trainer assignments, and monthly payment tracking

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -24,7 +24,7 @@
         <div class="toolbar">
             <div style="display:flex;align-items:center;gap:10px">
                 <div class="pill">{{ user?.email }}</div>
-                <span class="pill">{{ t('toolbar.admin') }}</span>
+                <span class="pill">{{ roleLabel }}</span>
             </div>
             <div class="pill-menu">
                 <button :class="{active: activeSection==='dashboard'}" @click="activeSection='dashboard'">{{ t('sections.dashboard') }}</button>
@@ -152,6 +152,47 @@
                                 </div>
                             </div>
                             <div class="muted small" v-else>{{ t('status.noProgress') }}</div>
+                            <div class="trainer-row">
+                                <span class="muted small">{{ t('trainers.assigned') }}</span>
+                                <div class="trainer-tags">
+                                    <span v-if="!u.trainers || u.trainers.length===0" class="muted small">
+                                        {{ t('trainers.none') }}
+                                    </span>
+                                    <span v-else v-for="trainer in u.trainers" :key="trainer.id" class="pill trainer-pill">
+                                        {{ trainer.name }}
+                                        <button
+                                            v-if="canAssignTrainers"
+                                            class="icon-button"
+                                            type="button"
+                                            @click="removeTrainerAssignment(u, trainer)"
+                                            :aria-label="t('actions.delete')"
+                                        >
+                                            ×
+                                        </button>
+                                    </span>
+                                </div>
+                            </div>
+                            <div v-if="canAssignTrainers" class="trainer-assign">
+                                <select v-model="trainerSelections[u.id]">
+                                    <option value="">{{ t('trainers.select') }}</option>
+                                    <option
+                                        v-for="trainer in trainers"
+                                        :key="trainer.id"
+                                        :value="trainer.id"
+                                        :disabled="u.trainerIds && u.trainerIds.includes(trainer.id)"
+                                    >
+                                        {{ trainer.name }}
+                                    </option>
+                                </select>
+                                <button
+                                    class="small"
+                                    type="button"
+                                    :disabled="trainerAssignmentSaving[u.id] || !trainerSelections[u.id]"
+                                    @click="assignTrainerToTrainee(u)"
+                                >
+                                    {{ t('actions.assignTrainer') }}
+                                </button>
+                            </div>
                             <div class="payment-row">
                                 <span class="pill" :class="u.paid ? 'paid' : 'overdue'">
                                     {{ u.paid ? t('payment.onTime') : t('payment.overdue') }}
@@ -167,6 +208,7 @@
                                 </label>
                             </div>
                             <div class="muted small" v-if="paymentSaving[u.id]">{{ t('status.updatingPayment') }}</div>
+                            <div class="muted small" v-if="trainerAssignmentSaving[u.id]">{{ t('status.updatingTrainer') }}</div>
                             <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
                                 <button class="btn" @click="selectUser(u); activeSection='program'">{{ t('actions.openSchedule') }}</button>
                                 <button class="btn" @click="loadDays(u); activeSection='program'">{{ t('actions.loadDays') }}</button>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -87,6 +87,12 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .payment-toggle input{margin:0}
 .pill.paid{border-color:#1c2b23;background:#0e1a14;color:#b7f5d8}
 .pill.overdue{border-color:#3b0f10;background:#1a0b0c;color:#fca5a5}
+.trainer-row{display:flex;flex-direction:column;gap:6px;margin-top:10px}
+.trainer-tags{display:flex;flex-wrap:wrap;gap:6px;align-items:center}
+.trainer-pill{display:inline-flex;align-items:center;gap:6px}
+.icon-button{border:1px solid var(--line);background:#0f1118;color:var(--muted);border-radius:999px;padding:2px 6px;line-height:1}
+.icon-button:hover{border-color:var(--accent);color:var(--accent)}
+.trainer-assign{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-top:6px}
 .day-form-card{display:flex;flex-direction:column;gap:10px}
 .day-form-header{display:flex;justify-content:space-between;gap:8px;align-items:center;flex-wrap:wrap}
 .day-code-picker{display:flex;gap:6px;flex-wrap:wrap}

--- a/db/database.sql
+++ b/db/database.sql
@@ -47,6 +47,45 @@ CREATE TABLE public.trainees (
   weight numeric,
   CONSTRAINT trainees_pkey PRIMARY KEY (id)
 );
+CREATE TABLE public.trainers (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  name text NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT trainers_pkey PRIMARY KEY (id),
+  CONSTRAINT trainers_user_id_key UNIQUE (user_id)
+);
+CREATE TABLE public.admins (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  name text,
+  can_assign_trainers boolean NOT NULL DEFAULT false,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT admins_pkey PRIMARY KEY (id),
+  CONSTRAINT admins_user_id_key UNIQUE (user_id)
+);
+CREATE TABLE public.trainee_trainers (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  trainee_id uuid NOT NULL,
+  trainer_id uuid NOT NULL,
+  assigned_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT trainee_trainers_pkey PRIMARY KEY (id),
+  CONSTRAINT trainee_trainers_trainee_id_fkey FOREIGN KEY (trainee_id) REFERENCES public.trainees(id),
+  CONSTRAINT trainee_trainers_trainer_id_fkey FOREIGN KEY (trainer_id) REFERENCES public.trainers(id),
+  CONSTRAINT trainee_trainers_unique UNIQUE (trainee_id, trainer_id)
+);
+CREATE TABLE public.trainee_monthly_payments (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  trainee_id uuid NOT NULL,
+  month_start date NOT NULL,
+  paid boolean NOT NULL DEFAULT false,
+  paid_at timestamp with time zone,
+  amount numeric,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT trainee_monthly_payments_pkey PRIMARY KEY (id),
+  CONSTRAINT trainee_monthly_payments_trainee_id_fkey FOREIGN KEY (trainee_id) REFERENCES public.trainees(id),
+  CONSTRAINT trainee_monthly_payments_unique UNIQUE (trainee_id, month_start)
+);
 CREATE TABLE public.trainee_feedbacks (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   trainee_id uuid NOT NULL,


### PR DESCRIPTION
### Motivation

- Introduce trainer and admin concepts so staff can be represented in the database and admins can manage trainer–trainee assignments. 
- Allow some admins to assign trainers to trainees from the admin portal while limiting trainer users to only see their assigned trainees. 
- Track monthly payment status per trainee for better payment auditing.

### Description

- Schema: added `trainers`, `admins`, `trainee_trainers`, and `trainee_monthly_payments` tables to `db/database.sql` with appropriate keys and uniqueness constraints. 
- Backend/admin UI/logic: added role detection (`loadAccess`), `loadTrainers`, `assignTrainerToTrainee`, `removeTrainerAssignment`, `roleLabel`, and `canAssignTrainers` computed flag in `backend/admin/app.js`. 
- Scoped data for trainers: `loadUsers`, `loadTraineeProgress`, and `loadDashboardNotes` now restrict results when the signed-in user is a trainer (non-admin). 
- Payment tracking: `togglePayment` now upserts a record into `trainee_monthly_payments` for the current month when a trainee payment flag is updated. 
- UI updates: added trainer assignment UI, role badge in the toolbar, translations and new status strings, and CSS rules in `backend/admin/index.html` and `backend/admin/styles.css` to display trainer tags and assignment controls.

### Testing

- Performed a local smoke test by serving `backend/admin` with a simple HTTP server and capturing a Playwright screenshot of the login page, which completed successfully. 
- No automated unit/integration test suite was run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970ada955388333be65a0504644e3b4)