### PR TITLE
Move Max test tracking to dedicated menu page

### DIFF
--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -9,6 +9,7 @@ import '../l10n/app_localizations.dart';
 import 'exercise_guides.dart';
 import 'home_content.dart';
 import 'login.dart';
+import 'max_tests_menu.dart';
 import 'workout_plan_page.dart';
 
 class AuthGate extends StatelessWidget {
@@ -81,6 +82,7 @@ class _HomePageState extends State<HomePage> {
       const HomeContent(),
       const ExerciseGuidesPage(),
       const ProfilePage(),
+      const MaxTestsMenuPage(),
       const TerminologiaPage(),
       const WorkoutPlanPage(),
     ];
@@ -167,8 +169,8 @@ class _HomePageState extends State<HomePage> {
                 },
               ),
               ListTile(
-                leading: const Icon(Icons.menu_book),
-                title: Text(l10n.navTerminology),
+                leading: const Icon(Icons.emoji_events_outlined),
+                title: Text(l10n.profileMaxTestsTitle),
                 selected: selectedIndex == 3,
                 onTap: () {
                   setState(() {
@@ -178,12 +180,23 @@ class _HomePageState extends State<HomePage> {
                 },
               ),
               ListTile(
-                leading: const Icon(Icons.event_note),
-                title: Text(l10n.workoutPlanTitle),
+                leading: const Icon(Icons.menu_book),
+                title: Text(l10n.navTerminology),
                 selected: selectedIndex == 4,
                 onTap: () {
                   setState(() {
                     selectedIndex = 4;
+                  });
+                  Navigator.pop(context);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.event_note),
+                title: Text(l10n.workoutPlanTitle),
+                selected: selectedIndex == 5,
+                onTap: () {
+                  setState(() {
+                    selectedIndex = 5;
                   });
                   Navigator.pop(context);
                 },

--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -8,7 +8,7 @@ import '../model/max_test.dart';
 
 final supabase = Supabase.instance.client;
 
-class MaxTestsPage extends StatefulWidget {
+class MaxTestsPage extends StatelessWidget {
   const MaxTestsPage({
     super.key,
     required this.userId,
@@ -19,10 +19,35 @@ class MaxTestsPage extends StatefulWidget {
   final String displayName;
 
   @override
-  State<MaxTestsPage> createState() => _MaxTestsPageState();
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.profileMaxTestsTitle),
+      ),
+      body: MaxTestsContent(
+        userId: userId,
+        displayName: displayName,
+      ),
+    );
+  }
 }
 
-class _MaxTestsPageState extends State<MaxTestsPage> {
+class MaxTestsContent extends StatefulWidget {
+  const MaxTestsContent({
+    super.key,
+    required this.userId,
+    required this.displayName,
+  });
+
+  final String userId;
+  final String displayName;
+
+  @override
+  State<MaxTestsContent> createState() => _MaxTestsContentState();
+}
+
+class _MaxTestsContentState extends State<MaxTestsContent> {
   Future<List<MaxTest>>? _maxTestsFuture;
 
   @override
@@ -69,9 +94,6 @@ class _MaxTestsPageState extends State<MaxTestsPage> {
     final colorScheme = theme.colorScheme;
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.profileMaxTestsTitle),
-      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),

--- a/lib/pages/max_tests_menu.dart
+++ b/lib/pages/max_tests_menu.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../l10n/app_localizations.dart';
+import 'max_tests.dart';
+
+final supabase = Supabase.instance.client;
+
+class MaxTestsMenuPage extends StatefulWidget {
+  const MaxTestsMenuPage({super.key});
+
+  @override
+  State<MaxTestsMenuPage> createState() => _MaxTestsMenuPageState();
+}
+
+class _MaxTestsMenuPageState extends State<MaxTestsMenuPage> {
+  late Future<_MaxTestsUserData> _userFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _userFuture = _loadUserData();
+  }
+
+  Future<_MaxTestsUserData> _loadUserData() async {
+    final user = supabase.auth.currentUser;
+    if (user == null) {
+      throw Exception('user-not-authenticated');
+    }
+
+    final profileResponse = await supabase
+        .from('trainees')
+        .select('id, name')
+        .eq('id', user.id)
+        .limit(1)
+        .maybeSingle();
+
+    final profileName = (profileResponse?['name'] as String?)?.trim();
+    final displayName = profileName != null && profileName.isNotEmpty
+        ? profileName
+        : (user.email?.split('@').first ?? '');
+
+    return _MaxTestsUserData(
+      userId: user.id,
+      displayName: displayName.isNotEmpty ? displayName : user.id,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return FutureBuilder<_MaxTestsUserData>(
+      future: _userFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (snapshot.hasError) {
+          final rawError = snapshot.error.toString();
+          final errorText =
+              rawError.contains('user-not-authenticated') ? l10n.userNotFound : rawError;
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error_outline, size: 48),
+                  const SizedBox(height: 16),
+                  Text(
+                    l10n.profileLoadError,
+                    style: Theme.of(context).textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    errorText,
+                    style: Theme.of(context).textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        final data = snapshot.data;
+        if (data == null) {
+          return Center(child: Text(l10n.profileNoData));
+        }
+
+        return MaxTestsContent(
+          userId: data.userId,
+          displayName: data.displayName,
+        );
+      },
+    );
+  }
+}
+
+class _MaxTestsUserData {
+  const _MaxTestsUserData({
+    required this.userId,
+    required this.displayName,
+  });
+
+  final String userId;
+  final String displayName;
+}

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
-import 'max_tests.dart';
 import 'login.dart';
 
 final supabase = Supabase.instance.client;
@@ -146,17 +145,6 @@ class _ProfilePageState extends State<ProfilePage> {
     }
   }
 
-  void _openMaxTests(UserProfileData data) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => MaxTestsPage(
-          userId: data.userId,
-          displayName: data.displayName(AppLocalizations.of(context)!),
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -281,17 +269,6 @@ class _ProfilePageState extends State<ProfilePage> {
                           subtitle: Text(weightText),
                         ),
                       ],
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  Card(
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                    child: ListTile(
-                      leading: const Icon(Icons.emoji_events_outlined),
-                      title: Text(l10n.profileMaxTestsTitle),
-                      subtitle: Text(l10n.profileMaxTestsDescription),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap: () => _openMaxTests(data),
                     ),
                   ),
                   const SizedBox(height: 16),


### PR DESCRIPTION
### Motivation
- Move the "Max test tracking" feature out of the profile screen into its own page so it can be accessed directly from the main menu and reused independently of the profile UI.

### Description
- Refactor `lib/pages/max_tests.dart` by converting `MaxTestsPage` to a thin `StatelessWidget` that hosts a new `MaxTestsContent` `StatefulWidget` containing the max tests logic and UI for reuse.
- Add a new `lib/pages/max_tests_menu.dart` page that loads the current user and displays the `MaxTestsContent` for the logged-in trainee.
- Remove the max tests card from the profile UI by deleting the `ListTile` that opened the max tests screen in `lib/pages/profile.dart` and the now-unused `_openMaxTests` helper.
- Wire the new `MaxTestsMenuPage` into the main navigation by importing it in `lib/pages/main.dart`, inserting it into the `pages` list, and adding a drawer `ListTile` entry so the page is reachable from the menu.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697212171990833391f5aab111078b18)