### PR TITLE
Disable screenshots on mobile (Android & iOS)

### DIFF
--- a/android/app/src/main/kotlin/com/idipaolo/calisync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/idipaolo/calisync/MainActivity.kt
@@ -1,5 +1,15 @@
 package com.idipaolo.calisync
 
+import android.os.Bundle
+import android.view.WindowManager
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,11 +3,40 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  private var secureTextField: UITextField?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    enableScreenSecurity()
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  private func enableScreenSecurity() {
+    guard let window = window else { return }
+
+    let textField = UITextField(frame: .zero)
+    textField.isSecureTextEntry = true
+    textField.isUserInteractionEnabled = false
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.backgroundColor = .clear
+    textField.text = " "
+
+    window.addSubview(textField)
+    NSLayoutConstraint.activate([
+      textField.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+      textField.trailingAnchor.constraint(equalTo: window.trailingAnchor),
+      textField.topAnchor.constraint(equalTo: window.topAnchor),
+      textField.bottomAnchor.constraint(equalTo: window.bottomAnchor)
+    ])
+
+    if let superlayer = window.layer.superlayer {
+      superlayer.addSublayer(textField.layer)
+      textField.layer.sublayers?.first?.addSublayer(window.layer)
+    }
+
+    secureTextField = textField
   }
 }


### PR DESCRIPTION
### Motivation

- Prevent screenshots and screen recordings of sensitive UI to improve security on mobile platforms.  
- Use native platform APIs to provide per-platform protection where behavior differs between Android and iOS.

### Description

- On Android, set `WindowManager.LayoutParams.FLAG_SECURE` in `MainActivity.onCreate` to disable screenshots and screen recording.  
- On iOS, add a secure `UITextField` overlay in `AppDelegate` via `enableScreenSecurity()` and retain it in `secureTextField` to reduce screenshot capture of the app window.  
- Files changed: `android/app/src/main/kotlin/com/idipaolo/calisync/MainActivity.kt` and `ios/Runner/AppDelegate.swift`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972223d20f0833385a90afac20c0c54)