### PR TITLE
Adjust workout plan page layout to match app shell

### DIFF
--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -27,57 +27,17 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.workoutPlanTitle),
-      ),
-      body: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            colors: [
-              colorScheme.primaryContainer.withValues(alpha: 0.12),
-              colorScheme.secondaryContainer.withValues(alpha: 0.08),
-            ],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
-          ),
-        ),
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: theme.cardColor.withValues(alpha: 0.9),
-                borderRadius: BorderRadius.circular(24),
-                boxShadow: [
-                  BoxShadow(
-                    color: theme.shadowColor.withValues(alpha: 0.06),
-                    offset: const Offset(0, 12),
-                    blurRadius: 24,
-                  ),
-                ],
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(24),
-                child: _WorkoutPlanBody(
-                  l10n: l10n,
-                  onRefresh: _refresh,
-                  planDataFuture: _planDataFuture,
-                  onRetry: () {
-                    setState(() {
-                      _planDataFuture = _loadPlanData();
-                    });
-                  },
-                  buildPlanGroups: _buildPlanGroups,
-                  onOpenDay: _openDay,
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
+    return _WorkoutPlanBody(
+      l10n: l10n,
+      onRefresh: _refresh,
+      planDataFuture: _planDataFuture,
+      onRetry: () {
+        setState(() {
+          _planDataFuture = _loadPlanData();
+        });
+      },
+      buildPlanGroups: _buildPlanGroups,
+      onOpenDay: _openDay,
     );
   }
 
@@ -341,24 +301,31 @@ class _WorkoutPlanBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const listPadding = EdgeInsets.fromLTRB(16, 20, 16, 24);
     return FutureBuilder<_WorkoutPlanData>(
       future: planDataFuture,
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return ListView(
+            padding: listPadding,
             physics: const AlwaysScrollableScrollPhysics(),
             children: const [
+              _WorkoutPlanHeader(),
               SizedBox(height: 32),
-              Center(child: CircularProgressIndicator()),
+              Center(
+                child: CircularProgressIndicator(),
+              ),
             ],
           );
         }
 
         if (snapshot.hasError) {
           return ListView(
+            padding: listPadding,
             physics: const AlwaysScrollableScrollPhysics(),
             children: [
-              const SizedBox(height: 32),
+              const _WorkoutPlanHeader(),
+              const SizedBox(height: 24),
               Icon(
                 Icons.error_outline,
                 size: 56,
@@ -392,9 +359,17 @@ class _WorkoutPlanBody extends StatelessWidget {
         final days = homeData.days;
         final plans = homeData.plans;
         if (_isPlanExpired(plans)) {
-          return _ExpiredPlanStub(
-            title: l10n.profilePlanExpired,
-            description: l10n.homeEmptyDescription,
+          return ListView(
+            padding: listPadding,
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: [
+              const _WorkoutPlanHeader(),
+              const SizedBox(height: 24),
+              _ExpiredPlanStub(
+                title: l10n.profilePlanExpired,
+                description: l10n.homeEmptyDescription,
+              ),
+            ],
           );
         }
 
@@ -406,9 +381,11 @@ class _WorkoutPlanBody extends StatelessWidget {
           return RefreshIndicator(
             onRefresh: onRefresh,
             child: ListView(
+              padding: listPadding,
               physics: const AlwaysScrollableScrollPhysics(),
               children: [
-                const SizedBox(height: 32),
+                const _WorkoutPlanHeader(),
+                const SizedBox(height: 24),
                 Image.asset(
                   'assets/logo.png',
                   height: 56,
@@ -437,8 +414,11 @@ class _WorkoutPlanBody extends StatelessWidget {
         return RefreshIndicator(
           onRefresh: onRefresh,
           child: ListView(
+            padding: listPadding,
             physics: const AlwaysScrollableScrollPhysics(),
             children: [
+              const _WorkoutPlanHeader(),
+              const SizedBox(height: 16),
               planOverview,
               const SizedBox(height: 16),
               ...planGroups
@@ -480,8 +460,7 @@ class _ExpiredPlanStub extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return ListView(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 32),
+    return Column(
       children: [
         Icon(
           Icons.assignment_late_outlined,
@@ -498,6 +477,34 @@ class _ExpiredPlanStub extends StatelessWidget {
         Text(
           description,
           textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WorkoutPlanHeader extends StatelessWidget {
+  const _WorkoutPlanHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.workoutPlanTitle,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          l10n.homePlansSectionSubtitle,
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),


### PR DESCRIPTION
### Motivation
- Ensure the workout plans page follows the app-wide shell styling and exposes the global navigation drawer by removing the nested/scoped scaffold that previously hid the main menu.
- Make empty/error/expired states consistent with other pages by reusing the app's list padding, header style, and spacing.
- Improve visual consistency for plan overview and sections by using a shared header component and uniform paddings.

### Description
- Removed the inner `Scaffold`/gradient container from `WorkoutPlanPage` so the page renders inside the main app shell and the global drawer/menu is available again by default (`lib/pages/workout_plan_page.dart`).
- Replaced multiple ad-hoc paddings with a single `listPadding` and added a new `_WorkoutPlanHeader` widget to provide a consistent title/subtitle for the page.
- Updated loading, error, empty and expired states to include the new header and use the shared padding instead of standalone `ListView` spacing, and changed `_ExpiredPlanStub` to return a `Column` so it composes correctly within the outer `ListView`.
- Kept existing data loading and grouping logic intact and passed the same callbacks into the refactored `_WorkoutPlanBody` component.

### Testing
- No automated tests were executed against the running app in this environment.
- An attempt to check the Flutter SDK with `flutter --version` failed because `flutter` is not available in the environment (command not found).
- Local static inspection and basic runtime file edits were performed and the change was committed; interactive UI/runtime verification was not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69764019cb308333bf4578a975670c82)