### PR TITLE
Show trainee notes in completed exercise log

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -398,16 +398,16 @@ import {
             );
             const completedAt = parseCompletedAt(day.completed_at);
             const timestamp = completedAt ? completedAt.valueOf() : null;
-            const noteParts = [entry.notes, entry.trainee_notes]
-              .map((note) => (note || '').trim())
-              .filter(Boolean);
+            const notes = (entry.notes || '').trim();
+            const traineeNotes = (entry.trainee_notes || '').trim();
             return {
               id: entry.id,
               exercise:
                 (entry.exercise || '').trim() || t('labels.unknownExercise'),
               dayLabel,
               timeLabel: completedAt ? formatTime(completedAt) : '',
-              notes: noteParts.join(' • '),
+              notes,
+              traineeNotes,
               sortValue:
                 timestamp ??
                 (week * 100 + (order.has(code) ? order.get(code) : 99)),

--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -633,6 +633,7 @@
                                         <span class="muted small">{{ item.dayLabel }}</span>
                                         <span class="muted small" v-if="item.timeLabel">{{ item.timeLabel }}</span>
                                         <span class="muted small" v-if="item.notes">{{ t('labels.notes') }}: {{ item.notes }}</span>
+                                        <span class="muted small" v-if="item.traineeNotes">{{ t('labels.traineeNotes') }}: {{ item.traineeNotes }}</span>
                                     </div>
                                 </div>
                             </div>

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -79,6 +79,7 @@ export const translations = {
       day: 'Day',
       amount: 'Amount',
       unknownExercise: 'Unknown exercise',
+      traineeNotes: 'Trainee notes',
     },
     dashboard: {
       feedbackTitle: 'Feedback & trainee notes',
@@ -374,6 +375,7 @@ export const translations = {
       day: 'Giorno',
       amount: 'Importo',
       unknownExercise: 'Esercizio sconosciuto',
+      traineeNotes: 'Note dell’allievo',
     },
     dashboard: {
       feedbackTitle: 'Feedback & note allievi',


### PR DESCRIPTION
### Motivation
- Make trainee-provided notes visible and separate from coach/entry notes in the admin program completed exercise log.

### Description
- Extract `entry.trainee_notes` into a separate `traineeNotes` field in the `completedExerciseLog` computed map in `backend/admin/app.js`.
- Display a dedicated trainee notes line in the completed exercises UI in `backend/admin/index.html` using the new field.
- Add `labels.traineeNotes` translations to `backend/admin/translations.js` for English and Italian.

### Testing
- Served the admin UI with `python -m http.server` in `backend/admin` and captured a screenshot using a Playwright script to verify the UI change, and the page rendered and screenshot capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736676ab308333ba23188fb595384f)