### PR TITLE
Add workout day completed timestamps

### DIFF
--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -30,6 +30,7 @@ class WorkoutDay {
   final String? planName;
   final DateTime? planStartedAt;
   final DateTime? createdAt;
+  final DateTime? completedAt;
   final int? planPosition;
   final List<WorkoutExercise> exercises;
 
@@ -45,6 +46,7 @@ class WorkoutDay {
     this.planName,
     this.planStartedAt,
     this.createdAt,
+    this.completedAt,
     this.planPosition,
   });
 

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -125,7 +125,7 @@ class _HomeContentState extends State<HomeContent> {
     String userId,
   ) async {
     final response = await client.from('days').select(
-          'week, day_code, completed, '
+          'id, week, day_code, completed, completed_at, '
           'workout_plan_days!inner ( position, workout_plans!inner ( id, title, starts_on, created_at ) )',
         )
         .eq('workout_plan_days.workout_plans.trainee_id', userId)
@@ -157,12 +157,13 @@ class _HomeContentState extends State<HomeContent> {
       final planPosition = (wpd?['position'] as num?)?.toInt();
 
       return WorkoutDay(
-        id: null,
+        id: row['id'] as String?,
         week: (row['week'] as num?)?.toInt() ?? 0,
         dayCode: (row['day_code'] as String? ?? '').trim(),
         title: null,
         notes: null,
         isCompleted: row['completed'] as bool? ?? false,
+        completedAt: parseDate(row['completed_at']),
         planId: planId,
         planName: planName,
         planStartedAt: planStartedAt,
@@ -301,6 +302,11 @@ class _HomeContentState extends State<HomeContent> {
   }
 
   DateTime? _resolveWorkoutDate(WorkoutDay day) {
+    final completedAt = day.completedAt;
+    if (completedAt != null) {
+      return _normalizeDate(completedAt);
+    }
+
     final planStart = day.planStartedAt;
     final weekOffset = day.week > 0 ? day.week - 1 : 0;
     final dayOffset = _dayOffsetFromCode(day.dayCode);

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -254,9 +254,13 @@ class _TrainingState extends State<Training> {
     });
 
     try {
+      final completedAt = newValue ? DateTime.now().toUtc() : null;
       await Supabase.instance.client
           .from('days')
-          .update({'completed': newValue})
+          .update({
+            'completed': newValue,
+            'completed_at': completedAt?.toIso8601String(),
+          })
           .eq('id', dayId);
 
       if (!mounted) return;

--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -158,7 +158,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
     final response = await client
         .from('days')
         .select(
-          'id, week, day_code, title, notes, completed, '
+          'id, week, day_code, title, notes, completed, completed_at, '
           'workout_plan_days!inner ( position, workout_plans!inner ( id, title, starts_on, created_at ) ), '
           'day_exercises ( id, position, notes, completed, trainee_notes, exercise )',
         )
@@ -214,6 +214,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         title: row['title'] as String?,
         notes: row['notes'] as String?,
         isCompleted: row['completed'] as bool? ?? false,
+        completedAt: parseDate(row['completed_at']),
         planId: planId,
         planName: planName,
         planStartedAt: planStartedAt,


### PR DESCRIPTION
### Motivation
- The database schema includes a `completed_at` timestamp on `days`, so the app should track and use that field for workout days.
- Use `completed_at` as the authoritative date for completed workout days when resolving schedule dates.
- Ensure toggling a day’s completion writes the `completed_at` timestamp so existing records can be backfilled and interpreted correctly.

### Description
- Add a `completedAt` field to the `WorkoutDay` model (`lib/model/workout_day.dart`).
- Include `completed_at` (and `id`) in the day queries and populate `completedAt` in `lib/pages/home_content.dart` and `lib/pages/workout_plan_page.dart`.
- Change `_resolveWorkoutDate` in `lib/pages/home_content.dart` to prefer `day.completedAt` (normalized) before computing a date from the plan start and `day_code`.
- When toggling day completion in `lib/pages/training.dart` write `completed_at` as `DateTime.now().toUtc().toIso8601String()` when marking complete and `null` when marking incomplete.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69723c785304833392b256800a176bd9)