### PR TITLE
Add exercises catalog schema and seed data

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -9,16 +9,39 @@ CREATE TABLE public.admins (
   CONSTRAINT admins_pkey PRIMARY KEY (id),
   CONSTRAINT admins_id_fkey FOREIGN KEY (id) REFERENCES auth.users(id)
 );
+CREATE TABLE public.exercises (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  slug text NOT NULL,
+  name text NOT NULL,
+  difficulty text NOT NULL DEFAULT 'beginner'::text,
+  sort_order integer NOT NULL DEFAULT 1,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT exercises_pkey PRIMARY KEY (id),
+  CONSTRAINT exercises_slug_key UNIQUE (slug),
+  CONSTRAINT exercises_name_key UNIQUE (name)
+);
+CREATE TABLE public.trainee_exercise_unlocks (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  trainee_id uuid NOT NULL,
+  exercise_id uuid NOT NULL,
+  unlocked_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT trainee_exercise_unlocks_pkey PRIMARY KEY (id),
+  CONSTRAINT trainee_exercise_unlocks_trainee_id_fkey FOREIGN KEY (trainee_id) REFERENCES public.trainees(id),
+  CONSTRAINT trainee_exercise_unlocks_exercise_id_fkey FOREIGN KEY (exercise_id) REFERENCES public.exercises(id),
+  CONSTRAINT trainee_exercise_unlocks_unique UNIQUE (trainee_id, exercise_id)
+);
 CREATE TABLE public.day_exercises (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   day_id uuid NOT NULL,
+  exercise_id uuid NOT NULL,
   exercise text NOT NULL,
   position integer NOT NULL DEFAULT 1,
   notes text,
   trainee_notes text,
   completed boolean,
   CONSTRAINT day_exercises_pkey PRIMARY KEY (id),
-  CONSTRAINT day_exercises_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.days(id)
+  CONSTRAINT day_exercises_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.days(id),
+  CONSTRAINT day_exercises_exercise_id_fkey FOREIGN KEY (exercise_id) REFERENCES public.exercises(id)
 );
 CREATE TABLE public.days (
   id uuid NOT NULL DEFAULT gen_random_uuid(),

--- a/db/exercises.sql
+++ b/db/exercises.sql
@@ -1,0 +1,20 @@
+-- Exercise seed data for Supabase
+-- Keep in sync with guides in lib/pages/exercise_guides.dart
+
+INSERT INTO public.exercises (slug, name, difficulty, sort_order)
+VALUES
+  ('pull-up', 'Pull-up', 'intermediate', 1),
+  ('chin-up', 'Chin-up', 'intermediate', 2),
+  ('push-up', 'Push-up', 'beginner', 3),
+  ('bodyweight-squat', 'Bodyweight squat', 'beginner', 4),
+  ('glute-bridge', 'Glute bridge', 'beginner', 5),
+  ('hanging-leg-raise', 'Hanging leg raise', 'intermediate', 6),
+  ('muscle-up', 'Muscle-up', 'advanced', 7),
+  ('straight-bar-dip', 'Straight bar dip', 'intermediate', 8),
+  ('dips', 'Dips', 'intermediate', 9),
+  ('australian-row', 'Australian row', 'beginner', 10),
+  ('pike-push-up', 'Pike push-up', 'intermediate', 11),
+  ('hollow-body-hold', 'Hollow body hold', 'beginner', 12),
+  ('plank', 'Plank', 'beginner', 13),
+  ('l-sit', 'L-sit', 'intermediate', 14),
+  ('handstand-hold', 'Handstand hold', 'advanced', 15);


### PR DESCRIPTION
### Motivation
- Provide a centralized `exercises` catalog so exercises from the in-app guides can be managed and loaded via Supabase. 
- Allow workout days to reference canonical exercises and let trainees unlock exercises as they progress.

### Description
- Add `public.exercises` table with `id`, `slug`, `name`, `difficulty`, `sort_order`, `created_at`, and unique constraints on `slug` and `name` in `db/database.sql`.
- Add `public.trainee_exercise_unlocks` table to track per-trainee unlocks with a unique constraint on `(trainee_id, exercise_id)` and FK references to `public.trainees` and `public.exercises`.
- Update `public.day_exercises` to include `exercise_id uuid` and a FK `day_exercises_exercise_id_fkey` referencing `public.exercises` while keeping the existing `exercise` text column for compatibility.
- Add `db/exercises.sql` seed file inserting the guide exercises (slug, name, difficulty, sort_order) to mirror `lib/pages/exercise_guides.dart`.

### Testing
- No automated tests or migrations were executed for these schema/data-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69763ca9df84833380631f3f6e3db224)