### PR TITLE
Add plan management controls to admin portal (create/edit/delete, inactive status)

### DIFF
--- a/backend/admin/constants.js
+++ b/backend/admin/constants.js
@@ -1,4 +1,4 @@
-export const planStatuses = ['active', 'upcoming', 'draft', 'archived'];
+export const planStatuses = ['active', 'inactive', 'upcoming', 'draft', 'archived'];
 export const dayCodeOptions = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
 export const templateDayOptions = [1, 2, 3, 4, 5, 6, 7];
 export const templateWeekOptions = [1, 2, 3, 4, 5, 6, 8, 12];

--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -462,7 +462,7 @@
                     </div>
 
                     <div class="overview-grid">
-                        <div class="card">
+                        <div class="card plan-manager-card">
                             <div class="overview-card-header">
                                 <div class="stack">
                                     <h3 style="margin:0">{{ t('program.plansTitle') }}</h3>
@@ -470,13 +470,90 @@
                                 </div>
                                 <button class="small" type="button" @click="loadPlans">{{ t('actions.refresh') }}</button>
                             </div>
-                            <div v-if="plans.length===0" class="muted small">{{ t('plans.none') }}</div>
-                            <div v-else class="list">
-                                <div v-for="plan in plans" :key="plan.id" class="plan-item">
-                                    <div class="stack">
-                                        <strong>{{ plan.title }}</strong>
-                                        <span class="muted small">{{ planStatusLabel(plan.status) }}</span>
-                                        <span class="muted small" v-if="plan.starts_on">{{ t('labels.startsAt') }}: {{ plan.starts_on }}</span>
+                            <div class="plan-manager">
+                                <div class="plan-form">
+                                    <h4 style="margin:0">{{ t('plans.addTitle') }}</h4>
+                                    <div class="plan-form-row">
+                                        <label class="stack small">
+                                            <span class="muted small">{{ t('labels.planName') }}</span>
+                                            <input v-model="newPlanName" :placeholder="t('program.planExample')" />
+                                        </label>
+                                        <label class="stack small">
+                                            <span class="muted small">{{ t('labels.status') }}</span>
+                                            <select v-model="newPlanStatus">
+                                                <option v-for="status in planStatuses" :key="status" :value="status">
+                                                    {{ planStatusLabel(status) }}
+                                                </option>
+                                            </select>
+                                        </label>
+                                        <label class="stack small">
+                                            <span class="muted small">{{ t('labels.startsAt') }}</span>
+                                            <input type="date" v-model="newPlanStartsAt" />
+                                        </label>
+                                    </div>
+                                    <label class="stack small">
+                                        <span class="muted small">{{ t('labels.notes') }}</span>
+                                        <textarea v-model="newPlanNotes" :placeholder="t('program.planNotes')"></textarea>
+                                    </label>
+                                    <div class="plan-form-actions">
+                                        <button class="small" type="button" @click="addPlan" :disabled="savingPlan">
+                                            {{ t('actions.add') }}
+                                        </button>
+                                        <button class="small" type="button" @click="resetPlanForm" :disabled="savingPlan">
+                                            {{ t('actions.clear') }}
+                                        </button>
+                                        <span v-if="savingPlan" class="muted small">{{ t('status.savingPlan') }}</span>
+                                    </div>
+                                </div>
+                                <div class="plan-list">
+                                    <h4 style="margin:0">{{ t('plans.listTitle') }}</h4>
+                                    <div v-if="plans.length===0" class="muted small">{{ t('plans.none') }}</div>
+                                    <div v-else class="plan-edit-list">
+                                        <div v-for="plan in plans" :key="plan.id" class="plan-item plan-edit-card">
+                                            <div class="stack">
+                                                <strong>{{ plan.title }}</strong>
+                                                <span class="muted small">{{ planStatusLabel(plan.status) }}</span>
+                                                <span class="muted small" v-if="plan.created_at">
+                                                    {{ t('labels.createdAt') }}: {{ formatDate(plan.created_at) }}
+                                                </span>
+                                                <span class="muted small" v-if="plan.starts_on">
+                                                    {{ t('labels.startsAt') }}: {{ formatDate(plan.starts_on) }}
+                                                </span>
+                                            </div>
+                                            <div v-if="planEdits[plan.id]" class="plan-edit-form">
+                                                <label class="stack small">
+                                                    <span class="muted small">{{ t('labels.planName') }}</span>
+                                                    <input v-model="planEdits[plan.id].name" />
+                                                </label>
+                                                <label class="stack small">
+                                                    <span class="muted small">{{ t('labels.status') }}</span>
+                                                    <select v-model="planEdits[plan.id].status">
+                                                        <option v-for="status in planStatuses" :key="status" :value="status">
+                                                            {{ planStatusLabel(status) }}
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                                <label class="stack small">
+                                                    <span class="muted small">{{ t('labels.startsAt') }}</span>
+                                                    <input type="date" v-model="planEdits[plan.id].starts_on" />
+                                                </label>
+                                                <label class="stack small plan-edit-notes">
+                                                    <span class="muted small">{{ t('labels.notes') }}</span>
+                                                    <textarea v-model="planEdits[plan.id].notes"></textarea>
+                                                </label>
+                                            </div>
+                                            <div class="plan-form-actions">
+                                                <button class="small" type="button" @click="savePlan(plan)" :disabled="savingPlan">
+                                                    {{ t('actions.save') }}
+                                                </button>
+                                                <button class="small" type="button" @click="resetPlanEdit(plan)" :disabled="savingPlan">
+                                                    {{ t('actions.reset') }}
+                                                </button>
+                                                <button class="small danger" type="button" @click="deletePlan(plan)" :disabled="savingPlan">
+                                                    {{ t('actions.delete') }}
+                                                </button>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -71,6 +71,14 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .data-block{margin-top:14px;display:flex;flex-direction:column;gap:8px}
 .data-chips{display:flex;flex-wrap:wrap;gap:6px}
 .plan-item{border:1px solid var(--line);border-radius:12px;padding:12px;background:#0f1118}
+.plan-manager{display:grid;gap:16px;margin-top:12px}
+.plan-manager-card .plan-form,.plan-manager-card .plan-list{display:flex;flex-direction:column;gap:12px}
+.plan-form-row{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}
+.plan-form textarea,.plan-edit-form textarea{min-height:80px}
+.plan-edit-list{display:grid;gap:12px}
+.plan-edit-card{display:flex;flex-direction:column;gap:12px}
+.plan-edit-form{display:grid;gap:12px}
+.plan-form-actions{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
 .payment-history-item{border:1px solid var(--line);border-radius:12px;padding:12px;background:#0f1118;display:flex;justify-content:space-between;gap:12px;align-items:flex-start;flex-wrap:wrap}
 .program-template{display:flex;flex-direction:column;gap:12px}
 .program-template-header{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -57,6 +57,7 @@ export const translations = {
       name: 'Name',
       id: 'ID',
       status: 'Status',
+      createdAt: 'Created at',
       startsAt: 'Starts at',
       endsAt: 'Ends at',
       notes: 'Notes',
@@ -271,6 +272,7 @@ export const translations = {
     },
     planStatuses: {
       active: 'active',
+      inactive: 'inactive',
       upcoming: 'upcoming',
       draft: 'draft',
       archived: 'archived',
@@ -334,6 +336,7 @@ export const translations = {
       name: 'Nome',
       id: 'ID',
       status: 'Stato',
+      createdAt: 'Creato il',
       startsAt: 'Inizio',
       endsAt: 'Fine',
       notes: 'Note',
@@ -548,6 +551,7 @@ export const translations = {
     },
     planStatuses: {
       active: 'attivo',
+      inactive: 'inattivo',
       upcoming: 'in arrivo',
       draft: 'bozza',
       archived: 'archiviato',


### PR DESCRIPTION
### Motivation
- Replace the simple read-only plans list with an in-place plan manager so admins can create, edit, toggle status (including inactive), and remove plans without leaving the admin UI.
- Surface plan metadata (created/starts dates and notes) to enable viewing and selecting older plans for a trainee.

### Description
- Replaced the simple plans card with a plan manager UI that provides a plan creation form and an editable list of existing plans in `backend/admin/index.html`.
- Added the `inactive` status to `planStatuses` in `backend/admin/constants.js` and updated translations/labels to include `createdAt` and localized `inactive` strings in `backend/admin/translations.js`.
- Added styles for the plan management layout and form controls in `backend/admin/styles.css` to match existing admin UI patterns.
- The new UI binds to existing functions (`addPlan`, `savePlan`, `deletePlan`, `loadPlans`, `resetPlanForm`, `resetPlanEdit`) exposed by the admin app logic so plan create/edit/delete flows use the same Supabase-backed implementations.

### Testing
- Started a local static server with `python -m http.server` in `backend/admin` and loaded `index.html` with Playwright to capture a screenshot of the admin login (the plan manager view requires an authenticated session to display); the page loaded and the screenshot was produced successfully.
- No automated unit or integration test suite was executed for this change. If desired, run the app and sign in to exercise the full create/edit/delete flows against the configured Supabase instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721a94e7848333ad55cd3cef372531)