### PR TITLE
Add payments dashboard to admin portal

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -29,6 +29,7 @@
             <div class="pill-menu">
                 <button :class="{active: activeSection==='dashboard'}" @click="activeSection='dashboard'">{{ t('sections.dashboard') }}</button>
                 <button :class="{active: activeSection==='trainees'}" @click="activeSection='trainees'">{{ t('sections.trainees') }}</button>
+                <button :class="{active: activeSection==='payments'}" @click="activeSection='payments'">{{ t('sections.payments') }}</button>
                 <button :class="{active: activeSection==='program'}" @click="activeSection='program'">{{ t('sections.program') }}</button>
             </div>
             <div class="toolbar-secondary">
@@ -90,38 +91,6 @@
                     </div>
                 </div>
 
-                <div class="card">
-                    <div class="dashboard-card-header">
-                        <div class="stack">
-                            <h2 style="margin:0">{{ t('dashboard.paymentsTitle') }}</h2>
-                            <span class="muted small">{{ t('dashboard.paymentsSubtitle') }}</span>
-                        </div>
-                    </div>
-                    <div class="summary-grid">
-                        <div class="summary-item">
-                            <span class="summary-label">{{ t('dashboard.paymentsTotal') }}</span>
-                            <strong>{{ paymentSummary.total }}</strong>
-                        </div>
-                        <div class="summary-item">
-                            <span class="summary-label">{{ t('dashboard.paymentsOnTime') }}</span>
-                            <strong>{{ paymentSummary.paid }}</strong>
-                        </div>
-                        <div class="summary-item">
-                            <span class="summary-label">{{ t('dashboard.paymentsOverdue') }}</span>
-                            <strong>{{ paymentSummary.overdue }}</strong>
-                        </div>
-                    </div>
-                    <div v-if="overdueUsers.length===0" class="muted small" style="margin-top:10px">{{ t('dashboard.noOverdue') }}</div>
-                    <div v-else class="list" style="margin-top:10px">
-                        <div v-for="u in overdueUsers" :key="u.id" class="payment-alert">
-                            <div class="stack">
-                                <strong>{{ u.displayName || shortId(u.id) }}</strong>
-                                <span class="muted small mono">{{ u.id }}</span>
-                            </div>
-                            <button class="small" type="button" @click="selectUser(u); activeSection='program'">{{ t('dashboard.openProgram') }}</button>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
 
