### PR TITLE
Align day lookups with workout plan ownership

### DIFF
--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -126,9 +126,9 @@ class _HomeContentState extends State<HomeContent> {
   ) async {
     final response = await client.from('days').select(
           'week, day_code, completed, '
-          'workout_plan_days ( position, workout_plans ( id, title, starts_on, created_at ) )',
+          'workout_plan_days!inner ( position, workout_plans!inner ( id, title, starts_on, created_at ) )',
         )
-        .eq('trainee_id', userId)
+        .eq('workout_plan_days.workout_plans.trainee_id', userId)
         .order('week', ascending: true)
         .order('day_code', ascending: true)
         .order('position', referencedTable: 'workout_plan_days', ascending: true);

--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -159,10 +159,10 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         .from('days')
         .select(
           'id, week, day_code, title, notes, completed, '
-          'workout_plan_days ( position, workout_plans ( id, title, starts_on, created_at ) ), '
+          'workout_plan_days!inner ( position, workout_plans!inner ( id, title, starts_on, created_at ) ), '
           'day_exercises ( id, position, notes, completed, trainee_notes, exercise )',
         )
-        .eq('trainee_id', userId)
+        .eq('workout_plan_days.workout_plans.trainee_id', userId)
         .order('week', ascending: true)
         .order('day_code', ascending: true)
         .order('position', referencedTable: 'workout_plan_days', ascending: true)


### PR DESCRIPTION
### Motivation
- Fix incorrect assumptions where days were filtered by a `trainee_id` on the `days` row, instead of using the `workout_plan_days -> workout_plans.trainee_id` relationship implied by the schema.

### Description
- Update admin progress query to select through `days!inner ( workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )` and filter by `days.workout_plan_days.workout_plans.trainee_id` while extracting the trainee id from the joined plan entries.
- Change day and completed-exercise lookups in the admin UI to use `workout_plan_days!inner` / `workout_plans!inner` joins and to filter via `workout_plan_days.workout_plans.trainee_id` instead of `days.trainee_id`.
- When creating template plans, stop inserting a `trainee_id` directly on `days` and instead create `days` then link them via `workout_plan_days` (preserving plan association semantics).
- Require an existing plan when adding a standalone day in the admin UI by calling `resolveDefaultPlanId()` and failing early if no plan exists, and stop inserting `trainee_id` on `days` there as well.
- Update Flutter client queries in `lib/pages/home_content.dart` and `lib/pages/workout_plan_page.dart` to select inner workout-plan relationships and filter by `workout_plan_days.workout_plans.trainee_id`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69722aed7fe48333ac5a107d0826de05)