### PR TITLE
Add coach dashboard completion watchlist

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -139,6 +139,35 @@
   "homeWorkoutsThisMonthTitle": "This month",
   "homeUpcomingWeekTitle": "Coming up this week",
   "homeUpcomingWeekEmpty": "No sessions scheduled for the next 7 days.",
+  "homeCoachProgressTitle": "Trainees nearing completion",
+  "homeCoachProgressSubtitle": "Latest plans over 75% complete.",
+  "homeCoachProgressPlanLabel": "Latest plan: {plan}",
+  "@homeCoachProgressPlanLabel": {
+    "placeholders": {
+      "plan": {
+        "type": "String"
+      }
+    }
+  },
+  "homeCoachProgressPercentLabel": "{percent}% complete",
+  "@homeCoachProgressPercentLabel": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "homeCoachProgressCountLabel": "{completed}/{total} sessions",
+  "@homeCoachProgressCountLabel": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "homeWorkoutPlanTitle": "Workout plan",
   "homeWorkoutPlanSubtitle": "Review your assigned plan and upcoming sessions.",
   "homeTraineeFeedbackTitle": "Trainee feedback",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -139,6 +139,35 @@
   "homeWorkoutsThisMonthTitle": "Questo mese",
   "homeUpcomingWeekTitle": "In arrivo questa settimana",
   "homeUpcomingWeekEmpty": "Nessuna sessione programmata nei prossimi 7 giorni.",
+  "homeCoachProgressTitle": "Allievi prossimi al completamento",
+  "homeCoachProgressSubtitle": "Piani più recenti oltre il 75% completati.",
+  "homeCoachProgressPlanLabel": "Ultimo piano: {plan}",
+  "@homeCoachProgressPlanLabel": {
+    "placeholders": {
+      "plan": {
+        "type": "String"
+      }
+    }
+  },
+  "homeCoachProgressPercentLabel": "{percent}% completato",
+  "@homeCoachProgressPercentLabel": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
+  "homeCoachProgressCountLabel": "{completed}/{total} sessioni",
+  "@homeCoachProgressCountLabel": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "homeWorkoutPlanTitle": "Piano di allenamento",
   "homeWorkoutPlanSubtitle": "Rivedi il piano assegnato e le prossime sessioni.",
   "homeTraineeFeedbackTitle": "Feedback atleta",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -752,6 +752,36 @@ abstract class AppLocalizations {
   /// **'Nessuna sessione programmata nei prossimi 7 giorni.'**
   String get homeUpcomingWeekEmpty;
 
+  /// No description provided for @homeCoachProgressTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Allievi prossimi al completamento'**
+  String get homeCoachProgressTitle;
+
+  /// No description provided for @homeCoachProgressSubtitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Piani più recenti oltre il 75% completati.'**
+  String get homeCoachProgressSubtitle;
+
+  /// No description provided for @homeCoachProgressPlanLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Ultimo piano: {plan}'**
+  String homeCoachProgressPlanLabel(String plan);
+
+  /// No description provided for @homeCoachProgressPercentLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'{percent}% completato'**
+  String homeCoachProgressPercentLabel(int percent);
+
+  /// No description provided for @homeCoachProgressCountLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'{completed}/{total} sessioni'**
+  String homeCoachProgressCountLabel(int completed, int total);
+
   /// No description provided for @homeWorkoutPlanTitle.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -400,6 +400,27 @@ class AppLocalizationsEn extends AppLocalizations {
       'No sessions scheduled for the next 7 days.';
 
   @override
+  String get homeCoachProgressTitle => 'Trainees nearing completion';
+
+  @override
+  String get homeCoachProgressSubtitle => 'Latest plans over 75% complete.';
+
+  @override
+  String homeCoachProgressPlanLabel(String plan) {
+    return 'Latest plan: $plan';
+  }
+
+  @override
+  String homeCoachProgressPercentLabel(int percent) {
+    return '$percent% complete';
+  }
+
+  @override
+  String homeCoachProgressCountLabel(int completed, int total) {
+    return '$completed/$total sessions';
+  }
+
+  @override
   String get homeWorkoutPlanTitle => 'Workout plan';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -405,6 +405,28 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nessuna sessione programmata nei prossimi 7 giorni.';
 
   @override
+  String get homeCoachProgressTitle => 'Allievi prossimi al completamento';
+
+  @override
+  String get homeCoachProgressSubtitle =>
+      'Piani più recenti oltre il 75% completati.';
+
+  @override
+  String homeCoachProgressPlanLabel(String plan) {
+    return 'Ultimo piano: $plan';
+  }
+
+  @override
+  String homeCoachProgressPercentLabel(int percent) {
+    return '$percent% completato';
+  }
+
+  @override
+  String homeCoachProgressCountLabel(int completed, int total) {
+    return '$completed/$total sessioni';
+  }
+
+  @override
   String get homeWorkoutPlanTitle => 'Piano di allenamento';
 
   @override


### PR DESCRIPTION
### Motivation
- Provide coaches with a quick watchlist on the home dashboard showing trainees whose latest assigned plan is largely complete so coaches can follow up before a plan finishes.
- Surface completion progress (threshold > 75%) and plan details for the coach without changing existing trainee views.

### Description
- Added a new coach data flow to `lib/pages/home_content.dart` by introducing `_coachProgressFuture` and the loader ` _loadCoachPlanProgress ` which queries `trainers`, `trainee_trainers`, `workout_plans` and `workout_plan_days` to compute latest-plan completion rates per trainee and filters entries over 75% completion.
- Implemented lightweight data types `_TraineeSummary`, `_PlanDetails`, `_PlanCompletion`, and `_CoachPlanProgress` and a UI widget ` _CoachPlanProgressSection ` to render trainee name, plan title, a progress bar and counts in the home list using a `FutureBuilder`.
- Updated refresh behavior to fetch both workout days and coach progress in parallel and avoid showing an extra loading spinner for the coach section by returning a `SizedBox.shrink()` while that data is loading.
- Added localization keys and translations for English and Italian in `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb`, and updated `lib/l10n/app_localizations.*` to expose the new strings and helper formatters.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b8eb127c83339a3392205a2c79d6)