### PR TITLE
Restyle max tests cards with recent-performance chart and metrics

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -323,6 +323,19 @@
   "profileMaxTestsHistoryTitle": "Progress over time",
   "profileMaxTestsHistoryDescription": "Review each attempt and see how your max values evolve.",
   "profileMaxTestsHistoryEmpty": "No max tests recorded yet. Add a new attempt to see your progress over time.",
+  "profileMaxTestsRecentPerformanceLabel": "Recent Performance",
+  "profileMaxTestsGoalLabel": "Goal",
+  "profileMaxTestsTipsTitle": "Tips & Tutorials",
+  "profileMaxTestsTipsSubtitle": "Review technique cues and accessory drills.",
+  "profileMaxTestsEmptyShort": "Add a new test to see your performance chart.",
+  "profileMaxTestsSessionLabel": "Session {index}",
+  "@profileMaxTestsSessionLabel": {
+    "placeholders": {
+      "index": {
+        "type": "int"
+      }
+    }
+  },
   "profileMaxTestsHistoryError": "Unable to load progress history: {error}",
   "@profileMaxTestsHistoryError": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -323,6 +323,19 @@
   "profileMaxTestsHistoryTitle": "Progressi nel tempo",
   "profileMaxTestsHistoryDescription": "Rivedi ogni prova e osserva come evolvono i tuoi massimali.",
   "profileMaxTestsHistoryEmpty": "Nessun test massimale registrato. Aggiungi una nuova prova per vedere i progressi nel tempo.",
+  "profileMaxTestsRecentPerformanceLabel": "Performance recente",
+  "profileMaxTestsGoalLabel": "Obiettivo",
+  "profileMaxTestsTipsTitle": "Suggerimenti e tutorial",
+  "profileMaxTestsTipsSubtitle": "Rivedi i consigli tecnici e gli esercizi complementari.",
+  "profileMaxTestsEmptyShort": "Aggiungi un nuovo test per vedere il grafico delle prestazioni.",
+  "profileMaxTestsSessionLabel": "Sessione {index}",
+  "@profileMaxTestsSessionLabel": {
+    "placeholders": {
+      "index": {
+        "type": "int"
+      }
+    }
+  },
   "profileMaxTestsHistoryError": "Impossibile caricare lo storico dei progressi: {error}",
   "@profileMaxTestsHistoryError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1460,6 +1460,42 @@ abstract class AppLocalizations {
   /// **'Nessun test massimale registrato. Aggiungi una nuova prova per vedere i progressi nel tempo.'**
   String get profileMaxTestsHistoryEmpty;
 
+  /// No description provided for @profileMaxTestsRecentPerformanceLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Performance recente'**
+  String get profileMaxTestsRecentPerformanceLabel;
+
+  /// No description provided for @profileMaxTestsGoalLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Obiettivo'**
+  String get profileMaxTestsGoalLabel;
+
+  /// No description provided for @profileMaxTestsTipsTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Suggerimenti e tutorial'**
+  String get profileMaxTestsTipsTitle;
+
+  /// No description provided for @profileMaxTestsTipsSubtitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Rivedi i consigli tecnici e gli esercizi complementari.'**
+  String get profileMaxTestsTipsSubtitle;
+
+  /// No description provided for @profileMaxTestsEmptyShort.
+  ///
+  /// In it, this message translates to:
+  /// **'Aggiungi un nuovo test per vedere il grafico delle prestazioni.'**
+  String get profileMaxTestsEmptyShort;
+
+  /// No description provided for @profileMaxTestsSessionLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Sessione {index}'**
+  String profileMaxTestsSessionLabel(int index);
+
   /// No description provided for @profileMaxTestsHistoryError.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -800,6 +800,28 @@ class AppLocalizationsEn extends AppLocalizations {
       'No max tests recorded yet. Add a new attempt to see your progress over time.';
 
   @override
+  String get profileMaxTestsRecentPerformanceLabel => 'Recent Performance';
+
+  @override
+  String get profileMaxTestsGoalLabel => 'Goal';
+
+  @override
+  String get profileMaxTestsTipsTitle => 'Tips & Tutorials';
+
+  @override
+  String get profileMaxTestsTipsSubtitle =>
+      'Review technique cues and accessory drills.';
+
+  @override
+  String get profileMaxTestsEmptyShort =>
+      'Add a new test to see your performance chart.';
+
+  @override
+  String profileMaxTestsSessionLabel(int index) {
+    return 'Session $index';
+  }
+
+  @override
   String profileMaxTestsHistoryError(Object error) {
     return 'Unable to load progress history: $error';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -807,6 +807,28 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nessun test massimale registrato. Aggiungi una nuova prova per vedere i progressi nel tempo.';
 
   @override
+  String get profileMaxTestsRecentPerformanceLabel => 'Performance recente';
+
+  @override
+  String get profileMaxTestsGoalLabel => 'Obiettivo';
+
+  @override
+  String get profileMaxTestsTipsTitle => 'Suggerimenti e tutorial';
+
+  @override
+  String get profileMaxTestsTipsSubtitle =>
+      'Rivedi i consigli tecnici e gli esercizi complementari.';
+
+  @override
+  String get profileMaxTestsEmptyShort =>
+      'Aggiungi un nuovo test per vedere il grafico delle prestazioni.';
+
+  @override
+  String profileMaxTestsSessionLabel(int index) {
+    return 'Sessione $index';
+  }
+
+  @override
   String profileMaxTestsHistoryError(Object error) {
     return 'Impossibile caricare lo storico dei progressi: $error';
   }


### PR DESCRIPTION
### Motivation

- Align the max tests screen with the reference layout by surfacing recent performance, best/goal metrics and tips. 
- Improve readability and visual hierarchy of exercise groups by introducing a compact chart and metric summary. 

### Description

- Restyled `_ExerciseGroupCard` to use a gradient card, larger corner radius and shadow, and reorganized content to show a recent-performance chart, metric rows, and a tips card before the test list. 
- Implemented `_RecentPerformanceChart`, `_PerformanceBar`, `_MetricRow`, and `_TipsCard` widgets and added logic to compute `recentSlice`, `bestValueLabel`, and a simple `nextGoal` for display. 
- Added new localization keys to `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb`, and updated generated localization APIs in `lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, and `lib/l10n/app_localizations_it.dart` to expose the new labels and session formatting. 

### Testing

- Attempted to run `flutter --version` but the command failed because `flutter` is not available in the environment, so no Flutter build or widget tests were executed. 
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69737e375f048333a90179a40a699898)