### PR TITLE
Simplify trainee feedback to single question

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -168,6 +168,8 @@
   "workoutPlanTitle": "Workout plan",
   "traineeFeedbackTitle": "Trainee feedback",
   "traineeFeedbackSubtitle": "Tell your coach how you're feeling and how the plan is going.",
+  "traineeFeedbackQuestionLabel": "How did your training feel?",
+  "traineeFeedbackQuestionHint": "Share anything going well or that needs attention.",
   "traineeFeedbackHighlightsLabel": "Highlights",
   "traineeFeedbackHighlightsHint": "What felt good or went well?",
   "traineeFeedbackChallengesLabel": "Challenges",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -168,6 +168,8 @@
   "workoutPlanTitle": "Piano di allenamento",
   "traineeFeedbackTitle": "Feedback atleta",
   "traineeFeedbackSubtitle": "Racconta al tuo coach come ti senti e come procede il piano.",
+  "traineeFeedbackQuestionLabel": "Come è andato l'allenamento?",
+  "traineeFeedbackQuestionHint": "Condividi cosa sta andando bene o cosa richiede attenzione.",
   "traineeFeedbackHighlightsLabel": "Punti forti",
   "traineeFeedbackHighlightsHint": "Cosa è andato bene o ti è piaciuto?",
   "traineeFeedbackChallengesLabel": "Difficoltà",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -824,6 +824,18 @@ abstract class AppLocalizations {
   /// **'Racconta al tuo coach come ti senti e come procede il piano.'**
   String get traineeFeedbackSubtitle;
 
+  /// No description provided for @traineeFeedbackQuestionLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Come è andato l\'allenamento?'**
+  String get traineeFeedbackQuestionLabel;
+
+  /// No description provided for @traineeFeedbackQuestionHint.
+  ///
+  /// In it, this message translates to:
+  /// **'Condividi cosa sta andando bene o cosa richiede attenzione.'**
+  String get traineeFeedbackQuestionHint;
+
   /// No description provided for @traineeFeedbackHighlightsLabel.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -444,6 +444,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Tell your coach how you\'re feeling and how the plan is going.';
 
   @override
+  String get traineeFeedbackQuestionLabel => 'How did your training feel?';
+
+  @override
+  String get traineeFeedbackQuestionHint =>
+      'Share anything going well or that needs attention.';
+
+  @override
   String get traineeFeedbackHighlightsLabel => 'Highlights';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -448,6 +448,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Racconta al tuo coach come ti senti e come procede il piano.';
 
   @override
+  String get traineeFeedbackQuestionLabel => 'Come è andato l\'allenamento?';
+
+  @override
+  String get traineeFeedbackQuestionHint =>
+      'Condividi cosa sta andando bene o cosa richiede attenzione.';
+
+  @override
   String get traineeFeedbackHighlightsLabel => 'Punti forti';
 
   @override

--- a/lib/pages/trainee_feedback.dart
+++ b/lib/pages/trainee_feedback.dart
@@ -11,16 +11,12 @@ class TraineeFeedbackPage extends StatefulWidget {
 }
 
 class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
-  final _highlightsController = TextEditingController();
-  final _challengesController = TextEditingController();
-  final _notesController = TextEditingController();
+  final _feedbackController = TextEditingController();
   bool _isSubmitting = false;
 
   @override
   void dispose() {
-    _highlightsController.dispose();
-    _challengesController.dispose();
-    _notesController.dispose();
+    _feedbackController.dispose();
     super.dispose();
   }
 
@@ -45,21 +41,9 @@ class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
             ),
             const SizedBox(height: 16),
             _FeedbackFieldCard(
-              label: l10n.traineeFeedbackHighlightsLabel,
-              hintText: l10n.traineeFeedbackHighlightsHint,
-              controller: _highlightsController,
-            ),
-            const SizedBox(height: 12),
-            _FeedbackFieldCard(
-              label: l10n.traineeFeedbackChallengesLabel,
-              hintText: l10n.traineeFeedbackChallengesHint,
-              controller: _challengesController,
-            ),
-            const SizedBox(height: 12),
-            _FeedbackFieldCard(
-              label: l10n.traineeFeedbackNotesLabel,
-              hintText: l10n.traineeFeedbackNotesHint,
-              controller: _notesController,
+              label: l10n.traineeFeedbackQuestionLabel,
+              hintText: l10n.traineeFeedbackQuestionHint,
+              controller: _feedbackController,
               minLines: 4,
             ),
             const SizedBox(height: 20),
@@ -85,27 +69,13 @@ class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
       return;
     }
 
-    final highlights = _highlightsController.text.trim();
-    final challenges = _challengesController.text.trim();
-    final notes = _notesController.text.trim();
-    if (highlights.isEmpty && challenges.isEmpty && notes.isEmpty) {
+    final feedback = _feedbackController.text.trim();
+    if (feedback.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.missingFieldsError)),
       );
       return;
     }
-
-    final sections = <String>[];
-    if (highlights.isNotEmpty) {
-      sections.add('${l10n.traineeFeedbackHighlightsLabel}\n$highlights');
-    }
-    if (challenges.isNotEmpty) {
-      sections.add('${l10n.traineeFeedbackChallengesLabel}\n$challenges');
-    }
-    if (notes.isNotEmpty) {
-      sections.add('${l10n.traineeFeedbackNotesLabel}\n$notes');
-    }
-    final message = sections.join('\n\n');
 
     setState(() {
       _isSubmitting = true;
@@ -114,12 +84,10 @@ class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
     try {
       await client.from('trainee_feedbacks').insert({
         'trainee_id': userId,
-        'message': message,
+        'message': feedback,
       });
       if (!mounted) return;
-      _highlightsController.clear();
-      _challengesController.clear();
-      _notesController.clear();
+      _feedbackController.clear();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.traineeFeedbackSubmitted)),
       );


### PR DESCRIPTION
### Motivation
- Reduce complexity of the trainee feedback flow by replacing three separate text fields with a single open-ended question to make it quicker for trainees to submit feedback.
- Add localized UI strings so the single-question prompt is available in English and Italian.

### Description
- Replaced three controllers (`_highlightsController`, `_challengesController`, `_notesController`) with a single `TextEditingController` (`_feedbackController`) in `lib/pages/trainee_feedback.dart` and updated the UI to show one `_FeedbackFieldCard` using `l10n.traineeFeedbackQuestionLabel` and `l10n.traineeFeedbackQuestionHint`.
- Simplified submission logic in `_submitFeedback()` to validate and save the single `feedback` text and clear `_feedbackController` after successful insert into the `trainee_feedbacks` table.
- Added new localized keys `traineeFeedbackQuestionLabel` and `traineeFeedbackQuestionHint` to `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb` and updated generated localization files (`lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, `lib/l10n/app_localizations_it.dart`) to expose the new getters.
- Files changed: `lib/pages/trainee_feedback.dart`, `lib/l10n/app_en.arb`, `lib/l10n/app_it.arb`, `lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, and `lib/l10n/app_localizations_it.dart`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711e423b44833382eee796cbe9cf13)