### PR TITLE
Make max test tracking case-insensitive

### DIFF
--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -191,9 +191,12 @@ class _MaxTestsContentState extends State<MaxTestsContent> {
                           }
 
                           final groupedTests = <String, List<MaxTest>>{};
+                          final displayNames = <String, String>{};
                           for (final test in tests) {
-                            final key = test.exercise.trim();
+                            final displayName = test.exercise.trim();
+                            final key = displayName.toLowerCase();
                             groupedTests.putIfAbsent(key, () => []).add(test);
+                            displayNames.putIfAbsent(key, () => displayName);
                           }
 
                           final bestByExercise = <String, double>{};
@@ -209,13 +212,16 @@ class _MaxTestsContentState extends State<MaxTestsContent> {
                             separatorBuilder: (context, index) => const SizedBox(height: 16),
                             itemBuilder: (context, index) {
                               final entry = groupedTests.entries.elementAt(index);
-                              final exercise = entry.key;
+                              final exerciseKey = entry.key;
                               final groupTests = entry.value;
+                              final exercise =
+                                  displayNames[exerciseKey] ??
+                                  groupTests.first.exercise.trim();
 
                               return _ExerciseGroupCard(
                                 exercise: exercise,
                                 tests: groupTests,
-                                bestValue: bestByExercise[exercise] ?? 0,
+                                bestValue: bestByExercise[exerciseKey] ?? 0,
                               );
                             },
                           );


### PR DESCRIPTION
### Motivation
- Treat exercises with different capitalization (e.g. `Pull-up` vs `pull-up`) as the same logical exercise when grouping and computing best values.

### Description
- Normalize exercise grouping keys with `toLowerCase()` and collect original display names in a `displayNames` map in `lib/pages/max_tests.dart`.
- Compute `bestByExercise` using the normalized keys and pass the preserved display name into `_ExerciseGroupCard` while looking up best values by the normalized key.
- Adjusted the list building so grouping is case-insensitive without changing how exercise names are presented in the UI.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972163729dc8333b0d5016d7696462a)