### PR TITLE
Add admin dashboard burndown chart showing per‑trainee plan progress

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -168,6 +168,57 @@
                     </div>
                 </div>
 
+                    <div class="card dashboard-burndown-card">
+                    <div class="dashboard-card-header">
+                        <div class="stack">
+                            <h2 style="margin:0">{{ t('dashboard.burndownTitle') }}</h2>
+                            <span class="muted small">{{ t('dashboard.burndownSubtitle') }}</span>
+                        </div>
+                        <span class="pill" v-if="dashboardBurndown.minDateLabel && dashboardBurndown.maxDateLabel">
+                            {{ dashboardBurndown.minDateLabel }} → {{ dashboardBurndown.maxDateLabel }}
+                        </span>
+                    </div>
+                    <div v-if="dashboardBurndownLoading" class="muted small" style="margin-top:10px">
+                        {{ t('dashboard.burndownLoading') }}
+                    </div>
+                    <div v-else-if="dashboardBurndownError" class="muted small" style="margin-top:10px">
+                        {{ dashboardBurndownError }}
+                    </div>
+                    <div v-else-if="dashboardBurndown.lines.length===0" class="muted small" style="margin-top:10px">
+                        {{ t('dashboard.burndownEmpty') }}
+                    </div>
+                    <div v-else class="burndown-chart-wrap">
+                        <svg
+                            class="burndown-chart"
+                            role="img"
+                            aria-hidden="true"
+                            :viewBox="`0 0 ${dashboardBurndown.chartWidth} ${dashboardBurndown.chartHeight}`"
+                        >
+                            <polyline
+                                v-for="line in dashboardBurndown.lines"
+                                :key="line.traineeId"
+                                :points="line.polyline"
+                                :stroke="line.color"
+                                stroke-width="2"
+                                fill="none"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                            />
+                        </svg>
+                        <div class="burndown-legend">
+                            <div class="burndown-legend-item" v-for="line in dashboardBurndown.lines" :key="line.traineeId">
+                                <span class="burndown-legend-swatch" :style="{ backgroundColor: line.color }"></span>
+                                <div>
+                                    <strong>{{ line.traineeName }}</strong>
+                                    <div class="muted small">
+                                        {{ t('dashboard.burndownRemaining', { remaining: line.latestRemaining, total: line.total }) }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                     <div v-if="showLastWeekCard" class="card">
                     <div class="dashboard-card-header">
                         <div class="stack">

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -163,6 +163,12 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .history-point.latest{fill:var(--accent)}
 .history-meta{display:flex;justify-content:space-between;align-items:center;color:var(--muted)}
 .exercise-log-item{border:1px solid var(--line);border-radius:12px;padding:12px;background:#f8fafc}
+.dashboard-burndown-card{grid-column:1/-1}
+.burndown-chart-wrap{display:flex;flex-direction:column;gap:16px;margin-top:12px}
+.burndown-chart{width:100%;height:260px;background:#f8fafc;border-radius:16px;border:1px solid var(--line);padding:12px;box-sizing:border-box}
+.burndown-legend{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
+.burndown-legend-item{display:flex;gap:10px;align-items:center}
+.burndown-legend-swatch{width:12px;height:12px;border-radius:999px;display:inline-block;flex-shrink:0}
 
 .auth-shell{flex:1;display:grid;place-items:center;padding:40px}
 .auth-card{background:#fff;border-radius:24px;padding:32px;box-shadow:0 30px 60px rgba(15,23,42,.12);border:1px solid #e5e7eb;max-width:460px;width:100%}

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -96,6 +96,11 @@ export const translations = {
       lastWeekEmpty: 'No trainees are in their last week right now.',
       lastWeekProgress: 'Week {current} of {total}',
       openProgram: 'Open program',
+      burndownTitle: 'Plan burndown',
+      burndownSubtitle: 'Shows remaining exercises in the latest plan over the last month.',
+      burndownLoading: 'Loading plan progress…',
+      burndownEmpty: 'No plan progress found for the last month.',
+      burndownRemaining: '{remaining} of {total} exercises remaining',
     },
     payments: {
       overviewTitle: 'Payment dashboard',
@@ -386,6 +391,12 @@ export const translations = {
       lastWeekEmpty: 'Nessun allievo è nell’ultima settimana al momento.',
       lastWeekProgress: 'Settimana {current} di {total}',
       openProgram: 'Apri programma',
+      burndownTitle: 'Burn down piano',
+      burndownSubtitle:
+        'Mostra gli esercizi rimanenti del piano più recente nell’ultimo mese.',
+      burndownLoading: 'Caricamento progresso piano…',
+      burndownEmpty: 'Nessun progresso del piano trovato nell’ultimo mese.',
+      burndownRemaining: '{remaining} di {total} esercizi rimanenti',
     },
     payments: {
       overviewTitle: 'Dashboard pagamenti',


### PR DESCRIPTION
### Motivation
- Provide a one‑month burndown view on the admin overview so coaches can see remaining exercises for each trainee's latest plan at a glance.
- Use the latest plan per trainee and daily completion timestamps to compute remaining exercise lines across the last 30 days.

### Description
- Added reactive state and helpers in `backend/admin/app.js` (`dashboardBurndown`, `dateKey`, `buildDateRange`) and wired `loadDashboardBurndown` into `bootstrap` to load burndown data for the latest plan per trainee. 
- Implemented `loadDashboardBurndown` to query `workout_plans` and `day_exercises`, compute totals/completions by date, build per‑trainee series and SVG polylines, and expose `dashboardBurndown` (lines, dates, labels). 
- Added UI markup in `backend/admin/index.html` to render an SVG burndown chart and a legend showing each trainee line and remaining/total counts. 
- Added styles in `backend/admin/styles.css` for the burndown card, chart and legend. 
- Added new translation keys in `backend/admin/translations.js` for English and Italian copy used by the burndown card.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735c3a0fe08333a2f4bbdf92531e63)