### PR TITLE
Add max test progress history page

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -318,7 +318,24 @@
   "profileMaxTestsBestPeriodLabel": "Best in selected period",
   "profileMaxTestsAdd": "Add max test",
   "profileMaxTestsRefresh": "Refresh",
+  "profileMaxTestsHistoryAction": "View progress",
   "profileMaxTestsEmpty": "No max tests recorded yet. Add your first attempt to start tracking progress.",
+  "profileMaxTestsHistoryTitle": "Progress over time",
+  "profileMaxTestsHistoryDescription": "Review each attempt and see how your max values evolve.",
+  "profileMaxTestsHistoryEmpty": "No max tests recorded yet. Add a new attempt to see your progress over time.",
+  "profileMaxTestsHistoryError": "Unable to load progress history: {error}",
+  "@profileMaxTestsHistoryError": {
+    "placeholders": {
+      "error": {}
+    }
+  },
+  "profileMaxTestsHistoryDeltaLabel": "Change {delta}",
+  "@profileMaxTestsHistoryDeltaLabel": {
+    "placeholders": {
+      "delta": {}
+    }
+  },
+  "profileMaxTestsHistoryFirstEntry": "First recorded attempt",
   "profileMaxTestsError": "Unable to load max tests: {error}",
   "@profileMaxTestsError": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -318,7 +318,28 @@
   "profileMaxTestsBestPeriodLabel": "Migliore nel periodo selezionato",
   "profileMaxTestsAdd": "Aggiungi test massimale",
   "profileMaxTestsRefresh": "Aggiorna",
+  "profileMaxTestsHistoryAction": "Vedi progressi",
   "profileMaxTestsEmpty": "Nessun test massimale registrato. Aggiungi il primo per iniziare a tracciare i progressi.",
