### PR TITLE
Add period filter and progression view to max test tracking

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -302,6 +302,20 @@
   },
   "profileMaxTestsTitle": "Max test tracking",
   "profileMaxTestsDescription": "Log your best attempts to see how your strength evolves over time.",
+  "profileMaxTestsPeriodLabel": "Period",
+  "profileMaxTestsPeriodMonth": "Last 1 month",
+  "profileMaxTestsPeriodHalfYear": "Last 6 months",
+  "profileMaxTestsPeriodYear": "Last 1 year",
+  "profileMaxTestsPeriodAll": "All time",
+  "profileMaxTestsEmptyPeriod": "No max tests recorded in {period}. Try a longer time range.",
+  "@profileMaxTestsEmptyPeriod": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsBestPeriodLabel": "Best in selected period",
   "profileMaxTestsAdd": "Add max test",
   "profileMaxTestsRefresh": "Refresh",
   "profileMaxTestsEmpty": "No max tests recorded yet. Add your first attempt to start tracking progress.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -302,6 +302,20 @@
   },
   "profileMaxTestsTitle": "Test massimali",
   "profileMaxTestsDescription": "Tieni traccia dei tuoi massimali per vedere come progredisci nel tempo.",
+  "profileMaxTestsPeriodLabel": "Periodo",
+  "profileMaxTestsPeriodMonth": "Ultimo mese",
+  "profileMaxTestsPeriodHalfYear": "Ultimi 6 mesi",
+  "profileMaxTestsPeriodYear": "Ultimo anno",
+  "profileMaxTestsPeriodAll": "Tutto il periodo",
+  "profileMaxTestsEmptyPeriod": "Nessun test massimale registrato in {period}. Prova un intervallo più lungo.",
+  "@profileMaxTestsEmptyPeriod": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsBestPeriodLabel": "Migliore nel periodo selezionato",
   "profileMaxTestsAdd": "Aggiungi test massimale",
   "profileMaxTestsRefresh": "Aggiorna",
   "profileMaxTestsEmpty": "Nessun test massimale registrato. Aggiungi il primo per iniziare a tracciare i progressi.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1376,6 +1376,48 @@ abstract class AppLocalizations {
   /// **'Tieni traccia dei tuoi massimali per vedere come progredisci nel tempo.'**
   String get profileMaxTestsDescription;
 
+  /// No description provided for @profileMaxTestsPeriodLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Period'**
+  String get profileMaxTestsPeriodLabel;
+
+  /// No description provided for @profileMaxTestsPeriodMonth.
+  ///
+  /// In en, this message translates to:
+  /// **'Last 1 month'**
+  String get profileMaxTestsPeriodMonth;
+
+  /// No description provided for @profileMaxTestsPeriodHalfYear.
+  ///
+  /// In en, this message translates to:
+  /// **'Last 6 months'**
+  String get profileMaxTestsPeriodHalfYear;
+
+  /// No description provided for @profileMaxTestsPeriodYear.
+  ///
+  /// In en, this message translates to:
+  /// **'Last 1 year'**
+  String get profileMaxTestsPeriodYear;
+
+  /// No description provided for @profileMaxTestsPeriodAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All time'**
+  String get profileMaxTestsPeriodAll;
+
+  /// No description provided for @profileMaxTestsEmptyPeriod.
+  ///
+  /// In en, this message translates to:
+  /// **'No max tests recorded in {period}. Try a longer time range.'**
+  String profileMaxTestsEmptyPeriod(String period);
+
+  /// No description provided for @profileMaxTestsBestPeriodLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Best in selected period'**
+  String get profileMaxTestsBestPeriodLabel;
+
   /// No description provided for @profileMaxTestsAdd.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -753,6 +753,29 @@ class AppLocalizationsEn extends AppLocalizations {
       'Log your best attempts to see how your strength evolves over time.';
 
   @override
+  String get profileMaxTestsPeriodLabel => 'Period';
+
+  @override
+  String get profileMaxTestsPeriodMonth => 'Last 1 month';
+
+  @override
+  String get profileMaxTestsPeriodHalfYear => 'Last 6 months';
+
+  @override
+  String get profileMaxTestsPeriodYear => 'Last 1 year';
+
+  @override
+  String get profileMaxTestsPeriodAll => 'All time';
+
+  @override
+  String profileMaxTestsEmptyPeriod(String period) {
+    return 'No max tests recorded in $period. Try a longer time range.';
+  }
+
+  @override
+  String get profileMaxTestsBestPeriodLabel => 'Best in selected period';
+
+  @override
   String get profileMaxTestsAdd => 'Add max test';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -759,6 +759,30 @@ class AppLocalizationsIt extends AppLocalizations {
       'Tieni traccia dei tuoi massimali per vedere come progredisci nel tempo.';
 
   @override
+  String get profileMaxTestsPeriodLabel => 'Periodo';
+
+  @override
+  String get profileMaxTestsPeriodMonth => 'Ultimo mese';
+
+  @override
+  String get profileMaxTestsPeriodHalfYear => 'Ultimi 6 mesi';
+
+  @override
+  String get profileMaxTestsPeriodYear => 'Ultimo anno';
+
+  @override
+  String get profileMaxTestsPeriodAll => 'Tutto il periodo';
+
+  @override
+  String profileMaxTestsEmptyPeriod(String period) {
+    return 'Nessun test massimale registrato in $period. Prova un intervallo più lungo.';
+  }
+
+  @override
+  String get profileMaxTestsBestPeriodLabel =>
+      'Migliore nel periodo selezionato';
+
+  @override
   String get profileMaxTestsAdd => 'Aggiungi test massimale';
 
   @override


### PR DESCRIPTION
### Motivation
- Provide a period selector (1 month, 6 months, 1 year, all) so users can view their personal best within a chosen range and inspect all-time progression of max attempts.

### Description
- Added a `_MaxTestPeriod` enum and `_selectedPeriod` state to `lib/pages/max_tests.dart`, plus a `DropdownButton` UI to pick the period and compute a `periodStart` for filtering. 
- Implemented filtering of tests by the selected period and an empty-state message `profileMaxTestsEmptyPeriod` when no tests exist in the chosen range. 
- For non-`all` periods show the single best attempt per exercise in that period; for `all` show an all-time progression computed by `_buildProgression` that emits only improving attempts over time. 
- Updated `lib/pages/max_tests.dart` to pass `summaryLabel`, `badgeLabel` and `enableToggle` into `_ExerciseGroupCard`/`_MaxTestTile`, and added localization keys and translations in `lib/l10n/app_en.arb`, `lib/l10n/app_it.arb`, `lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, and `lib/l10n/app_localizations_it.dart`.

### Testing
- Attempted to run `dart format` on the modified files but it failed because Dart/Flutter are not available in the environment, so automated formatting and SDK checks were not run. 
- No unit or widget tests were executed due to the missing Flutter SDK; changes were validated via static inspection of the updated files (`lib/pages/max_tests.dart` and localization files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697367bfb9088333aa5bfd20ac1ca11c)