### PR TITLE
Associate workout days with workout plans

### DIFF
--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -30,6 +30,7 @@ class WorkoutDay {
   final String? planName;
   final DateTime? planStartedAt;
   final DateTime? createdAt;
+  final int? planPosition;
   final List<WorkoutExercise> exercises;
 
   const WorkoutDay({
@@ -44,6 +45,7 @@ class WorkoutDay {
     this.planName,
     this.planStartedAt,
     this.createdAt,
+    this.planPosition,
   });
 
   String formattedTitle(AppLocalizations l10n, {String? fallback}) {

--- a/lib/model/workout_plan.dart
+++ b/lib/model/workout_plan.dart
@@ -32,7 +32,7 @@ class WorkoutPlan {
 
     return WorkoutPlan(
       id: json['id'] as String?,
-      name: (json['name'] as String? ?? '').trim(),
+      name: (json['title'] as String? ?? json['name'] as String? ?? '').trim(),
       status: (json['status'] as String? ?? '').trim(),
       notes: json['notes'] as String?,
       startsOn: parseDate(json['starts_on']),

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -116,7 +116,7 @@ class _HomeContentState extends State<HomeContent> {
 
     final response = await client.from('days').select(
           'week, day_code, completed, '
-          'workout_plan_days ( workout_plans ( id, title, starts_on, created_at ) )',
+          'workout_plan_days ( position, workout_plans ( id, title, starts_on, created_at ) )',
         )
         .eq('trainee_id', userId)
         .order('week', ascending: true)
@@ -144,6 +144,8 @@ class _HomeContentState extends State<HomeContent> {
       final planCreatedAt = parseDate(planDetails['created_at']);
       final planId = planDetails['id'] as String?;
       final planName = planDetails['title'] as String?;
+      final planPosition =
+          planEntries.isNotEmpty ? (planEntries.first['position'] as num?)?.toInt() : null;
 
       return WorkoutDay(
         id: null,
@@ -156,6 +158,7 @@ class _HomeContentState extends State<HomeContent> {
         planName: planName,
         planStartedAt: planStartedAt,
         createdAt: planCreatedAt,
+        planPosition: planPosition,
         exercises: const [],
       );
     }).toList();

--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -187,6 +187,8 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
       final planDetails = planEntries.isNotEmpty
           ? (planEntries.first['workout_plans'] as Map<String, dynamic>?) ?? {}
           : <String, dynamic>{};
+      final planPosition =
+          planEntries.isNotEmpty ? (planEntries.first['position'] as num?)?.toInt() : null;
 
       final planStartedAt = parseDate(planDetails['starts_on']);
       final planCreatedAt = parseDate(planDetails['created_at']);
@@ -217,6 +219,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         planName: planName,
         planStartedAt: planStartedAt,
         createdAt: planCreatedAt,
+        planPosition: planPosition,
         exercises: exercises,
       );
     }).toList();
@@ -264,6 +267,13 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         ..sort((a, b) {
           if (a.isCompleted != b.isCompleted) {
             return a.isCompleted ? 1 : -1;
+          }
+          final aPosition = a.planPosition;
+          final bPosition = b.planPosition;
+          if (aPosition != null || bPosition != null) {
+            if (aPosition == null) return 1;
+            if (bPosition == null) return -1;
+            if (aPosition != bPosition) return aPosition.compareTo(bPosition);
           }
           if (a.week != b.week) return a.week.compareTo(b.week);
           return a.dayCode.compareTo(b.dayCode);


### PR DESCRIPTION
### Motivation
- Ensure newly created `days` are linked to a workout plan and expose plan metadata when loading days for admin and mobile views.
- Prefer the DB column `workout_plans.title` as the canonical plan name when creating and updating plans in the admin UI.
- Preserve plan ordering by capturing and using the `workout_plan_days.position` when grouping and ordering days in the app.

### Description
- Admin: changed plan create/update payloads to use `title`, added `resolveDefaultPlanId()` to pick the latest active plan, included `workout_plan_days` in the `days` query, and updated `addDay()` to insert a day then associate it to a plan via `workout_plan_days` with computed `position` and error handling (`backend/admin/app.js`).
- Mobile: added `planPosition` to `WorkoutDay` and populated it from `workout_plan_days.position` when loading days in both the plan page and home content, and used `planPosition` when sorting plan days (`lib/model/workout_day.dart`, `lib/pages/workout_plan_page.dart`, `lib/pages/home_content.dart`).
- Model: aligned `WorkoutPlan.fromJson` to prefer `title` and fall back to `name` for backward compatibility (`lib/model/workout_plan.dart`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f93a27a083339cfe973345cc2a46)