### PR TITLE
Add current plan progress summary to Home

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -137,6 +137,28 @@
   "homeNextWorkoutEmpty": "No scheduled workouts yet.",
   "homeWorkoutsThisWeekTitle": "This week",
   "homeWorkoutsThisMonthTitle": "This month",
+  "homePlanProgressTitle": "Overall plan progress",
+  "homePlanProgressCurrentPlan": "Current plan",
+  "homePlanProgressEmpty": "No plan progress to show yet.",
+  "homePlanProgressValue": "{completed} of {total} sessions completed",
+  "@homePlanProgressValue": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "homePlanProgressPercent": "{percent}% complete",
+  "@homePlanProgressPercent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
   "homeUpcomingWeekTitle": "Coming up this week",
   "homeUpcomingWeekEmpty": "No sessions scheduled for the next 7 days.",
   "homeWorkoutPlanTitle": "Workout plan",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -137,6 +137,28 @@
   "homeNextWorkoutEmpty": "Nessun allenamento programmato.",
   "homeWorkoutsThisWeekTitle": "Questa settimana",
   "homeWorkoutsThisMonthTitle": "Questo mese",
+  "homePlanProgressTitle": "Progresso complessivo del piano",
+  "homePlanProgressCurrentPlan": "Piano attuale",
+  "homePlanProgressEmpty": "Nessun progresso del piano da mostrare.",
+  "homePlanProgressValue": "{completed} di {total} sessioni completate",
+  "@homePlanProgressValue": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "homePlanProgressPercent": "{percent}% completato",
+  "@homePlanProgressPercent": {
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
   "homeUpcomingWeekTitle": "In arrivo questa settimana",
   "homeUpcomingWeekEmpty": "Nessuna sessione programmata nei prossimi 7 giorni.",
   "homeWorkoutPlanTitle": "Piano di allenamento",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -740,6 +740,36 @@ abstract class AppLocalizations {
   /// **'Questo mese'**
   String get homeWorkoutsThisMonthTitle;
 
+  /// No description provided for @homePlanProgressTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Progresso complessivo del piano'**
+  String get homePlanProgressTitle;
+
+  /// No description provided for @homePlanProgressCurrentPlan.
+  ///
+  /// In it, this message translates to:
+  /// **'Piano attuale'**
+  String get homePlanProgressCurrentPlan;
+
+  /// No description provided for @homePlanProgressEmpty.
+  ///
+  /// In it, this message translates to:
+  /// **'Nessun progresso del piano da mostrare.'**
+  String get homePlanProgressEmpty;
+
+  /// No description provided for @homePlanProgressValue.
+  ///
+  /// In it, this message translates to:
+  /// **'{completed} di {total} sessioni completate'**
+  String homePlanProgressValue(int completed, int total);
+
+  /// No description provided for @homePlanProgressPercent.
+  ///
+  /// In it, this message translates to:
+  /// **'{percent}% completato'**
+  String homePlanProgressPercent(int percent);
+
   /// No description provided for @homeUpcomingWeekTitle.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -393,6 +393,37 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeWorkoutsThisMonthTitle => 'This month';
 
   @override
+  String get homePlanProgressTitle => 'Overall plan progress';
+
+  @override
+  String get homePlanProgressCurrentPlan => 'Current plan';
+
+  @override
+  String get homePlanProgressEmpty => 'No plan progress to show yet.';
+
+  @override
+  String homePlanProgressValue(int completed, int total) {
+    return intl.Intl.message(
+      '$completed of $total sessions completed',
+      name: 'homePlanProgressValue',
+      args: [completed, total],
+      desc: '',
+      examples: const {},
+    );
+  }
+
+  @override
+  String homePlanProgressPercent(int percent) {
+    return intl.Intl.message(
+      '$percent% complete',
+      name: 'homePlanProgressPercent',
+      args: [percent],
+      desc: '',
+      examples: const {},
+    );
+  }
+
+  @override
   String get homeUpcomingWeekTitle => 'Coming up this week';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -398,6 +398,37 @@ class AppLocalizationsIt extends AppLocalizations {
   String get homeWorkoutsThisMonthTitle => 'Questo mese';
 
   @override
+  String get homePlanProgressTitle => 'Progresso complessivo del piano';
+
+  @override
+  String get homePlanProgressCurrentPlan => 'Piano attuale';
+
+  @override
+  String get homePlanProgressEmpty => 'Nessun progresso del piano da mostrare.';
+
+  @override
+  String homePlanProgressValue(int completed, int total) {
+    return intl.Intl.message(
+      '$completed di $total sessioni completate',
+      name: 'homePlanProgressValue',
+      args: [completed, total],
+      desc: '',
+      examples: const {},
+    );
+  }
+
+  @override
+  String homePlanProgressPercent(int percent) {
+    return intl.Intl.message(
+      '$percent% completato',
+      name: 'homePlanProgressPercent',
+      args: [percent],
+      desc: '',
+      examples: const {},
+    );
+  }
+
+  @override
   String get homeUpcomingWeekTitle => 'In arrivo questa settimana';
 
   @override


### PR DESCRIPTION
### Motivation
- Surface users' overall progress on their active workout plan on the Home screen so they can quickly see completion rate and counts for the current plan.

### Description
- Extended `lib/pages/home_content.dart` to request `completed` and plan metadata (`id`, `title`, `starts_on`, `created_at`) from the `days` query and populate `WorkoutDay` fields accordingly.
- Added a `_buildPlanProgressSummary` helper that groups `WorkoutDay` entries by plan, picks the latest plan, computes `totalDays` and `completedDays`, and exposes a completion ratio via a new `_PlanProgressSummary` model.
- Rendered a plan progress card in the schedule section with `LinearProgressIndicator`, textual counts and percent, and fallback text when no plan data exists.
- Added localization entries for English and Italian and updated generated localization APIs in `lib/l10n/*` (`app_en.arb`, `app_it.arb`, `app_localizations.dart`, `app_localizations_en.dart`, `app_localizations_it.dart`) for the new strings and plural/parameterized messages.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970bcb1ea0083339d0ef7aa2df11a26)