### PR TITLE
Clean up pubspec dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,9 +42,7 @@ dependencies:
   flutter_reactive_ble: ^5.0.2
   provider: ^6.1.1
   fl_chart: ^1.1.1
-  change_app_package_name: ^1.5.0
   app_links: ^6.0.0
-  camera:
   intl: ^0.20.2
 
 dev_dependencies:
@@ -58,6 +56,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
   flutter_launcher_icons: ^0.13.1
+  change_app_package_name: ^1.5.0
 
 flutter_icons:
   android: "launcher_icon"


### PR DESCRIPTION
### Motivation
- Tidy `pubspec.yaml` by removing an unintended empty `camera` dependency and placing the dev-only `change_app_package_name` under `dev_dependencies`.

### Description
- Removed the empty `camera:` entry from `pubspec.yaml` and moved `change_app_package_name: ^1.5.0` from `dependencies` into `dev_dependencies`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763a2e5a9c8333bb9f08f6edecd3d8)