### PR TITLE
Add week selection to plan builder

### DIFF
--- a/backend/admin/constants.js
+++ b/backend/admin/constants.js
@@ -1,5 +1,6 @@
 export const planStatuses = ['active', 'upcoming', 'draft', 'archived'];
 export const dayCodeOptions = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'];
 export const templateDayOptions = [1, 2, 3, 4, 5, 6, 7];
+export const templateWeekOptions = [1, 2, 3, 4, 5, 6, 8, 12];
 export const templateSlotsPerDay = 6;
 export const templateExerciseOptions = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];

--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -456,6 +456,14 @@
                                     </select>
                                 </label>
                                 <label class="stack small">
+                                    <span class="muted small">{{ t('labels.weeks') }}</span>
+                                    <select v-model.number="templateWeekCount">
+                                        <option v-for="option in templateWeekOptions" :key="option" :value="option">
+                                            {{ option }}
+                                        </option>
+                                    </select>
+                                </label>
+                                <label class="stack small">
                                     <span class="muted small">{{ t('labels.exercises') }}</span>
                                     <select v-model.number="templateSlotCount">
                                         <option v-for="option in templateExerciseOptions" :key="option" :value="option">


### PR DESCRIPTION
### Motivation
- Enable building multi-week workout templates from the admin plan builder so trainers can generate multiple weeks of days and exercises at once.

### Description
- Add `templateWeekOptions` to `backend/admin/constants.js` and expose `templateWeekCount` in `backend/admin/app.js` to store the number of weeks to generate.
- Generate `programTemplateDays` as `templateDayCount * templateWeekCount` and update the `watch` handler to recalc when weeks change, preserving existing slot content via `buildTemplateDays`.
- Adjust `templateDayLabel` and the payload used in `saveTemplatePlan` to compute `week` and `day_code` using `templateDayCount`, and reset `templateWeekCount` after save.
- Add a `weeks` selector to the plan builder UI in `backend/admin/index.html` and export the new template week bindings from the app setup.

### Testing
- Ran an automated UI smoke script that served the admin static page and captured a screenshot of the plan builder; the script completed successfully.
- No unit tests or CI test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971f6040b4883338b878acc516ee496)