@@ -214,6 +183,105 @@
                                 <button class="btn" @click="loadDays(u); activeSection='program'">{{ t('actions.loadDays') }}</button>
                                 <button class="btn" @click="loadPlans(u); activeSection='program'">{{ t('actions.loadPlans') }}</button>
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="section-panel payments-panel" :class="{active: activeSection==='payments'}">
+            <div class="dashboard-grid payments-grid">
+                <div class="card">
+                    <div class="dashboard-card-header">
+                        <div class="stack">
+                            <h2 style="margin:0">{{ t('payments.overviewTitle') }}</h2>
+                            <span class="muted small">{{ t('payments.overviewSubtitle') }}</span>
+                        </div>
+                        <span class="pill">{{ t('labels.shownCount', { count: paymentUsers.length }) }}</span>
+                    </div>
+                    <div class="summary-grid">
+                        <div class="summary-item">
+                            <span class="summary-label">{{ t('payments.totalLabel') }}</span>
+                            <strong>{{ paymentSummary.total }}</strong>
+                        </div>
+                        <div class="summary-item">
+                            <span class="summary-label">{{ t('payments.paidLabel') }}</span>
+                            <strong>{{ paymentSummary.paid }}</strong>
+                        </div>
+                        <div class="summary-item">
+                            <span class="summary-label">{{ t('payments.overdueLabel') }}</span>
+                            <strong>{{ paymentSummary.overdue }}</strong>
+                        </div>
+                    </div>
+                    <div class="filter-row">
+                        <button
+                            v-for="filter in paymentFilterOptions"
+                            :key="filter.value"
+                            type="button"
+                            :class="{active: paymentFilter===filter.value}"
+                            @click="paymentFilter=filter.value"
+                        >
+                            {{ t(filter.labelKey) }}
+                        </button>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="dashboard-card-header">
+                        <div class="stack">
+                            <h2 style="margin:0">{{ t('payments.overdueTitle') }}</h2>
+                            <span class="muted small">{{ t('payments.overdueSubtitle') }}</span>
+                        </div>
+                    </div>
+                    <div v-if="overdueUsers.length===0" class="muted small">{{ t('payments.noOverdue') }}</div>
+                    <div v-else class="list">
+                        <div v-for="u in overdueUsers" :key="u.id" class="payment-alert">
+                            <div class="stack">
+                                <strong>{{ u.displayName || shortId(u.id) }}</strong>
+                                <span class="muted small mono">{{ u.id }}</span>
+                            </div>
+                            <div class="inline-actions">
+                                <button class="small" type="button" :disabled="paymentSaving[u.id]" @click="markPaymentPaid(u)">
+                                    {{ t('payments.markPaid') }}
+                                </button>
+                                <button class="small" type="button" @click="selectUser(u); activeSection='program'">{{ t('dashboard.openProgram') }}</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card payments-manage-card">
+                    <div class="dashboard-card-header">
+                        <div class="stack">
+                            <h2 style="margin:0">{{ t('payments.manageTitle') }}</h2>
+                            <span class="muted small">{{ t('payments.manageSubtitle') }}</span>
+                        </div>
+                    </div>
+                    <div v-if="paymentUsers.length===0" class="muted small">{{ t('payments.noMatches') }}</div>
+                    <div v-else class="list scroll-area payments-list">
+                        <div v-for="u in paymentUsers" :key="u.id" class="card payment-card">
+                            <div class="payment-card-header">
+                                <div class="stack">
+                                    <strong>{{ u.displayName || shortId(u.id) }}</strong>
+                                    <span class="muted small mono">{{ u.id }}</span>
+                                </div>
+                                <span class="pill" :class="u.paid ? 'paid' : 'overdue'">
+                                    {{ u.paid ? t('payment.onTime') : t('payment.overdue') }}
+                                </span>
+                            </div>
+                            <div class="payment-actions">
+                                <label class="payment-toggle small">
+                                    <input
+                                        type="checkbox"
+                                        :checked="u.paid"
+                                        :disabled="paymentSaving[u.id]"
+                                        @change="togglePayment(u, $event)"
+                                    />
+                                    <span>{{ t('payment.toggle') }}</span>
+                                </label>
+                                <button class="small" type="button" @click="selectUser(u); activeSection='program'">{{ t('actions.openSchedule') }}</button>
+                            </div>
+                            <div class="muted small" v-if="paymentSaving[u.id]">{{ t('status.updatingPayment') }}</div>
                         </div>
                     </div>
                 </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -43,6 +43,13 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .notice-list{display:flex;flex-direction:column;gap:10px;margin-top:12px}
 .notice-item{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;border:1px solid var(--line);border-radius:12px;padding:10px;background:#0f1118}
 .payment-alert{display:flex;align-items:center;justify-content:space-between;gap:12px;border:1px solid var(--line);border-radius:12px;padding:10px;background:#0f1118}
+.filter-row{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}
+.filter-row button{border-radius:999px;padding:6px 12px;border:1px solid var(--line);background:#0f1118;color:var(--ink)}
+.filter-row button.active{background:var(--accent);color:#04120c;border-color:transparent}
+.payments-list{max-height:520px}
+.payment-card{padding:12px}
+.payment-card-header{display:flex;align-items:flex-start;justify-content:space-between;gap:10px;flex-wrap:wrap}
+.payment-actions{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;margin-top:10px}
 .day-list{display:flex;flex-direction:column;gap:10px}
 .day-card{border:1px solid var(--line);border-radius:12px;background:#0f1118;padding:12px;box-shadow:0 2px 12px rgba(0,0,0,.18)}
 .day-header{display:flex;justify-content:space-between;gap:10px;align-items:flex-start;flex-wrap:wrap}


### PR DESCRIPTION
### Motivation
- Provide a dedicated Payments area in the admin UI so admins can review, filter and update trainee payment status separately from the dashboard.
- Reuse and centralize payment update logic to avoid duplication between trainees list and the new payments management views.

### Description
- Added a new `Payments` section link in the toolbar and a full payments panel in `backend/admin/index.html` with overview, overdue reminders, and a manage list with filtering and actions.
- Introduced localization strings for the payments UI in both English and Italian in `backend/admin/app.js` and removed the old small payments card from the main dashboard.
- Added reactive state and helpers: `paymentFilter`, `paymentFilterOptions`, `paymentUsers`, `paymentSummary`, and a shared `updatePaymentStatus` function with `togglePayment` and `markPaymentPaid` wrappers in `backend/admin/app.js`.
- Added styling for filter buttons and payment cards in `backend/admin/styles.css` and adjusted list scrolling/spacing for the payments layout.

### Testing
- Started a local static server serving `backend/admin` and captured a Playwright screenshot of the admin page to verify the panel renders (screenshot run succeeded).
- No unit/integration test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b2b647d0833382f2783314056923)