### PR TITLE
Remove exercises model; store exercise name on day_exercises and update admin/UI

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -424,39 +424,6 @@
                 </template>
             </div>
 
-            <div class="col program-sidebar">
-                <div class="card exercise-panel exercise-sidebar">
-                    <h2 style="display:flex;justify-content:space-between;align-items:center;gap:8px">{{ t('sections.exercises') }} <span class="pill">{{ t('labels.totalCount', { count: exerciseOptions.length }) }}</span></h2>
-                    <div class="stack">
-                        <form @submit.prevent="addExerciseDefinition" style="display:flex;flex-direction:column;gap:8px">
-                            <label class="small" style="display:flex;flex-direction:column;gap:4px">
-                                {{ t('labels.name') }}
-                                <input v-model="newExerciseName" :placeholder="t('placeholders.exerciseExample')" required />
-                            </label>
-                            <div style="display:flex;gap:8px;flex-wrap:wrap">
-                                <button class="btn small" type="submit" :disabled="savingExercise">{{ t('actions.addExercise') }}</button>
-                            </div>
-                            <div v-if="savingExercise" class="muted small">{{ t('status.savingExercise') }}</div>
-                        </form>
-                        <div>
-                            <h3 style="margin-top:0">{{ t('exercises.available') }}</h3>
-                            <div v-if="exerciseOptions.length===0" class="muted small">{{ t('exercises.none') }}</div>
-                            <div v-else class="exercise-list scroll-area">
-                                <div v-for="ex in exerciseOptions" :key="ex.id" class="exercise-item small">
-                                    <div class="exercise-head">
-                                        <input v-model="exerciseEdits[ex.id].name" :placeholder="t('placeholders.exerciseName')" />
-                                        <span class="pill">#{{ ex.id.slice(0,4) }}</span>
-                                    </div>
-                                    <div class="exercise-actions">
-                                        <button class="btn small icon-button" @click="updateExercise(ex)" :disabled="savingExercise" :title="t('actions.save')" :aria-label="t('actions.save')">💾</button>
-                                        <button class="small icon-button danger" type="button" @click="deleteExercise(ex)" :disabled="savingExercise" :title="t('actions.delete')" :aria-label="t('actions.delete')">🗑️</button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -58,24 +58,6 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .tag.accent{background:#0d2219;color:#b7f5d8;border-color:#1c2b23}
 .day-body{display:flex;flex-direction:column;gap:10px;margin-top:10px}
 .inline-actions{display:flex;gap:6px;flex-wrap:wrap;align-items:center}
-.exercise-list{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:8px}
-.exercise-item{border:1px solid var(--line);border-radius:12px;background:#0f1118;padding:10px;display:flex;align-items:center;gap:8px}
-.exercise-head{display:flex;gap:8px;align-items:center;flex-wrap:nowrap;flex:1}
-.exercise-head input{flex:1 1 160px;min-width:0}
-.exercise-actions{display:flex;gap:6px;flex-wrap:nowrap;justify-content:flex-end}
-.exercise-actions .icon-button{min-width:auto;padding:6px 8px}
-.exercise-actions .icon-button.danger{color:#fca5a5;border-color:#3b0f10;background:#1a0b0c}
-.exercise-panel h2{margin:12px 0 6px}
-.exercise-panel .row{gap:12px}
-.exercise-panel form{gap:6px}
-.exercise-panel input{padding:6px 8px}
-.exercise-panel .exercise-list{grid-template-columns:repeat(auto-fill,minmax(220px,1fr))}
-.exercise-panel .exercise-item{padding:8px;gap:6px}
-.exercise-panel .exercise-head{gap:6px}
-.exercise-panel .exercise-actions{gap:4px;justify-content:flex-start}
-.exercise-panel .btn.small,
-.exercise-panel button.small{padding:6px 10px}
-.exercise-sidebar .exercise-list{grid-template-columns:1fr}
 .program-panel .program-main{flex:2 1 640px}
 .program-panel .program-sidebar{flex:1 1 320px}
 .overview-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px}

--- a/db/database.sql
+++ b/db/database.sql
@@ -12,14 +12,13 @@ CREATE TABLE public.admins (
 CREATE TABLE public.day_exercises (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   day_id uuid NOT NULL,
-  exercise_id uuid NOT NULL,
+  exercise text NOT NULL,
   position integer NOT NULL DEFAULT 1,
   notes text,
   trainee_notes text,
   completed boolean,
   CONSTRAINT day_exercises_pkey PRIMARY KEY (id),
-  CONSTRAINT day_exercises_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.days(id),
-  CONSTRAINT day_exercises_exercise_id_fkey FOREIGN KEY (exercise_id) REFERENCES public.exercises(id)
+  CONSTRAINT day_exercises_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.days(id)
 );
 CREATE TABLE public.days (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
@@ -31,12 +30,6 @@ CREATE TABLE public.days (
   completed boolean DEFAULT false,
   completed_at time with time zone,
   CONSTRAINT days_pkey PRIMARY KEY (id)
-);
-CREATE TABLE public.exercises (
-  id uuid NOT NULL DEFAULT gen_random_uuid(),
-  name text NOT NULL UNIQUE,
-  explanation text,
-  CONSTRAINT exercises_pkey PRIMARY KEY (id)
 );
 CREATE TABLE public.max_tests (
   id uuid NOT NULL DEFAULT gen_random_uuid(),

--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -160,7 +160,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         .select(
           'id, week, day_code, title, notes, completed, '
           'workout_plan_days ( position, workout_plans ( id, title, starts_on, created_at ) ), '
-          'day_exercises ( id, position, notes, completed, trainee_notes, exercises ( id, name ) )',
+          'day_exercises ( id, position, notes, completed, trainee_notes, exercise )',
         )
         .eq('trainee_id', userId)
         .order('week', ascending: true)
@@ -194,11 +194,9 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
       final planName = planDetails['title'] as String?;
 
       final exercises = dayExercises.map((exercise) {
-        final exerciseDetails =
-            (exercise['exercises'] as Map<String, dynamic>?) ?? {};
         return WorkoutExercise(
           id: exercise['id'] as String?,
-          name: exerciseDetails['name'] as String?,
+          name: exercise['exercise'] as String?,
           position: (exercise['position'] as num?)?.toInt(),
           notes: exercise['notes'] as String?,
           traineeNotes: exercise['trainee_notes'] as String?,


### PR DESCRIPTION
### Motivation
- Simplify the data model by removing the separate `exercises` table and store exercise names directly on `day_exercises` as free text so day entries no longer require a foreign-keyed exercise record. 
- Reflect the schema change across the admin UI and client-side loaders so the app reads and writes the new text field instead of referencing exercise records.

### Description
- Changed `db/database.sql` to replace `day_exercises.exercise_id uuid` with `day_exercises.exercise text` and removed the `exercises` table and its FK constraints. 
- Updated `backend/admin/app.js` to remove exercise-definition management (options, edits, load/add/update/delete operations) and to treat day exercise selection as free-text `exercise` when loading and inserting `day_exercises`. 
- Removed the admin exercise panel UI from `backend/admin/index.html` and removed related CSS rules from `backend/admin/styles.css`. 
- Updated the Flutter loader in `lib/pages/workout_plan_page.dart` to select and use `day_exercises.exercise` (text) when building `WorkoutExercise` instances.

### Testing
- Launched a local static server for the admin UI with `python -m http.server 8000` to validate assets served successfully. 
- Attempted an automated UI screenshot with Playwright, but the Chromium process crashed with a SIGSEGV so no screenshot or interactive verification was captured. 
- No automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f8b1f2308333938f8fdde3ef9588)