### PR TITLE
Fetch payment status from monthly payments and remove Trainee.paid

### DIFF
--- a/lib/components/plan_expired_gate.dart
+++ b/lib/components/plan_expired_gate.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
-import '../model/trainee.dart';
 
 final supabase = Supabase.instance.client;
 
@@ -84,20 +83,15 @@ class _PlanExpiredGateState extends State<PlanExpiredGate> {
     final userId = client.auth.currentUser?.id;
     if (userId == null) return false;
 
-    final profileResponse = await supabase
-        .from('trainees')
-        .select(
-        'id, name, paid, weight')
-        .eq('id', userId)
+    final paymentResponse = await supabase
+        .from('trainee_monthly_payments')
+        .select('paid, month_start')
+        .eq('trainee_id', userId)
+        .order('month_start', ascending: false)
         .limit(1)
         .maybeSingle();
 
-    if (profileResponse == null) {
-      throw Exception('user-not-found');
-    }
-
-    final profile = Trainee.fromMap(profileResponse);
-    return profile.paid ?? false;
+    return paymentResponse?['paid'] as bool? ?? false;
   }
 }
 

--- a/lib/model/trainee.dart
+++ b/lib/model/trainee.dart
@@ -2,13 +2,11 @@
 class Trainee {
   final String id;
   final String? name;
-  final bool? paid;
   final double? weight;
 
   const Trainee({
     required this.id,
     this.name,
-    this.paid,
     this.weight,
   });
 
@@ -16,7 +14,6 @@ class Trainee {
     return Trainee(
       id: map['id'] as String,
       name: map['name'] as String?,
-      paid: map['paid'] as bool?,
       weight: (map['weight'] as num?)?.toDouble(),
     );
   }
@@ -25,7 +22,6 @@ class Trainee {
     return {
       'id': id,
       'name': name,
-      'paid': paid,
       'weight': weight,
     };
   }
@@ -33,13 +29,11 @@ class Trainee {
   Trainee copyWith({
     String? id,
     String? name,
-    bool? paid,
     double? weight,
   }) {
     return Trainee(
       id: id ?? this.id,
       name: name ?? this.name,
-      paid: paid ?? this.paid,
       weight: weight ?? this.weight,
     );
   }
@@ -48,7 +42,6 @@ class Trainee {
   String toString() => 'Profiles(${{
         'id': id,
         'name': name,
-        'paid': paid,
         'weight': weight
       }})';
 
@@ -59,7 +52,6 @@ class Trainee {
       runtimeType == other.runtimeType &&
       id == other.id &&
       name == other.name &&
-      paid == other.paid &&
       weight == other.weight;
 
   @override
@@ -67,7 +59,6 @@ class Trainee {
       Object.hashAll([
         id,
         name,
-        paid,
         weight
       ]);
 }

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -59,8 +59,7 @@ Future<UserProfileData> getUserData() async {
 
   final profileResponse = await supabase
       .from('trainees')
-      .select(
-          'id, name, paid, weight')
+      .select('id, name, weight')
       .eq('id', user.id)
       .limit(1)
       .maybeSingle();
@@ -73,12 +72,22 @@ Future<UserProfileData> getUserData() async {
   final name = profile.name ??
       (user.email != null ? user.email!.split('@').first : '');
 
+  final paymentResponse = await supabase
+      .from('trainee_monthly_payments')
+      .select('paid, month_start')
+      .eq('trainee_id', user.id)
+      .order('month_start', ascending: false)
+      .limit(1)
+      .maybeSingle();
+
+  final isPayed = paymentResponse?['paid'] as bool? ?? false;
+
   return UserProfileData(
     userId: user.id,
     email: user.email ?? '',
     username: name,
     isActive: true,
-    isPayed: profile.paid ?? false,
+    isPayed: isPayed,
     profile: profile,
   );
 }


### PR DESCRIPTION
### Motivation
- The `paid` column was removed from the `trainees` table in the DB schema, so plan/payment checks must use the monthly payments table instead.
- Profile and plan-gate logic must reflect the current schema by deriving plan status from `trainee_monthly_payments`.

### Description
- Remove the deprecated `paid` field and related serialization/comparison code from the `Trainee` model in `lib/model/trainee.dart`.
- Update `getUserData()` in `lib/pages/profile.dart` to stop selecting `paid` from `trainees`, and instead query `trainee_monthly_payments` for the latest record with `select('paid, month_start')`, ordered by `month_start` descending, to compute `isPayed`.
- Update `lib/components/plan_expired_gate.dart` to query `trainee_monthly_payments` for the latest payment and return its `paid` flag when deciding whether the plan is expired.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e58f7ff48333889e8bf5bed831d8)