### PR TITLE
Admin: add payment amount editing & display in payments UI

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -271,7 +271,28 @@
                                 </span>
                                 <button class="small" type="button" @click="openTrainee(u)">{{ t('actions.openTrainee') }}</button>
                             </div>
+                            <div class="payment-amount-row">
+                                <label class="stack small">
+                                    <span class="muted small">{{ t('labels.amount') }}</span>
+                                    <input
+                                        type="number"
+                                        min="0"
+                                        step="0.01"
+                                        v-model="paymentAmountEdits[u.id]"
+                                        :placeholder="t('placeholders.amount')"
+                                    />
+                                </label>
+                                <button
+                                    class="small"
+                                    type="button"
+                                    :disabled="paymentAmountSaving[u.id]"
+                                    @click="savePaymentAmount(u)"
+                                >
+                                    {{ t('actions.save') }}
+                                </button>
+                            </div>
                             <div class="muted small" v-if="paymentSaving[u.id]">{{ t('status.updatingPayment') }}</div>
+                            <div class="muted small" v-if="paymentAmountSaving[u.id]">{{ t('status.updatingPaymentAmount') }}</div>
                         </div>
                     </div>
                 </div>
@@ -575,6 +596,12 @@
                                     <div class="stack">
                                         <strong>{{ formatDate(payment.month_start) }}</strong>
                                         <span class="muted small" v-if="payment.paid_at">{{ t('program.paidAt', { date: formatDate(payment.paid_at) }) }}</span>
+                                        <span
+                                            class="muted small"
+                                            v-if="payment.amount !== null && payment.amount !== undefined"
+                                        >
+                                            {{ t('payment.amountLabel', { amount: formatAmount(payment.amount) }) }}
+                                        </span>
                                     </div>
                                     <span class="pill" :class="payment.paid ? 'paid' : 'overdue'">
                                         {{ payment.paid ? t('payment.onTime') : t('payment.overdue') }}

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -51,6 +51,8 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .payment-card{padding:12px}
 .payment-card-header{display:flex;align-items:flex-start;justify-content:space-between;gap:10px;flex-wrap:wrap}
 .payment-actions{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;margin-top:10px}
+.payment-amount-row{display:flex;align-items:flex-end;gap:8px;flex-wrap:wrap;margin-top:10px}
+.payment-amount-row input{min-width:140px}
 .day-list{display:flex;flex-direction:column;gap:10px}
 .day-card{border:1px solid var(--line);border-radius:12px;background:#0f1118;padding:12px;box-shadow:0 2px 12px rgba(0,0,0,.18)}
 .day-header{display:flex;justify-content:space-between;gap:10px;align-items:flex-start;flex-wrap:wrap}

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -76,6 +76,7 @@ export const translations = {
       untitled: 'Untitled',
       exercise: 'Exercise',
       day: 'Day',
+      amount: 'Amount',
       unknownExercise: 'Unknown exercise',
     },
     dashboard: {
@@ -142,6 +143,7 @@ export const translations = {
     placeholders: {
       email: 'Email',
       password: 'Password',
+      amount: 'Amount',
       exerciseExample: 'e.g. Push-ups',
       exerciseName: 'Exercise name',
       planExample: 'e.g. Summer Strength',
@@ -168,6 +170,7 @@ export const translations = {
       onTime: 'Payments on time',
       overdue: 'Payment overdue',
       toggle: 'On time',
+      amountLabel: 'Amount {amount}',
     },
     status: {
       savingExercise: 'Saving exercise…',
@@ -181,6 +184,7 @@ export const translations = {
       loadingMaxTests: 'Loading max tests…',
       loadingPayments: 'Loading payments…',
       loadingCompletedExercises: 'Loading completed exercises…',
+      updatingPaymentAmount: 'Updating payment amount…',
     },
     plans: {
       title: 'Workout plans',
@@ -355,6 +359,7 @@ export const translations = {
       untitled: 'Senza titolo',
       exercise: 'Esercizio',
       day: 'Giorno',
+      amount: 'Importo',
       unknownExercise: 'Esercizio sconosciuto',
     },
     dashboard: {
@@ -421,6 +426,7 @@ export const translations = {
     placeholders: {
       email: 'Email',
       password: 'Password',
+      amount: 'Importo',
       exerciseExample: 'es. Push-up',
       exerciseName: 'Nome esercizio',
       planExample: 'es. Forza Estiva',
@@ -447,6 +453,7 @@ export const translations = {
       onTime: 'Pagamenti in regola',
       overdue: 'Pagamento in ritardo',
       toggle: 'In regola',
+      amountLabel: 'Importo {amount}',
     },
     status: {
       savingExercise: 'Salvataggio esercizio…',
@@ -460,6 +467,7 @@ export const translations = {
       loadingMaxTests: 'Caricamento test massimali…',
       loadingPayments: 'Caricamento pagamenti…',
       loadingCompletedExercises: 'Caricamento esercizi completati…',
+      updatingPaymentAmount: 'Aggiornamento importo pagamento…',
     },
     plans: {
       title: 'Piani allenamento',


### PR DESCRIPTION
### Motivation
- Allow admins to record and store a monthly payment amount alongside the existing paid status for trainees so amounts can be set from the admin UI and surfaced in history.

### Description
- Added reactive state `paymentAmountEdits` and `paymentAmountSaving`, plus `formatAmount` and `normalizePaymentAmount` helpers and persisted `paymentAmount`/`paymentPaidAt` on users in `backend/admin/app.js`.
- Updated Supabase queries to load `amount` and `paid_at` (`.select('trainee_id, paid, paid_at, amount')`) and to include `amount` in the `.upsert` when updating monthly payments.
- Added an amount input and `Save` button to the payments list, a payment-amount row UI in `backend/admin/index.html`, and rendered amounts in the payment history with `formatAmount`.
- Added styling in `backend/admin/styles.css` and translation strings in `backend/admin/translations.js` for labels/placeholders/status messages.

### Testing
- Launched a local HTTP server for the admin static files and captured a full-page screenshot via Playwright which completed successfully, confirming the UI renders (screenshot artifact produced). 
- No automated unit tests were run against the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697253604c888333a4d1346ae5247891)