+  "profileMaxTestsHistoryTitle": "Progressi nel tempo",
+  "profileMaxTestsHistoryDescription": "Rivedi ogni prova e osserva come evolvono i tuoi massimali.",
+  "profileMaxTestsHistoryEmpty": "Nessun test massimale registrato. Aggiungi una nuova prova per vedere i progressi nel tempo.",
+  "profileMaxTestsHistoryError": "Impossibile caricare lo storico dei progressi: {error}",
+  "@profileMaxTestsHistoryError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsHistoryDeltaLabel": "Variazione {delta}",
+  "@profileMaxTestsHistoryDeltaLabel": {
+    "placeholders": {
+      "delta": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsHistoryFirstEntry": "Prima registrazione",
   "profileMaxTestsError": "Impossibile caricare i test massimali: {error}",
   "@profileMaxTestsError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1430,11 +1430,53 @@ abstract class AppLocalizations {
   /// **'Aggiorna'**
   String get profileMaxTestsRefresh;
 
+  /// No description provided for @profileMaxTestsHistoryAction.
+  ///
+  /// In it, this message translates to:
+  /// **'Vedi progressi'**
+  String get profileMaxTestsHistoryAction;
+
   /// No description provided for @profileMaxTestsEmpty.
   ///
   /// In it, this message translates to:
   /// **'Nessun test massimale registrato. Aggiungi il primo per iniziare a tracciare i progressi.'**
   String get profileMaxTestsEmpty;
+
+  /// No description provided for @profileMaxTestsHistoryTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Progressi nel tempo'**
+  String get profileMaxTestsHistoryTitle;
+
+  /// No description provided for @profileMaxTestsHistoryDescription.
+  ///
+  /// In it, this message translates to:
+  /// **'Rivedi ogni prova e osserva come evolvono i tuoi massimali.'**
+  String get profileMaxTestsHistoryDescription;
+
+  /// No description provided for @profileMaxTestsHistoryEmpty.
+  ///
+  /// In it, this message translates to:
+  /// **'Nessun test massimale registrato. Aggiungi una nuova prova per vedere i progressi nel tempo.'**
+  String get profileMaxTestsHistoryEmpty;
+
+  /// No description provided for @profileMaxTestsHistoryError.
+  ///
+  /// In it, this message translates to:
+  /// **'Impossibile caricare lo storico dei progressi: {error}'**
+  String profileMaxTestsHistoryError(Object error);
+
+  /// No description provided for @profileMaxTestsHistoryDeltaLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Variazione {delta}'**
+  String profileMaxTestsHistoryDeltaLabel(String delta);
+
+  /// No description provided for @profileMaxTestsHistoryFirstEntry.
+  ///
+  /// In it, this message translates to:
+  /// **'Prima registrazione'**
+  String get profileMaxTestsHistoryFirstEntry;
 
   /// No description provided for @profileMaxTestsError.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -782,8 +782,35 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileMaxTestsRefresh => 'Refresh';
 
   @override
+  String get profileMaxTestsHistoryAction => 'View progress';
+
+  @override
   String get profileMaxTestsEmpty =>
       'No max tests recorded yet. Add your first attempt to start tracking progress.';
+
+  @override
+  String get profileMaxTestsHistoryTitle => 'Progress over time';
+
+  @override
+  String get profileMaxTestsHistoryDescription =>
+      'Review each attempt and see how your max values evolve.';
+
+  @override
+  String get profileMaxTestsHistoryEmpty =>
+      'No max tests recorded yet. Add a new attempt to see your progress over time.';
+
+  @override
+  String profileMaxTestsHistoryError(Object error) {
+    return 'Unable to load progress history: $error';
+  }
+
+  @override
+  String profileMaxTestsHistoryDeltaLabel(String delta) {
+    return 'Change $delta';
+  }
+
+  @override
+  String get profileMaxTestsHistoryFirstEntry => 'First recorded attempt';
 
   @override
   String profileMaxTestsError(Object error) {

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -789,8 +789,35 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileMaxTestsRefresh => 'Aggiorna';
 
   @override
+  String get profileMaxTestsHistoryAction => 'Vedi progressi';
+
+  @override
   String get profileMaxTestsEmpty =>
       'Nessun test massimale registrato. Aggiungi il primo per iniziare a tracciare i progressi.';
+
+  @override
+  String get profileMaxTestsHistoryTitle => 'Progressi nel tempo';
+
+  @override
+  String get profileMaxTestsHistoryDescription =>
+      'Rivedi ogni prova e osserva come evolvono i tuoi massimali.';
+
+  @override
+  String get profileMaxTestsHistoryEmpty =>
+      'Nessun test massimale registrato. Aggiungi una nuova prova per vedere i progressi nel tempo.';
+
+  @override
+  String profileMaxTestsHistoryError(Object error) {
+    return 'Impossibile caricare lo storico dei progressi: $error';
+  }
+
+  @override
+  String profileMaxTestsHistoryDeltaLabel(String delta) {
+    return 'Variazione $delta';
+  }
+
+  @override
+  String get profileMaxTestsHistoryFirstEntry => 'Prima registrazione';
 
   @override
   String profileMaxTestsError(Object error) {

--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -5,6 +5,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
 import '../model/max_test.dart';
+import 'max_tests_history.dart';
 
 final supabase = Supabase.instance.client;
 
@@ -61,6 +62,17 @@ class _MaxTestsContentState extends State<MaxTestsContent> {
     setState(() {
       _maxTestsFuture = _loadMaxTests(widget.userId);
     });
+  }
+
+  void _openHistoryPage() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => MaxTestsHistoryPage(
+          userId: widget.userId,
+          displayName: widget.displayName,
+        ),
+      ),
+    );
   }
 
   DateTime? _periodStartDate(DateTime now) {
@@ -173,6 +185,11 @@ class _MaxTestsContentState extends State<MaxTestsContent> {
                           onPressed: _refreshMaxTests,
                           tooltip: l10n.profileMaxTestsRefresh,
                           icon: const Icon(Icons.refresh),
+                        ),
+                        IconButton(
+                          onPressed: _openHistoryPage,
+                          tooltip: l10n.profileMaxTestsHistoryAction,
+                          icon: const Icon(Icons.timeline_outlined),
                         ),
                         const SizedBox(width: 8),
                         FilledButton.tonalIcon(

--- a/lib/pages/max_tests_history.dart
+++ b/lib/pages/max_tests_history.dart
@@ -1,0 +1,272 @@
+import 'package:calisync/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../l10n/app_localizations.dart';
+import '../model/max_test.dart';
+
+final supabase = Supabase.instance.client;
+
+class MaxTestsHistoryPage extends StatefulWidget {
+  const MaxTestsHistoryPage({
+    super.key,
+    required this.userId,
+    required this.displayName,
+  });
+
+  final String userId;
+  final String displayName;
+
+  @override
+  State<MaxTestsHistoryPage> createState() => _MaxTestsHistoryPageState();
+}
+
+class _MaxTestsHistoryPageState extends State<MaxTestsHistoryPage> {
+  Future<List<MaxTest>>? _maxTestsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshMaxTests();
+  }
+
+  void _refreshMaxTests() {
+    setState(() {
+      _maxTestsFuture = _loadMaxTests(widget.userId);
+    });
+  }
+
+  Future<List<MaxTest>> _loadMaxTests(String userId) async {
+    final response = await supabase
+        .from('max_tests')
+        .select('id, exercise, value, unit, recorded_at')
+        .eq('trainee_id', userId)
+        .order('recorded_at', ascending: true);
+
+    final items = (response as List?)?.cast<Map<String, dynamic>>() ?? [];
+    return items.map(MaxTest.fromMap).toList();
+  }
+
+  String _formatValue(MaxTest test) {
+    final value = test.value;
+    final formatted = value.toStringAsFixed(
+      value.truncateToDouble() == value ? 0 : 1,
+    );
+    return '$formatted ${test.unit}'.trim();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.profileMaxTestsHistoryTitle),
+        actions: [
+          IconButton(
+            onPressed: _refreshMaxTests,
+            tooltip: l10n.profileMaxTestsRefresh,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.displayName,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                l10n.profileMaxTestsHistoryDescription,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: FutureBuilder<List<MaxTest>>(
+                  future: _maxTestsFuture,
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Center(child: CircularProgressIndicator());
+                    }
+
+                    if (snapshot.hasError) {
+                      final errorText = snapshot.error.toString();
+                      return Center(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Text(
+                            l10n.profileMaxTestsHistoryError(errorText),
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      );
+                    }
+
+                    final tests = snapshot.data ?? const [];
+                    if (tests.isEmpty) {
+                      return Center(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 16),
+                          child: Text(
+                            l10n.profileMaxTestsHistoryEmpty,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      );
+                    }
+
+                    final groupedTests = <String, List<MaxTest>>{};
+                    final displayNames = <String, String>{};
+                    for (final test in tests) {
+                      final displayName = test.exercise.trim();
+                      final key = displayName.toLowerCase();
+                      groupedTests.putIfAbsent(key, () => []).add(test);
+                      displayNames.putIfAbsent(key, () => displayName);
+                    }
+
+                    return ListView.separated(
+                      itemCount: groupedTests.length,
+                      separatorBuilder: (context, index) => const SizedBox(height: 16),
+                      itemBuilder: (context, index) {
+                        final entry = groupedTests.entries.elementAt(index);
+                        final exerciseKey = entry.key;
+                        final groupTests = entry.value
+                          ..sort((a, b) => a.recordedAt.compareTo(b.recordedAt));
+                        final exercise =
+                            displayNames[exerciseKey] ?? groupTests.first.exercise.trim();
+
+                        return _MaxTestHistoryCard(
+                          exercise: exercise,
+                          tests: groupTests,
+                          formatValue: _formatValue,
+                        );
+                      },
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MaxTestHistoryCard extends StatelessWidget {
+  const _MaxTestHistoryCard({
+    required this.exercise,
+    required this.tests,
+    required this.formatValue,
+  });
+
+  final String exercise;
+  final List<MaxTest> tests;
+  final String Function(MaxTest) formatValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: colorScheme.outlineVariant.withValues(alpha: 0.4),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              exercise,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 12),
+            for (var index = 0; index < tests.length; index++)
+              _MaxTestHistoryTile(
+                test: tests[index],
+                previousTest: index > 0 ? tests[index - 1] : null,
+                formatValue: formatValue,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MaxTestHistoryTile extends StatelessWidget {
+  const _MaxTestHistoryTile({
+    required this.test,
+    required this.previousTest,
+    required this.formatValue,
+  });
+
+  final MaxTest test;
+  final MaxTest? previousTest;
+  final String Function(MaxTest) formatValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final appColors = theme.extension<AppColors>();
+    final dateText = DateFormat.yMMMd().format(test.recordedAt);
+    final delta = previousTest == null ? null : test.value - previousTest!.value;
+    final deltaText = delta == null
+        ? l10n.profileMaxTestsHistoryFirstEntry
+        : l10n.profileMaxTestsHistoryDeltaLabel(
+            '${delta >= 0 ? '+' : ''}${delta.toStringAsFixed(delta.truncateToDouble() == delta ? 0 : 1)} ${test.unit}'.trim(),
+          );
+
+    final iconData = delta == null
+        ? Icons.flag_outlined
+        : delta > 0
+            ? Icons.trending_up
+            : delta < 0
+                ? Icons.trending_down
+                : Icons.trending_flat;
+    final highlightColor = delta == null
+        ? theme.colorScheme.primary
+        : delta > 0
+            ? appColors?.success ?? theme.colorScheme.secondary
+            : delta < 0
+                ? appColors?.warning ?? theme.colorScheme.error
+                : theme.colorScheme.outline;
+
+    return ListTile(
+      dense: true,
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        radius: 18,
+        backgroundColor: highlightColor.withValues(alpha: 0.15),
+        foregroundColor: highlightColor,
+        child: Icon(iconData),
+      ),
+      title: Text(formatValue(test)),
+      subtitle: Text(
+        '${l10n.profileMaxTestsDateLabel(dateText)} • $deltaText',
+        style: theme.textTheme.bodySmall,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a way for users to review how their max tests evolved over time by showing chronological attempts and the change between attempts.
- Surface the history from the existing max tests UI so users can quickly navigate from the current view to a dedicated history timeline.

### Description
- Added a new page `lib/pages/max_tests_history.dart` which fetches `max_tests` ordered by `recorded_at` ascending, groups entries by exercise, and renders chronological tiles that show deltas and trend icons.
- Added a navigation action in `lib/pages/max_tests.dart` that opens the history page via `_openHistoryPage()` and an icon button using `l10n.profileMaxTestsHistoryAction`.
- Introduced localization keys in `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb` and updated generated localization files (`app_localizations.dart`, `app_localizations_en.dart`, `app_localizations_it.dart`) to support the new UI strings.
- Kept the same data model `MaxTest` and Supabase queries, and reused formatting helpers for display values and dates.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736a9668a0833389d07f6db0dbc97f)