### PR TITLE
Remove unreferenced translations and prune generated localization code

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -86,124 +86,13 @@
   "guidesHandstandFocus": "Shoulders, core, balance",
   "guidesHandstandTip": "Stack wrists, shoulders, and hips while squeezing your glutes.",
   "guidesHandstandDescription": "Kick or press up to a wall or free balance and hold a tall line with toes pointed.",
-  "settingsComingSoon": "Settings coming soon.",
-  "settingsGeneralSection": "General",
-  "settingsDailyReminder": "Daily workout reminder",
-  "settingsDailyReminderDescription": "Get a gentle nudge to start training each day.",
-  "settingsReminderTime": "Reminder time",
-  "settingsReminderNotSet": "Not set",
-  "settingsSoundEffects": "Sound effects",
-  "settingsSoundEffectsDescription": "Play short sounds when logging repetitions.",
-  "settingsHapticFeedback": "Haptic feedback",
-  "settingsHapticFeedbackDescription": "Vibrate briefly on important actions.",
-  "settingsTrainingSection": "Training preferences",
-  "settingsUnitSystem": "Unit system",
-  "settingsUnitsMetric": "Metric (kg)",
-  "settingsUnitsImperial": "Imperial (lb)",
-  "settingsRestTimer": "Default rest timer",
-  "settingsRestTimerDescription": "Used when starting a rest timer from workouts.",
-  "settingsRestTimerMinutes": "{count, plural, one {# minute} other {# minutes}}",
-  "@settingsRestTimerMinutes": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsRestTimerMinutesSeconds": "{minutes, plural, one {# minute} other {# minutes}} and {seconds, plural, one {# second} other {# seconds}}",
-  "@settingsRestTimerMinutesSeconds": {
-    "placeholders": {
-      "minutes": {
-        "type": "int"
-      },
-      "seconds": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsRestTimerSeconds": "{count, plural, one {# second} other {# seconds}}",
-  "@settingsRestTimerSeconds": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsDataSection": "Data & privacy",
-  "settingsClearCache": "Clear cached workouts",
-  "settingsClearCacheDescription": "Remove workouts saved on this device.",
-  "settingsClearCacheSuccess": "Local workouts cleared.",
-  "settingsExportData": "Export training summary",
-  "settingsExportDataDescription": "Receive a CSV of your recent sessions via email.",
-  "settingsExportDataSuccess": "Export request submitted. Check your inbox soon.",
-  "settingsSupportSection": "Support",
-  "settingsContactCoach": "Contact your coach",
-  "settingsContactCoachDescription": "Send a quick message for adjustments.",
-  "settingsContactCoachHint": "Let us know how we can help.",
-  "settingsContactCoachSuccess": "Message sent to your coach.",
-  "settingsSendMessage": "Send message",
-  "settingsAppVersion": "App version",
-  "settingsAppVersionValue": "Version {version}",
-  "@settingsAppVersionValue": {
-    "placeholders": {
-      "version": {
-        "type": "Object"
-      }
-    }
-  },
-  "exerciseTrackerTitle": "Exercise tracker",
-  "poseEstimationTitle": "Pose estimation",
   "homeLoadErrorTitle": "Unable to load workouts",
   "retry": "Retry",
-  "homeCalendarTitle": "Workout calendar",
-  "homeCalendarSubtitle": "Workout days are highlighted.",
-  "homeScheduleTitle": "Weekly focus",
-  "homeScheduleSubtitle": "Stay on track with your upcoming sessions.",
-  "homeNextWorkoutTitle": "Next workout",
-  "homeNextWorkoutEmpty": "No scheduled workouts yet.",
-  "homeWorkoutsThisWeekTitle": "This week",
-  "homeWorkoutsThisMonthTitle": "This month",
-  "homePlanProgressTitle": "Overall plan progress",
-  "homePlanProgressCurrentPlan": "Current plan",
-  "homePlanProgressEmpty": "No plan progress to show yet.",
-  "homePlanProgressValue": "{completed} of {total} sessions completed",
-  "@homePlanProgressValue": {
-    "placeholders": {
-      "completed": {
-        "type": "int"
-      },
-      "total": {
-        "type": "int"
-      }
-    }
-  },
-  "homePlanProgressPercent": "{percent}% complete",
-  "@homePlanProgressPercent": {
-    "placeholders": {
-      "percent": {
-        "type": "int"
-      }
-    }
-  },
-  "homeUpcomingWeekTitle": "Coming up this week",
-  "homeUpcomingWeekEmpty": "No sessions scheduled for the next 7 days.",
-  "homeWorkoutPlanTitle": "Workout plan",
-  "homeWorkoutPlanSubtitle": "Review your assigned plan and upcoming sessions.",
-  "homeTraineeFeedbackTitle": "Trainee feedback",
-  "homeTraineeFeedbackSubtitle": "Share updates with your coach after sessions.",
-  "homeCoachTipTitle": "Coach tip",
-  "homeCoachTipPlaceholder": "Your coach's latest tip will appear here.",
   "workoutPlanTitle": "Workout plan",
   "traineeFeedbackTitle": "Trainee feedback",
   "traineeFeedbackSubtitle": "Tell your coach how you're feeling and how the plan is going.",
   "traineeFeedbackQuestionLabel": "How did your training feel?",
   "traineeFeedbackQuestionHint": "Share anything going well or that needs attention.",
-  "traineeFeedbackHighlightsLabel": "Highlights",
-  "traineeFeedbackHighlightsHint": "What felt good or went well?",
-  "traineeFeedbackChallengesLabel": "Challenges",
-  "traineeFeedbackChallengesHint": "What felt difficult or needs adjustment?",
-  "traineeFeedbackNotesLabel": "Coach notes",
-  "traineeFeedbackNotesHint": "Anything else to share?",
   "traineeFeedbackSubmit": "Send feedback",
   "traineeFeedbackSubmitted": "Feedback saved. We'll share it with your coach.",
   "homeEmptyTitle": "No workouts available",
@@ -228,32 +117,12 @@
   },
   "unauthenticated": "User not authenticated",
   "defaultExerciseName": "Exercise",
-  "generalNotes": "General notes",
   "trainingHeaderExercise": "Exercise",
   "trainingHeaderSets": "Sets",
   "trainingHeaderReps": "Repetitions",
-  "trainingHeaderRest": "Rest",
-  "trainingHeaderIntensity": "Intensity",
-  "trainingHeaderNotes": "Notes",
-  "trainingNotesLabel": "Exercise notes",
-  "trainingTraineeNotesLabel": "Trainee notes",
-  "trainingNotesSave": "Save notes",
-  "trainingNotesSaved": "Notes saved",
-  "trainingNotesError": "Unable to save notes: {error}",
-  "@trainingNotesError": {
-    "placeholders": {
-      "error": {
-        "type": "Object"
-      }
-    }
-  },
-  "trainingNotesUnavailable": "Cannot update notes for this exercise.",
-  "trainingOpenTracker": "Open tracker",
   "trainingTodayTitle": "Today's Workout",
   "trainingStartWorkout": "Start Workout",
   "trainingWorkoutCompleted": "Workout Completed",
-  "trainingMarkComplete": "Mark day as complete",
-  "trainingMarkIncomplete": "Mark day as incomplete",
   "trainingCompletionSaved": "Workout day updated",
   "trainingCompletionError": "Unable to update workout: {error}",
   "@trainingCompletionError": {
@@ -264,7 +133,6 @@
     }
   },
   "trainingCompletionUnavailable": "Cannot update this workout day.",
-  "trainingExerciseCompletedLabel": "Exercise completed",
   "trainingExerciseCompletionSaved": "Exercise updated",
   "trainingExerciseCompletionError": "Unable to update exercise: {error}",
   "@trainingExerciseCompletionError": {
@@ -293,11 +161,7 @@
   "profilePlanActive": "Active plan",
   "profilePlanExpired": "Plan expired",
   "profileUsername": "Username",
-  "profileLastUpdated": "Last updated",
-  "profileValueUnavailable": "Not available",
-  "profileTimezone": "Time zone",
   "profileNotSet": "Not set",
-  "profileUnitSystem": "Unit system",
   "profileWeight": "Weight",
   "profileWeightValue": "{weight} kg",
   "@profileWeightValue": {
@@ -398,7 +262,6 @@
   "profileMaxTestsShowMore": "Show all attempts",
   "profileMaxTestsShowLess": "Show fewer attempts",
   "profileEdit": "Edit profile",
-  "profileComingSoon": "Coming soon",
   "profileEditSubtitle": "Update your personal details",
   "profileEditTitle": "Edit profile",
   "profileEditFullNameLabel": "Full name",
@@ -406,12 +269,6 @@
   "profileEditWeightLabel": "Weight",
   "profileEditWeightHint": "Enter your weight in kg (optional)",
   "profileEditWeightInvalid": "Enter a valid positive weight.",
-  "profileEditTimezoneLabel": "Time zone",
-  "profileEditTimezoneHint": "Example: Europe/Rome",
-  "profileEditUnitSystemLabel": "Preferred unit system",
-  "profileEditUnitSystemNotSet": "Not specified",
-  "profileEditUnitSystemMetric": "Metric (kg, cm)",
-  "profileEditUnitSystemImperial": "Imperial (lb, in)",
   "profileEditCancel": "Cancel",
   "profileEditSave": "Save changes",
   "profileEditSuccess": "Profile updated successfully",
@@ -423,7 +280,6 @@
       }
     }
   },
-  "featureUnavailable": "Feature not available yet.",
   "logout": "Log out",
   "redirectError": "Error during redirect: {error}",
   "@redirectError": {
@@ -479,127 +335,9 @@
   "passwordResetMismatch": "Passwords do not match.",
   "passwordResetSuccess": "Password updated successfully. You can continue using the app.",
   "passwordResetSubmit": "Update password",
-  "exerciseAddDialogTitle": "Add exercise",
-  "exerciseNameLabel": "Exercise name",
-  "quickAddValuesLabel": "Quick add values",
-  "quickAddValuesHelper": "Comma separated repetitions (e.g. 1,5,10)",
   "cancel": "Cancel",
   "add": "Add",
-  "save": "Save",
-  "exerciseNameMissing": "Please provide a name.",
-  "exerciseTargetRepsLabel": "Target reps",
-  "exerciseTargetRepsHelper": "Optional total goal for the session",
-  "exerciseRestDurationLabel": "Rest duration (seconds)",
-  "exerciseRestDurationHelper": "Optional countdown timer preset",
-  "exerciseTrackerEmpty": "No exercises yet. Tap + to add one!",
-  "exerciseAddButton": "Add exercise",
-  "exercisePushUps": "Push-ups",
-  "exercisePullUps": "Pull-ups",
-  "exerciseChinUps": "Chin-ups",
-  "exerciseTotalReps": "{count} total reps",
-  "@exerciseTotalReps": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "exerciseGoalProgress": "{logged} / {goal} reps logged",
-  "@exerciseGoalProgress": {
-    "placeholders": {
-      "logged": {
-        "type": "int"
-      },
-      "goal": {
-        "type": "int"
-      }
-    }
-  },
-  "exerciseRestFinished": "Rest finished for {exercise}!",
-  "@exerciseRestFinished": {
-    "placeholders": {
-      "exercise": {
-        "type": "String"
-      }
-    }
-  },
-  "exerciseSetRestDuration": "Set rest duration",
-  "exerciseDurationSecondsLabel": "Duration (seconds)",
-  "restTimerLabel": "Rest timer",
-  "setDuration": "Set duration",
-  "undoLastSet": "Undo last set",
-  "custom": "Custom",
-  "reset": "Reset",
-  "logRepsTitle": "Log reps",
-  "repetitionsLabel": "Repetitions",
-  "positiveNumberError": "Enter a positive number.",
-  "repsChip": "{count} reps",
-  "@repsChip": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "goalCount": "Goal: {count}",
-  "@goalCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "repGoalReached": "Rep goal reached!",
-  "pause": "Pause",
   "start": "Start",
-  "seriesCount": "Sets: {count}",
-  "@seriesCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "resetReps": "Reset reps",
-  "emomTrackerTitle": "EMOM tracker",
-  "emomTrackerSubtitle": "Guided every-minute sets with prep countdown.",
-  "emomTrackerDescription": "Configure sets, reps, and intervals to stay on pace each minute.",
-  "emomSetsLabel": "Total sets",
-  "emomRepsLabel": "Reps per set",
-  "emomIntervalLabel": "Interval (seconds)",
-  "emomStartButton": "Start EMOM",
-  "emomResetButton": "Reset session",
-  "emomSessionComplete": "EMOM complete",
-  "emomCurrentSet": "Set {current} of {total}",
-  "@emomCurrentSet": {
-    "placeholders": {
-      "current": {
-        "type": "int"
-      },
-      "total": {
-        "type": "int"
-      }
-    }
-  },
-  "emomRepsPerSet": "{count} reps per set",
-  "@emomRepsPerSet": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "emomFinishedMessage": "Nice work! You hit every minute.",
-  "emomTimeRemainingLabel": "Time remaining this minute",
-  "emomPrepHeadline": "Get ready for set {set}",
-  "@emomPrepHeadline": {
-    "placeholders": {
-      "set": {
-        "type": "int"
-      }
-    }
-  },
-  "emomPrepSubhead": "The next set starts after this countdown.",
   "timerTitle": "Timer",
   "amrapTimerTitle": "AMRAP timer",
   "amrapTimerSubtitle": "Push through as many rounds as possible.",
@@ -615,13 +353,6 @@
   "countdownSecondsLabel": "Seconds",
   "countdownStartButton": "Start timer",
   "countdownResetButton": "Stop timer",
-  "weekdayMonday": "Monday",
-  "weekdayTuesday": "Tuesday",
-  "weekdayWednesday": "Wednesday",
-  "weekdayThursday": "Thursday",
-  "weekdayFriday": "Friday",
-  "weekdaySaturday": "Saturday",
-  "weekdaySunday": "Sunday",
   "weekNumber": "Week {week}",
   "@weekNumber": {
     "placeholders": {
@@ -655,47 +386,5 @@
   "termSomTitle": "SOM",
   "termSomDescription": "Indicates the duration of each phase of the repetition.",
   "termScaricoTitle": "Deload",
-  "termScaricoDescription": "Last week of the program to prepare for max attempts.",
-  "noCameras": "No cameras available",
-  "cameraInitFailed": "Camera init failed: {error}",
-  "@cameraInitFailed": {
-    "placeholders": {
-      "error": {
-        "type": "Object"
-      }
-    }
-  },
-  "poseDetected": "Pose detected",
-  "processing": "Processing…",
-  "idle": "Idle",
-  "cameraFront": "front",
-  "cameraBack": "back",
-  "hudMetrics": "fps: {fps}  ms: {milliseconds}  lmks: {landmarks}",
-  "@hudMetrics": {
-    "placeholders": {
-      "fps": {
-        "type": "String"
-      },
-      "milliseconds": {
-        "type": "String"
-      },
-      "landmarks": {
-        "type": "int"
-      }
-    }
-  },
-  "hudOrientation": "rot: {rotation}  cam: {camera}  fmt: {format}",
-  "@hudOrientation": {
-    "placeholders": {
-      "rotation": {
-        "type": "String"
-      },
-      "camera": {
-        "type": "String"
-      },
-      "format": {
-        "type": "String"
-      }
-    }
-  }
+  "termScaricoDescription": "Last week of the program to prepare for max attempts."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -86,124 +86,13 @@
   "guidesHandstandFocus": "Spalle, core, equilibrio",
   "guidesHandstandTip": "Allinea polsi, spalle e anche e contrai i glutei.",
   "guidesHandstandDescription": "Sali in verticale contro il muro o in equilibrio libero e mantieni una linea lunga con le punte tese.",
-  "settingsComingSoon": "Le impostazioni saranno presto disponibili.",
-  "settingsGeneralSection": "Generali",
-  "settingsDailyReminder": "Promemoria allenamento quotidiano",
-  "settingsDailyReminderDescription": "Ricevi un promemoria per iniziare ad allenarti ogni giorno.",
-  "settingsReminderTime": "Orario promemoria",
-  "settingsReminderNotSet": "Non impostato",
-  "settingsSoundEffects": "Effetti sonori",
-  "settingsSoundEffectsDescription": "Riproduci brevi suoni durante la registrazione delle ripetizioni.",
-  "settingsHapticFeedback": "Feedback aptico",
-  "settingsHapticFeedbackDescription": "Leggera vibrazione per le azioni importanti.",
-  "settingsTrainingSection": "Preferenze di allenamento",
-  "settingsUnitSystem": "Sistema di unità",
-  "settingsUnitsMetric": "Metrico (kg)",
-  "settingsUnitsImperial": "Imperiale (lb)",
-  "settingsRestTimer": "Timer di recupero predefinito",
-  "settingsRestTimerDescription": "Usato quando avvii un timer di recupero dagli allenamenti.",
-  "settingsRestTimerMinutes": "{count, plural, one {# minuto} other {# minuti}}",
-  "@settingsRestTimerMinutes": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsRestTimerMinutesSeconds": "{minutes, plural, one {# minuto} other {# minuti}} e {seconds, plural, one {# secondo} other {# secondi}}",
-  "@settingsRestTimerMinutesSeconds": {
-    "placeholders": {
-      "minutes": {
-        "type": "int"
-      },
-      "seconds": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsRestTimerSeconds": "{count, plural, one {# secondo} other {# secondi}}",
-  "@settingsRestTimerSeconds": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsDataSection": "Dati e privacy",
-  "settingsClearCache": "Cancella allenamenti salvati",
-  "settingsClearCacheDescription": "Rimuovi gli allenamenti memorizzati su questo dispositivo.",
-  "settingsClearCacheSuccess": "Allenamenti locali rimossi.",
-  "settingsExportData": "Esporta riepilogo allenamenti",
-  "settingsExportDataDescription": "Ricevi via email un CSV delle ultime sessioni.",
-  "settingsExportDataSuccess": "Richiesta di esportazione inviata. Controlla la casella di posta a breve.",
-  "settingsSupportSection": "Supporto",
-  "settingsContactCoach": "Contatta il tuo coach",
-  "settingsContactCoachDescription": "Invia un messaggio rapido per chiedere modifiche.",
-  "settingsContactCoachHint": "Dicci come possiamo aiutarti.",
-  "settingsContactCoachSuccess": "Messaggio inviato al coach.",
-  "settingsSendMessage": "Invia messaggio",
-  "settingsAppVersion": "Versione app",
-  "settingsAppVersionValue": "Versione {version}",
-  "@settingsAppVersionValue": {
-    "placeholders": {
-      "version": {
-        "type": "Object"
-      }
-    }
-  },
-  "exerciseTrackerTitle": "Tracker esercizi",
-  "poseEstimationTitle": "Stima postura",
   "homeLoadErrorTitle": "Impossibile caricare gli allenamenti",
   "retry": "Riprova",
-  "homeCalendarTitle": "Calendario allenamenti",
-  "homeCalendarSubtitle": "I giorni di allenamento sono evidenziati.",
-  "homeScheduleTitle": "Focus settimanale",
-  "homeScheduleSubtitle": "Rimani sul pezzo con le prossime sessioni.",
-  "homeNextWorkoutTitle": "Prossimo allenamento",
-  "homeNextWorkoutEmpty": "Nessun allenamento programmato.",
-  "homeWorkoutsThisWeekTitle": "Questa settimana",
-  "homeWorkoutsThisMonthTitle": "Questo mese",
-  "homePlanProgressTitle": "Progresso complessivo del piano",
-  "homePlanProgressCurrentPlan": "Piano attuale",
-  "homePlanProgressEmpty": "Nessun progresso del piano da mostrare.",
-  "homePlanProgressValue": "{completed} di {total} sessioni completate",
-  "@homePlanProgressValue": {
-    "placeholders": {
-      "completed": {
-        "type": "int"
-      },
-      "total": {
-        "type": "int"
-      }
-    }
-  },
-  "homePlanProgressPercent": "{percent}% completato",
-  "@homePlanProgressPercent": {
-    "placeholders": {
-      "percent": {
-        "type": "int"
-      }
-    }
-  },
-  "homeUpcomingWeekTitle": "In arrivo questa settimana",
-  "homeUpcomingWeekEmpty": "Nessuna sessione programmata nei prossimi 7 giorni.",
-  "homeWorkoutPlanTitle": "Piano di allenamento",
-  "homeWorkoutPlanSubtitle": "Rivedi il piano assegnato e le prossime sessioni.",
-  "homeTraineeFeedbackTitle": "Feedback atleta",
-  "homeTraineeFeedbackSubtitle": "Condividi aggiornamenti con il tuo coach dopo le sessioni.",
-  "homeCoachTipTitle": "Consiglio del coach",
-  "homeCoachTipPlaceholder": "Qui troverai l'ultimo consiglio del tuo coach.",
   "workoutPlanTitle": "Piano di allenamento",
   "traineeFeedbackTitle": "Feedback atleta",
   "traineeFeedbackSubtitle": "Racconta al tuo coach come ti senti e come procede il piano.",
   "traineeFeedbackQuestionLabel": "Come è andato l'allenamento?",
   "traineeFeedbackQuestionHint": "Condividi cosa sta andando bene o cosa richiede attenzione.",
-  "traineeFeedbackHighlightsLabel": "Punti forti",
-  "traineeFeedbackHighlightsHint": "Cosa è andato bene o ti è piaciuto?",
-  "traineeFeedbackChallengesLabel": "Difficoltà",
-  "traineeFeedbackChallengesHint": "Cosa è stato difficile o da adattare?",
-  "traineeFeedbackNotesLabel": "Note per il coach",
-  "traineeFeedbackNotesHint": "Hai altro da condividere?",
   "traineeFeedbackSubmit": "Invia feedback",
   "traineeFeedbackSubmitted": "Feedback salvato. Lo condivideremo con il tuo coach.",
   "homeEmptyTitle": "Nessun allenamento disponibile",
@@ -228,32 +117,12 @@
   },
   "unauthenticated": "Utente non autenticato",
   "defaultExerciseName": "Esercizio",
-  "generalNotes": "Note generali",
   "trainingHeaderExercise": "Esercizio",
   "trainingHeaderSets": "Serie",
   "trainingHeaderReps": "Ripetizioni",
-  "trainingHeaderRest": "Recupero",
-  "trainingHeaderIntensity": "Intensità",
-  "trainingHeaderNotes": "Note",
-  "trainingNotesLabel": "Note dell'esercizio",
-  "trainingTraineeNotesLabel": "Note del tirocinante",
-  "trainingNotesSave": "Salva note",
-  "trainingNotesSaved": "Note salvate",
-  "trainingNotesError": "Impossibile salvare le note: {error}",
-  "@trainingNotesError": {
-    "placeholders": {
-      "error": {
-        "type": "Object"
-      }
-    }
-  },
-  "trainingNotesUnavailable": "Impossibile aggiornare le note per questo esercizio.",
-  "trainingOpenTracker": "Apri tracker",
   "trainingTodayTitle": "Allenamento di oggi",
   "trainingStartWorkout": "Inizia allenamento",
   "trainingWorkoutCompleted": "Allenamento completato",
-  "trainingMarkComplete": "Segna giorno come completato",
-  "trainingMarkIncomplete": "Segna giorno come incompleto",
   "trainingCompletionSaved": "Allenamento aggiornato",
   "trainingCompletionError": "Impossibile aggiornare l'allenamento: {error}",
   "@trainingCompletionError": {
@@ -264,7 +133,6 @@
     }
   },
   "trainingCompletionUnavailable": "Impossibile aggiornare questo giorno di allenamento.",
-  "trainingExerciseCompletedLabel": "Esercizio completato",
   "trainingExerciseCompletionSaved": "Esercizio aggiornato",
   "trainingExerciseCompletionError": "Impossibile aggiornare l'esercizio: {error}",
   "@trainingExerciseCompletionError": {
@@ -293,11 +161,7 @@
   "profilePlanActive": "Piano attivo",
   "profilePlanExpired": "Piano scaduto",
   "profileUsername": "Username",
-  "profileLastUpdated": "Ultimo aggiornamento",
-  "profileValueUnavailable": "Non disponibile",
-  "profileTimezone": "Fuso orario",
   "profileNotSet": "Non impostato",
-  "profileUnitSystem": "Unità di misura",
   "profileWeight": "Peso",
   "profileWeightValue": "{weight} kg",
   "@profileWeightValue": {
@@ -398,7 +262,6 @@
   "profileMaxTestsShowMore": "Mostra tutti i tentativi",
   "profileMaxTestsShowLess": "Mostra meno tentativi",
   "profileEdit": "Modifica profilo",
-  "profileComingSoon": "Presto disponibile",
   "profileEditSubtitle": "Aggiorna le tue informazioni personali",
   "profileEditTitle": "Modifica profilo",
   "profileEditFullNameLabel": "Nome completo",
@@ -406,12 +269,6 @@
   "profileEditWeightLabel": "Peso",
   "profileEditWeightHint": "Inserisci il tuo peso in kg (opzionale)",
   "profileEditWeightInvalid": "Inserisci un peso valido e positivo.",
-  "profileEditTimezoneLabel": "Fuso orario",
-  "profileEditTimezoneHint": "Esempio: Europe/Rome",
-  "profileEditUnitSystemLabel": "Unità di misura preferita",
-  "profileEditUnitSystemNotSet": "Non specificato",
-  "profileEditUnitSystemMetric": "Metrico (kg, cm)",
-  "profileEditUnitSystemImperial": "Imperiale (lb, in)",
   "profileEditCancel": "Annulla",
   "profileEditSave": "Salva modifiche",
   "profileEditSuccess": "Profilo aggiornato correttamente",
@@ -423,7 +280,6 @@
       }
     }
   },
-  "featureUnavailable": "Funzionalità non ancora disponibile.",
   "logout": "Logout",
   "redirectError": "Errore durante il reindirizzamento: {error}",
   "@redirectError": {
@@ -479,127 +335,9 @@
   "passwordResetMismatch": "Le password non coincidono.",
   "passwordResetSuccess": "Password aggiornata con successo. Puoi continuare a usare l'app.",
   "passwordResetSubmit": "Aggiorna password",
-  "exerciseAddDialogTitle": "Aggiungi esercizio",
-  "exerciseNameLabel": "Nome esercizio",
-  "quickAddValuesLabel": "Valori rapidi",
-  "quickAddValuesHelper": "Ripetizioni separate da virgola (es. 1,5,10)",
   "cancel": "Annulla",
   "add": "Aggiungi",
-  "save": "Salva",
-  "exerciseNameMissing": "Inserisci un nome.",
-  "exerciseTargetRepsLabel": "Ripetizioni obiettivo",
-  "exerciseTargetRepsHelper": "Obiettivo totale opzionale per la sessione",
-  "exerciseRestDurationLabel": "Durata recupero (secondi)",
-  "exerciseRestDurationHelper": "Preset opzionale per il conto alla rovescia",
-  "exerciseTrackerEmpty": "Ancora nessun esercizio. Tocca + per aggiungerne uno!",
-  "exerciseAddButton": "Aggiungi esercizio",
-  "exercisePushUps": "Push-up",
-  "exercisePullUps": "Trazioni alla sbarra",
-  "exerciseChinUps": "Trazioni a presa inversa",
-  "exerciseTotalReps": "{count} ripetizioni totali",
-  "@exerciseTotalReps": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "exerciseGoalProgress": "{logged} / {goal} ripetizioni registrate",
-  "@exerciseGoalProgress": {
-    "placeholders": {
-      "logged": {
-        "type": "int"
-      },
-      "goal": {
-        "type": "int"
-      }
-    }
-  },
-  "exerciseRestFinished": "Recupero terminato per {exercise}!",
-  "@exerciseRestFinished": {
-    "placeholders": {
-      "exercise": {
-        "type": "String"
-      }
-    }
-  },
-  "exerciseSetRestDuration": "Imposta durata recupero",
-  "exerciseDurationSecondsLabel": "Durata (secondi)",
-  "restTimerLabel": "Timer di recupero",
-  "setDuration": "Imposta durata",
-  "undoLastSet": "Annulla ultima serie",
-  "custom": "Personalizzato",
-  "reset": "Reimposta",
-  "logRepsTitle": "Registra ripetizioni",
-  "repetitionsLabel": "Ripetizioni",
-  "positiveNumberError": "Inserisci un numero positivo.",
-  "repsChip": "{count} ripetizioni",
-  "@repsChip": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "goalCount": "Obiettivo: {count}",
-  "@goalCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "repGoalReached": "Obiettivo ripetizioni raggiunto!",
-  "pause": "Pausa",
   "start": "Avvia",
-  "seriesCount": "Serie: {count}",
-  "@seriesCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "resetReps": "Azzera ripetizioni",
-  "emomTrackerTitle": "Tracker EMOM",
-  "emomTrackerSubtitle": "Serie ogni minuto con conto alla rovescia.",
-  "emomTrackerDescription": "Configura serie, ripetizioni e intervalli per restare sul ritmo ogni minuto.",
-  "emomSetsLabel": "Serie totali",
-  "emomRepsLabel": "Ripetizioni per serie",
-  "emomIntervalLabel": "Intervallo (secondi)",
-  "emomStartButton": "Avvia EMOM",
-  "emomResetButton": "Reimposta sessione",
-  "emomSessionComplete": "EMOM completato",
-  "emomCurrentSet": "Serie {current} di {total}",
-  "@emomCurrentSet": {
-    "placeholders": {
-      "current": {
-        "type": "int"
-      },
-      "total": {
-        "type": "int"
-      }
-    }
-  },
-  "emomRepsPerSet": "{count} ripetizioni per serie",
-  "@emomRepsPerSet": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "emomFinishedMessage": "Ottimo lavoro! Hai rispettato ogni minuto.",
-  "emomTimeRemainingLabel": "Tempo rimanente in questo minuto",
-  "emomPrepHeadline": "Preparati per la serie {set}",
-  "@emomPrepHeadline": {
-    "placeholders": {
-      "set": {
-        "type": "int"
-      }
-    }
-  },
-  "emomPrepSubhead": "La prossima serie parte alla fine del conto alla rovescia.",
   "timerTitle": "Timer",
   "amrapTimerTitle": "Timer AMRAP",
   "amrapTimerSubtitle": "Spingi per quante più serie possibile.",
@@ -615,13 +353,6 @@
   "countdownSecondsLabel": "Secondi",
   "countdownStartButton": "Avvia timer",
   "countdownResetButton": "Ferma timer",
-  "weekdayMonday": "Lunedì",
-  "weekdayTuesday": "Martedì",
-  "weekdayWednesday": "Mercoledì",
-  "weekdayThursday": "Giovedì",
-  "weekdayFriday": "Venerdì",
-  "weekdaySaturday": "Sabato",
-  "weekdaySunday": "Domenica",
   "weekNumber": "Settimana {week}",
   "@weekNumber": {
     "placeholders": {
@@ -655,47 +386,5 @@
   "termSomTitle": "SOM",
   "termSomDescription": "Indica la durata di ogni fase della ripetizione.",
   "termScaricoTitle": "Scarico",
-  "termScaricoDescription": "Ultima settimana della scheda per prepararsi ai massimali.",
-  "noCameras": "Nessuna fotocamera disponibile",
-  "cameraInitFailed": "Inizializzazione fotocamera fallita: {error}",
-  "@cameraInitFailed": {
-    "placeholders": {
-      "error": {
-        "type": "Object"
-      }
-    }
-  },
-  "poseDetected": "Posa rilevata",
-  "processing": "Elaborazione…",
-  "idle": "In attesa",
-  "cameraFront": "frontale",
-  "cameraBack": "posteriore",
-  "hudMetrics": "fps: {fps}  ms: {milliseconds}  lmks: {landmarks}",
-  "@hudMetrics": {
-    "placeholders": {
-      "fps": {
-        "type": "String"
-      },
-      "milliseconds": {
-        "type": "String"
-      },
-      "landmarks": {
-        "type": "int"
-      }
-    }
-  },
-  "hudOrientation": "rot: {rotation}  cam: {camera}  fmt: {format}",
-  "@hudOrientation": {
-    "placeholders": {
-      "rotation": {
-        "type": "String"
-      },
-      "camera": {
-        "type": "String"
-      },
-      "format": {
-        "type": "String"
-      }
-    }
-  }
+  "termScaricoDescription": "Ultima settimana della scheda per prepararsi ai massimali."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -620,221 +620,41 @@ abstract class AppLocalizations {
   /// **'Sali in verticale contro il muro o in equilibrio libero e mantieni una linea lunga con le punte tese.'**
   String get guidesHandstandDescription;
 
-  /// No description provided for @settingsComingSoon.
-  ///
-  /// In it, this message translates to:
-  /// **'Le impostazioni saranno presto disponibili.'**
-  String get settingsComingSoon;
 
-  /// No description provided for @settingsGeneralSection.
-  ///
-  /// In it, this message translates to:
-  /// **'Generali'**
-  String get settingsGeneralSection;
 
-  /// No description provided for @settingsDailyReminder.
-  ///
-  /// In it, this message translates to:
-  /// **'Promemoria allenamento quotidiano'**
-  String get settingsDailyReminder;
 
-  /// No description provided for @settingsDailyReminderDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Ricevi un promemoria per iniziare ad allenarti ogni giorno.'**
-  String get settingsDailyReminderDescription;
 
-  /// No description provided for @settingsReminderTime.
-  ///
-  /// In it, this message translates to:
-  /// **'Orario promemoria'**
-  String get settingsReminderTime;
 
-  /// No description provided for @settingsReminderNotSet.
-  ///
-  /// In it, this message translates to:
-  /// **'Non impostato'**
-  String get settingsReminderNotSet;
 
-  /// No description provided for @settingsSoundEffects.
-  ///
-  /// In it, this message translates to:
-  /// **'Effetti sonori'**
-  String get settingsSoundEffects;
 
-  /// No description provided for @settingsSoundEffectsDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Riproduci brevi suoni durante la registrazione delle ripetizioni.'**
-  String get settingsSoundEffectsDescription;
 
-  /// No description provided for @settingsHapticFeedback.
-  ///
-  /// In it, this message translates to:
-  /// **'Feedback aptico'**
-  String get settingsHapticFeedback;
 
-  /// No description provided for @settingsHapticFeedbackDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Leggera vibrazione per le azioni importanti.'**
-  String get settingsHapticFeedbackDescription;
 
-  /// No description provided for @settingsTrainingSection.
-  ///
-  /// In it, this message translates to:
-  /// **'Preferenze di allenamento'**
-  String get settingsTrainingSection;
 
-  /// No description provided for @settingsUnitSystem.
-  ///
-  /// In it, this message translates to:
-  /// **'Sistema di unità'**
-  String get settingsUnitSystem;
 
-  /// No description provided for @settingsUnitsMetric.
-  ///
-  /// In it, this message translates to:
-  /// **'Metrico (kg)'**
-  String get settingsUnitsMetric;
 
-  /// No description provided for @settingsUnitsImperial.
-  ///
-  /// In it, this message translates to:
-  /// **'Imperiale (lb)'**
-  String get settingsUnitsImperial;
 
-  /// No description provided for @settingsRestTimer.
-  ///
-  /// In it, this message translates to:
-  /// **'Timer di recupero predefinito'**
-  String get settingsRestTimer;
 
-  /// No description provided for @settingsRestTimerDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Usato quando avvii un timer di recupero dagli allenamenti.'**
-  String get settingsRestTimerDescription;
 
-  /// No description provided for @settingsRestTimerMinutes.
-  ///
-  /// In it, this message translates to:
-  /// **'{count, plural, one {# minuto} other {# minuti}}'**
-  String settingsRestTimerMinutes(int count);
 
-  /// No description provided for @settingsRestTimerMinutesSeconds.
-  ///
-  /// In it, this message translates to:
-  /// **'{minutes, plural, one {# minuto} other {# minuti}} e {seconds, plural, one {# secondo} other {# secondi}}'**
-  String settingsRestTimerMinutesSeconds(int minutes, int seconds);
 
-  /// No description provided for @settingsRestTimerSeconds.
-  ///
-  /// In it, this message translates to:
-  /// **'{count, plural, one {# secondo} other {# secondi}}'**
-  String settingsRestTimerSeconds(int count);
 
-  /// No description provided for @settingsDataSection.
-  ///
-  /// In it, this message translates to:
-  /// **'Dati e privacy'**
-  String get settingsDataSection;
 
-  /// No description provided for @settingsClearCache.
-  ///
-  /// In it, this message translates to:
-  /// **'Cancella allenamenti salvati'**
-  String get settingsClearCache;
 
-  /// No description provided for @settingsClearCacheDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Rimuovi gli allenamenti memorizzati su questo dispositivo.'**
-  String get settingsClearCacheDescription;
 
-  /// No description provided for @settingsClearCacheSuccess.
-  ///
-  /// In it, this message translates to:
-  /// **'Allenamenti locali rimossi.'**
-  String get settingsClearCacheSuccess;
 
-  /// No description provided for @settingsExportData.
-  ///
-  /// In it, this message translates to:
-  /// **'Esporta riepilogo allenamenti'**
-  String get settingsExportData;
 
-  /// No description provided for @settingsExportDataDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Ricevi via email un CSV delle ultime sessioni.'**
-  String get settingsExportDataDescription;
 
-  /// No description provided for @settingsExportDataSuccess.
-  ///
-  /// In it, this message translates to:
-  /// **'Richiesta di esportazione inviata. Controlla la casella di posta a breve.'**
-  String get settingsExportDataSuccess;
 
-  /// No description provided for @settingsSupportSection.
-  ///
-  /// In it, this message translates to:
-  /// **'Supporto'**
-  String get settingsSupportSection;
 
-  /// No description provided for @settingsContactCoach.
-  ///
-  /// In it, this message translates to:
-  /// **'Contatta il tuo coach'**
-  String get settingsContactCoach;
 
-  /// No description provided for @settingsContactCoachDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Invia un messaggio rapido per chiedere modifiche.'**
-  String get settingsContactCoachDescription;
 
-  /// No description provided for @settingsContactCoachHint.
-  ///
-  /// In it, this message translates to:
-  /// **'Dicci come possiamo aiutarti.'**
-  String get settingsContactCoachHint;
 
-  /// No description provided for @settingsContactCoachSuccess.
-  ///
-  /// In it, this message translates to:
-  /// **'Messaggio inviato al coach.'**
-  String get settingsContactCoachSuccess;
 
-  /// No description provided for @settingsSendMessage.
-  ///
-  /// In it, this message translates to:
-  /// **'Invia messaggio'**
-  String get settingsSendMessage;
 
-  /// No description provided for @settingsAppVersion.
-  ///
-  /// In it, this message translates to:
-  /// **'Versione app'**
-  String get settingsAppVersion;
 
-  /// No description provided for @settingsAppVersionValue.
-  ///
-  /// In it, this message translates to:
-  /// **'Versione {version}'**
-  String settingsAppVersionValue(Object version);
 
-  /// No description provided for @exerciseTrackerTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Tracker esercizi'**
-  String get exerciseTrackerTitle;
 
-  /// No description provided for @poseEstimationTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Stima postura'**
-  String get poseEstimationTitle;
 
   /// No description provided for @homeLoadErrorTitle.
   ///
@@ -848,131 +668,26 @@ abstract class AppLocalizations {
   /// **'Riprova'**
   String get retry;
 
-  /// No description provided for @homeCalendarTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Calendario allenamenti'**
-  String get homeCalendarTitle;
 
-  /// No description provided for @homeCalendarSubtitle.
-  ///
-  /// In it, this message translates to:
-  /// **'I giorni di allenamento sono evidenziati.'**
-  String get homeCalendarSubtitle;
 
-  /// No description provided for @homeScheduleTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Focus settimanale'**
-  String get homeScheduleTitle;
 
-  /// No description provided for @homeScheduleSubtitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Rimani sul pezzo con le prossime sessioni.'**
-  String get homeScheduleSubtitle;
 
-  /// No description provided for @homeNextWorkoutTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Prossimo allenamento'**
-  String get homeNextWorkoutTitle;
 
-  /// No description provided for @homeNextWorkoutEmpty.
-  ///
-  /// In it, this message translates to:
-  /// **'Nessun allenamento programmato.'**
-  String get homeNextWorkoutEmpty;
 
-  /// No description provided for @homeWorkoutsThisWeekTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Questa settimana'**
-  String get homeWorkoutsThisWeekTitle;
 
-  /// No description provided for @homeWorkoutsThisMonthTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Questo mese'**
-  String get homeWorkoutsThisMonthTitle;
 
-  /// No description provided for @homePlanProgressTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Progresso complessivo del piano'**
-  String get homePlanProgressTitle;
 
-  /// No description provided for @homePlanProgressCurrentPlan.
-  ///
-  /// In it, this message translates to:
-  /// **'Piano attuale'**
-  String get homePlanProgressCurrentPlan;
 
-  /// No description provided for @homePlanProgressEmpty.
-  ///
-  /// In it, this message translates to:
-  /// **'Nessun progresso del piano da mostrare.'**
-  String get homePlanProgressEmpty;
 
-  /// No description provided for @homePlanProgressValue.
-  ///
-  /// In it, this message translates to:
-  /// **'{completed} di {total} sessioni completate'**
-  String homePlanProgressValue(int completed, int total);
 
-  /// No description provided for @homePlanProgressPercent.
-  ///
-  /// In it, this message translates to:
-  /// **'{percent}% completato'**
-  String homePlanProgressPercent(int percent);
 
-  /// No description provided for @homeUpcomingWeekTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'In arrivo questa settimana'**
-  String get homeUpcomingWeekTitle;
 
-  /// No description provided for @homeUpcomingWeekEmpty.
-  ///
-  /// In it, this message translates to:
-  /// **'Nessuna sessione programmata nei prossimi 7 giorni.'**
-  String get homeUpcomingWeekEmpty;
 
-  /// No description provided for @homeWorkoutPlanTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Piano di allenamento'**
-  String get homeWorkoutPlanTitle;
 
-  /// No description provided for @homeWorkoutPlanSubtitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Rivedi il piano assegnato e le prossime sessioni.'**
-  String get homeWorkoutPlanSubtitle;
 
-  /// No description provided for @homeTraineeFeedbackTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Feedback atleta'**
-  String get homeTraineeFeedbackTitle;
 
-  /// No description provided for @homeTraineeFeedbackSubtitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Condividi aggiornamenti con il tuo coach dopo le sessioni.'**
-  String get homeTraineeFeedbackSubtitle;
 
-  /// No description provided for @homeCoachTipTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Consiglio del coach'**
-  String get homeCoachTipTitle;
 
-  /// No description provided for @homeCoachTipPlaceholder.
-  ///
-  /// In it, this message translates to:
-  /// **'Qui troverai l\'ultimo consiglio del tuo coach.'**
-  String get homeCoachTipPlaceholder;
 
   /// No description provided for @workoutPlanTitle.
   ///
@@ -1004,41 +719,11 @@ abstract class AppLocalizations {
   /// **'Condividi cosa sta andando bene o cosa richiede attenzione.'**
   String get traineeFeedbackQuestionHint;
 
-  /// No description provided for @traineeFeedbackHighlightsLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Punti forti'**
-  String get traineeFeedbackHighlightsLabel;
 
-  /// No description provided for @traineeFeedbackHighlightsHint.
-  ///
-  /// In it, this message translates to:
-  /// **'Cosa è andato bene o ti è piaciuto?'**
-  String get traineeFeedbackHighlightsHint;
 
-  /// No description provided for @traineeFeedbackChallengesLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Difficoltà'**
-  String get traineeFeedbackChallengesLabel;
 
-  /// No description provided for @traineeFeedbackChallengesHint.
-  ///
-  /// In it, this message translates to:
-  /// **'Cosa è stato difficile o da adattare?'**
-  String get traineeFeedbackChallengesHint;
 
-  /// No description provided for @traineeFeedbackNotesLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Note per il coach'**
-  String get traineeFeedbackNotesLabel;
 
-  /// No description provided for @traineeFeedbackNotesHint.
-  ///
-  /// In it, this message translates to:
-  /// **'Hai altro da condividere?'**
-  String get traineeFeedbackNotesHint;
 
   /// No description provided for @traineeFeedbackSubmit.
   ///
@@ -1142,11 +827,6 @@ abstract class AppLocalizations {
   /// **'Esercizio'**
   String get defaultExerciseName;
 
-  /// No description provided for @generalNotes.
-  ///
-  /// In it, this message translates to:
-  /// **'Note generali'**
-  String get generalNotes;
 
   /// No description provided for @trainingHeaderExercise.
   ///
@@ -1166,65 +846,15 @@ abstract class AppLocalizations {
   /// **'Ripetizioni'**
   String get trainingHeaderReps;
 
-  /// No description provided for @trainingHeaderRest.
-  ///
-  /// In it, this message translates to:
-  /// **'Recupero'**
-  String get trainingHeaderRest;
 
-  /// No description provided for @trainingHeaderIntensity.
-  ///
-  /// In it, this message translates to:
-  /// **'Intensità'**
-  String get trainingHeaderIntensity;
 
-  /// No description provided for @trainingHeaderNotes.
-  ///
-  /// In it, this message translates to:
-  /// **'Note'**
-  String get trainingHeaderNotes;
 
-  /// No description provided for @trainingNotesLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Note dell\'esercizio'**
-  String get trainingNotesLabel;
 
-  /// No description provided for @trainingTraineeNotesLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Note del tirocinante'**
-  String get trainingTraineeNotesLabel;
 
-  /// No description provided for @trainingNotesSave.
-  ///
-  /// In it, this message translates to:
-  /// **'Salva note'**
-  String get trainingNotesSave;
 
-  /// No description provided for @trainingNotesSaved.
-  ///
-  /// In it, this message translates to:
-  /// **'Note salvate'**
-  String get trainingNotesSaved;
 
-  /// No description provided for @trainingNotesError.
-  ///
-  /// In it, this message translates to:
-  /// **'Impossibile salvare le note: {error}'**
-  String trainingNotesError(Object error);
 
-  /// No description provided for @trainingNotesUnavailable.
-  ///
-  /// In it, this message translates to:
-  /// **'Impossibile aggiornare le note per questo esercizio.'**
-  String get trainingNotesUnavailable;
 
-  /// No description provided for @trainingOpenTracker.
-  ///
-  /// In it, this message translates to:
-  /// **'Apri tracker'**
-  String get trainingOpenTracker;
 
   /// No description provided for @trainingTodayTitle.
   ///
@@ -1244,17 +874,7 @@ abstract class AppLocalizations {
   /// **'Allenamento completato'**
   String get trainingWorkoutCompleted;
 
-  /// No description provided for @trainingMarkComplete.
-  ///
-  /// In it, this message translates to:
-  /// **'Segna giorno come completato'**
-  String get trainingMarkComplete;
 
-  /// No description provided for @trainingMarkIncomplete.
-  ///
-  /// In it, this message translates to:
-  /// **'Segna giorno come incompleto'**
-  String get trainingMarkIncomplete;
 
   /// No description provided for @trainingCompletionSaved.
   ///
@@ -1274,11 +894,6 @@ abstract class AppLocalizations {
   /// **'Impossibile aggiornare questo giorno di allenamento.'**
   String get trainingCompletionUnavailable;
 
-  /// No description provided for @trainingExerciseCompletedLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Esercizio completato'**
-  String get trainingExerciseCompletedLabel;
 
   /// No description provided for @trainingExerciseCompletionSaved.
   ///
@@ -1364,23 +979,8 @@ abstract class AppLocalizations {
   /// **'Username'**
   String get profileUsername;
 
-  /// No description provided for @profileLastUpdated.
-  ///
-  /// In it, this message translates to:
-  /// **'Ultimo aggiornamento'**
-  String get profileLastUpdated;
 
-  /// No description provided for @profileValueUnavailable.
-  ///
-  /// In it, this message translates to:
-  /// **'Non disponibile'**
-  String get profileValueUnavailable;
 
-  /// No description provided for @profileTimezone.
-  ///
-  /// In it, this message translates to:
-  /// **'Fuso orario'**
-  String get profileTimezone;
 
   /// No description provided for @profileNotSet.
   ///
@@ -1388,11 +988,6 @@ abstract class AppLocalizations {
   /// **'Non impostato'**
   String get profileNotSet;
 
-  /// No description provided for @profileUnitSystem.
-  ///
-  /// In it, this message translates to:
-  /// **'Unità di misura'**
-  String get profileUnitSystem;
 
   /// No description provided for @profileWeight.
   ///
@@ -1658,11 +1253,6 @@ abstract class AppLocalizations {
   /// **'Modifica profilo'**
   String get profileEdit;
 
-  /// No description provided for @profileComingSoon.
-  ///
-  /// In it, this message translates to:
-  /// **'Presto disponibile'**
-  String get profileComingSoon;
 
   /// No description provided for @profileEditSubtitle.
   ///
@@ -1706,41 +1296,11 @@ abstract class AppLocalizations {
   /// **'Inserisci un peso valido e positivo.'**
   String get profileEditWeightInvalid;
 
-  /// No description provided for @profileEditTimezoneLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Fuso orario'**
-  String get profileEditTimezoneLabel;
 
-  /// No description provided for @profileEditTimezoneHint.
-  ///
-  /// In it, this message translates to:
-  /// **'Esempio: Europe/Rome'**
-  String get profileEditTimezoneHint;
 
-  /// No description provided for @profileEditUnitSystemLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Unità di misura preferita'**
-  String get profileEditUnitSystemLabel;
 
-  /// No description provided for @profileEditUnitSystemNotSet.
-  ///
-  /// In it, this message translates to:
-  /// **'Non specificato'**
-  String get profileEditUnitSystemNotSet;
 
-  /// No description provided for @profileEditUnitSystemMetric.
-  ///
-  /// In it, this message translates to:
-  /// **'Metrico (kg, cm)'**
-  String get profileEditUnitSystemMetric;
 
-  /// No description provided for @profileEditUnitSystemImperial.
-  ///
-  /// In it, this message translates to:
-  /// **'Imperiale (lb, in)'**
-  String get profileEditUnitSystemImperial;
 
   /// No description provided for @profileEditCancel.
   ///
@@ -1766,11 +1326,6 @@ abstract class AppLocalizations {
   /// **'Impossibile aggiornare il profilo: {error}'**
   String profileEditError(Object error);
 
-  /// No description provided for @featureUnavailable.
-  ///
-  /// In it, this message translates to:
-  /// **'Funzionalità non ancora disponibile.'**
-  String get featureUnavailable;
 
   /// No description provided for @logout.
   ///
@@ -1934,29 +1489,9 @@ abstract class AppLocalizations {
   /// **'Aggiorna password'**
   String get passwordResetSubmit;
 
-  /// No description provided for @exerciseAddDialogTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Aggiungi esercizio'**
-  String get exerciseAddDialogTitle;
 
-  /// No description provided for @exerciseNameLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Nome esercizio'**
-  String get exerciseNameLabel;
 
-  /// No description provided for @quickAddValuesLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Valori rapidi'**
-  String get quickAddValuesLabel;
 
-  /// No description provided for @quickAddValuesHelper.
-  ///
-  /// In it, this message translates to:
-  /// **'Ripetizioni separate da virgola (es. 1,5,10)'**
-  String get quickAddValuesHelper;
 
   /// No description provided for @cancel.
   ///
@@ -1970,173 +1505,33 @@ abstract class AppLocalizations {
   /// **'Aggiungi'**
   String get add;
 
-  /// No description provided for @save.
-  ///
-  /// In it, this message translates to:
-  /// **'Salva'**
-  String get save;
 
-  /// No description provided for @exerciseNameMissing.
-  ///
-  /// In it, this message translates to:
-  /// **'Inserisci un nome.'**
-  String get exerciseNameMissing;
 
-  /// No description provided for @exerciseTargetRepsLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Ripetizioni obiettivo'**
-  String get exerciseTargetRepsLabel;
 
-  /// No description provided for @exerciseTargetRepsHelper.
-  ///
-  /// In it, this message translates to:
-  /// **'Obiettivo totale opzionale per la sessione'**
-  String get exerciseTargetRepsHelper;
 
-  /// No description provided for @exerciseRestDurationLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Durata recupero (secondi)'**
-  String get exerciseRestDurationLabel;
 
-  /// No description provided for @exerciseRestDurationHelper.
-  ///
-  /// In it, this message translates to:
-  /// **'Preset opzionale per il conto alla rovescia'**
-  String get exerciseRestDurationHelper;
 
-  /// No description provided for @exerciseTrackerEmpty.
-  ///
-  /// In it, this message translates to:
-  /// **'Ancora nessun esercizio. Tocca + per aggiungerne uno!'**
-  String get exerciseTrackerEmpty;
 
-  /// No description provided for @exerciseAddButton.
-  ///
-  /// In it, this message translates to:
-  /// **'Aggiungi esercizio'**
-  String get exerciseAddButton;
 
-  /// No description provided for @exercisePushUps.
-  ///
-  /// In it, this message translates to:
-  /// **'Push-up'**
-  String get exercisePushUps;
 
-  /// No description provided for @exercisePullUps.
-  ///
-  /// In it, this message translates to:
-  /// **'Trazioni alla sbarra'**
-  String get exercisePullUps;
 
-  /// No description provided for @exerciseChinUps.
-  ///
-  /// In it, this message translates to:
-  /// **'Trazioni a presa inversa'**
-  String get exerciseChinUps;
 
-  /// No description provided for @exerciseTotalReps.
-  ///
-  /// In it, this message translates to:
-  /// **'{count} ripetizioni totali'**
-  String exerciseTotalReps(int count);
 
-  /// No description provided for @exerciseGoalProgress.
-  ///
-  /// In it, this message translates to:
-  /// **'{logged} / {goal} ripetizioni registrate'**
-  String exerciseGoalProgress(int logged, int goal);
 
-  /// No description provided for @exerciseRestFinished.
-  ///
-  /// In it, this message translates to:
-  /// **'Recupero terminato per {exercise}!'**
-  String exerciseRestFinished(String exercise);
 
-  /// No description provided for @exerciseSetRestDuration.
-  ///
-  /// In it, this message translates to:
-  /// **'Imposta durata recupero'**
-  String get exerciseSetRestDuration;
 
-  /// No description provided for @exerciseDurationSecondsLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Durata (secondi)'**
-  String get exerciseDurationSecondsLabel;
 
-  /// No description provided for @restTimerLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Timer di recupero'**
-  String get restTimerLabel;
 
-  /// No description provided for @setDuration.
-  ///
-  /// In it, this message translates to:
-  /// **'Imposta durata'**
-  String get setDuration;
 
-  /// No description provided for @undoLastSet.
-  ///
-  /// In it, this message translates to:
-  /// **'Annulla ultima serie'**
-  String get undoLastSet;
 
-  /// No description provided for @custom.
-  ///
-  /// In it, this message translates to:
-  /// **'Personalizzato'**
-  String get custom;
 
-  /// No description provided for @reset.
-  ///
-  /// In it, this message translates to:
-  /// **'Reimposta'**
-  String get reset;
 
-  /// No description provided for @logRepsTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Registra ripetizioni'**
-  String get logRepsTitle;
 
-  /// No description provided for @repetitionsLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Ripetizioni'**
-  String get repetitionsLabel;
 
-  /// No description provided for @positiveNumberError.
-  ///
-  /// In it, this message translates to:
-  /// **'Inserisci un numero positivo.'**
-  String get positiveNumberError;
 
-  /// No description provided for @repsChip.
-  ///
-  /// In it, this message translates to:
-  /// **'{count} ripetizioni'**
-  String repsChip(int count);
 
-  /// No description provided for @goalCount.
-  ///
-  /// In it, this message translates to:
-  /// **'Obiettivo: {count}'**
-  String goalCount(int count);
 
-  /// No description provided for @repGoalReached.
-  ///
-  /// In it, this message translates to:
-  /// **'Obiettivo ripetizioni raggiunto!'**
-  String get repGoalReached;
 
-  /// No description provided for @pause.
-  ///
-  /// In it, this message translates to:
-  /// **'Pausa'**
-  String get pause;
 
   /// No description provided for @start.
   ///
@@ -2144,107 +1539,22 @@ abstract class AppLocalizations {
   /// **'Avvia'**
   String get start;
 
-  /// No description provided for @seriesCount.
-  ///
-  /// In it, this message translates to:
-  /// **'Serie: {count}'**
-  String seriesCount(int count);
 
-  /// No description provided for @resetReps.
-  ///
-  /// In it, this message translates to:
-  /// **'Azzera ripetizioni'**
-  String get resetReps;
 
-  /// No description provided for @emomTrackerTitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Tracker EMOM'**
-  String get emomTrackerTitle;
 
-  /// No description provided for @emomTrackerSubtitle.
-  ///
-  /// In it, this message translates to:
-  /// **'Serie ogni minuto con conto alla rovescia.'**
-  String get emomTrackerSubtitle;
 
-  /// No description provided for @emomTrackerDescription.
-  ///
-  /// In it, this message translates to:
-  /// **'Configura serie, ripetizioni e intervalli per restare sul ritmo ogni minuto.'**
-  String get emomTrackerDescription;
 
-  /// No description provided for @emomSetsLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Serie totali'**
-  String get emomSetsLabel;
 
-  /// No description provided for @emomRepsLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Ripetizioni per serie'**
-  String get emomRepsLabel;
 
-  /// No description provided for @emomIntervalLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Intervallo (secondi)'**
-  String get emomIntervalLabel;
 
-  /// No description provided for @emomStartButton.
-  ///
-  /// In it, this message translates to:
-  /// **'Avvia EMOM'**
-  String get emomStartButton;
 
-  /// No description provided for @emomResetButton.
-  ///
-  /// In it, this message translates to:
-  /// **'Reimposta sessione'**
-  String get emomResetButton;
 
-  /// No description provided for @emomSessionComplete.
-  ///
-  /// In it, this message translates to:
-  /// **'EMOM completato'**
-  String get emomSessionComplete;
 
-  /// No description provided for @emomCurrentSet.
-  ///
-  /// In it, this message translates to:
-  /// **'Serie {current} di {total}'**
-  String emomCurrentSet(int current, int total);
 
-  /// No description provided for @emomRepsPerSet.
-  ///
-  /// In it, this message translates to:
-  /// **'{count} ripetizioni per serie'**
-  String emomRepsPerSet(int count);
 
-  /// No description provided for @emomFinishedMessage.
-  ///
-  /// In it, this message translates to:
-  /// **'Ottimo lavoro! Hai rispettato ogni minuto.'**
-  String get emomFinishedMessage;
 
-  /// No description provided for @emomTimeRemainingLabel.
-  ///
-  /// In it, this message translates to:
-  /// **'Tempo rimanente in questo minuto'**
-  String get emomTimeRemainingLabel;
 
-  /// No description provided for @emomPrepHeadline.
-  ///
-  /// In it, this message translates to:
-  /// **'Preparati per la serie {set}'**
-  String emomPrepHeadline(int set);
 
-  /// No description provided for @emomPrepSubhead.
-  ///
-  /// In it, this message translates to:
-  /// **'La prossima serie parte alla fine del conto alla rovescia.'**
-  String get emomPrepSubhead;
 
   /// No description provided for @timerTitle.
   ///
@@ -2336,47 +1646,12 @@ abstract class AppLocalizations {
   /// **'Ferma timer'**
   String get countdownResetButton;
 
-  /// No description provided for @weekdayMonday.
-  ///
-  /// In it, this message translates to:
-  /// **'Lunedì'**
-  String get weekdayMonday;
 
-  /// No description provided for @weekdayTuesday.
-  ///
-  /// In it, this message translates to:
-  /// **'Martedì'**
-  String get weekdayTuesday;
 
-  /// No description provided for @weekdayWednesday.
-  ///
-  /// In it, this message translates to:
-  /// **'Mercoledì'**
-  String get weekdayWednesday;
 
-  /// No description provided for @weekdayThursday.
-  ///
-  /// In it, this message translates to:
-  /// **'Giovedì'**
-  String get weekdayThursday;
 
-  /// No description provided for @weekdayFriday.
-  ///
-  /// In it, this message translates to:
-  /// **'Venerdì'**
-  String get weekdayFriday;
 
-  /// No description provided for @weekdaySaturday.
-  ///
-  /// In it, this message translates to:
-  /// **'Sabato'**
-  String get weekdaySaturday;
 
-  /// No description provided for @weekdaySunday.
-  ///
-  /// In it, this message translates to:
-  /// **'Domenica'**
-  String get weekdaySunday;
 
   /// No description provided for @weekNumber.
   ///
@@ -2540,59 +1815,14 @@ abstract class AppLocalizations {
   /// **'Ultima settimana della scheda per prepararsi ai massimali.'**
   String get termScaricoDescription;
 
-  /// No description provided for @noCameras.
-  ///
-  /// In it, this message translates to:
-  /// **'Nessuna fotocamera disponibile'**
-  String get noCameras;
 
-  /// No description provided for @cameraInitFailed.
-  ///
-  /// In it, this message translates to:
-  /// **'Inizializzazione fotocamera fallita: {error}'**
-  String cameraInitFailed(Object error);
 
-  /// No description provided for @poseDetected.
-  ///
-  /// In it, this message translates to:
-  /// **'Posa rilevata'**
-  String get poseDetected;
 
-  /// No description provided for @processing.
-  ///
-  /// In it, this message translates to:
-  /// **'Elaborazione…'**
-  String get processing;
 
-  /// No description provided for @idle.
-  ///
-  /// In it, this message translates to:
-  /// **'In attesa'**
-  String get idle;
 
-  /// No description provided for @cameraFront.
-  ///
-  /// In it, this message translates to:
-  /// **'frontale'**
-  String get cameraFront;
 
-  /// No description provided for @cameraBack.
-  ///
-  /// In it, this message translates to:
-  /// **'posteriore'**
-  String get cameraBack;
 
-  /// No description provided for @hudMetrics.
-  ///
-  /// In it, this message translates to:
-  /// **'fps: {fps}  ms: {milliseconds}  lmks: {landmarks}'**
-  String hudMetrics(String fps, String milliseconds, int landmarks);
 
-  /// No description provided for @hudOrientation.
-  ///
-  /// In it, this message translates to:
-  /// **'rot: {rotation}  cam: {camera}  fmt: {format}'**
-  String hudOrientation(String rotation, String camera, String format);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -304,230 +304,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Kick or press up to a wall or free balance and hold a tall line with toes pointed.';
 
   @override
-  String get settingsComingSoon => 'Settings coming soon.';
-
-  @override
-  String get settingsGeneralSection => 'General';
-
-  @override
-  String get settingsDailyReminder => 'Daily workout reminder';
-
-  @override
-  String get settingsDailyReminderDescription =>
-      'Get a gentle nudge to start training each day.';
-
-  @override
-  String get settingsReminderTime => 'Reminder time';
-
-  @override
-  String get settingsReminderNotSet => 'Not set';
-
-  @override
-  String get settingsSoundEffects => 'Sound effects';
-
-  @override
-  String get settingsSoundEffectsDescription =>
-      'Play short sounds when logging repetitions.';
-
-  @override
-  String get settingsHapticFeedback => 'Haptic feedback';
-
-  @override
-  String get settingsHapticFeedbackDescription =>
-      'Vibrate briefly on important actions.';
-
-  @override
-  String get settingsTrainingSection => 'Training preferences';
-
-  @override
-  String get settingsUnitSystem => 'Unit system';
-
-  @override
-  String get settingsUnitsMetric => 'Metric (kg)';
-
-  @override
-  String get settingsUnitsImperial => 'Imperial (lb)';
-
-  @override
-  String get settingsRestTimer => 'Default rest timer';
-
-  @override
-  String get settingsRestTimerDescription =>
-      'Used when starting a rest timer from workouts.';
-
-  @override
-  String settingsRestTimerMinutes(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '# minutes',
-      one: '# minute',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String settingsRestTimerMinutesSeconds(int minutes, int seconds) {
-    String _temp0 = intl.Intl.pluralLogic(
-      minutes,
-      locale: localeName,
-      other: '# minutes',
-      one: '# minute',
-    );
-    String _temp1 = intl.Intl.pluralLogic(
-      seconds,
-      locale: localeName,
-      other: '# seconds',
-      one: '# second',
-    );
-    return '$_temp0 and $_temp1';
-  }
-
-  @override
-  String settingsRestTimerSeconds(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '# seconds',
-      one: '# second',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get settingsDataSection => 'Data & privacy';
-
-  @override
-  String get settingsClearCache => 'Clear cached workouts';
-
-  @override
-  String get settingsClearCacheDescription =>
-      'Remove workouts saved on this device.';
-
-  @override
-  String get settingsClearCacheSuccess => 'Local workouts cleared.';
-
-  @override
-  String get settingsExportData => 'Export training summary';
-
-  @override
-  String get settingsExportDataDescription =>
-      'Receive a CSV of your recent sessions via email.';
-
-  @override
-  String get settingsExportDataSuccess =>
-      'Export request submitted. Check your inbox soon.';
-
-  @override
-  String get settingsSupportSection => 'Support';
-
-  @override
-  String get settingsContactCoach => 'Contact your coach';
-
-  @override
-  String get settingsContactCoachDescription =>
-      'Send a quick message for adjustments.';
-
-  @override
-  String get settingsContactCoachHint => 'Let us know how we can help.';
-
-  @override
-  String get settingsContactCoachSuccess => 'Message sent to your coach.';
-
-  @override
-  String get settingsSendMessage => 'Send message';
-
-  @override
-  String get settingsAppVersion => 'App version';
-
-  @override
-  String settingsAppVersionValue(Object version) {
-    return 'Version $version';
-  }
-
-  @override
-  String get exerciseTrackerTitle => 'Exercise tracker';
-
-  @override
-  String get poseEstimationTitle => 'Pose estimation';
-
-  @override
   String get homeLoadErrorTitle => 'Unable to load workouts';
 
   @override
   String get retry => 'Retry';
-
-  @override
-  String get homeCalendarTitle => 'Workout calendar';
-
-  @override
-  String get homeCalendarSubtitle => 'Workout days are highlighted.';
-
-  @override
-  String get homeScheduleTitle => 'Weekly focus';
-
-  @override
-  String get homeScheduleSubtitle =>
-      'Stay on track with your upcoming sessions.';
-
-  @override
-  String get homeNextWorkoutTitle => 'Next workout';
-
-  @override
-  String get homeNextWorkoutEmpty => 'No scheduled workouts yet.';
-
-  @override
-  String get homeWorkoutsThisWeekTitle => 'This week';
-
-  @override
-  String get homeWorkoutsThisMonthTitle => 'This month';
-
-  @override
-  String get homePlanProgressTitle => 'Overall plan progress';
-
-  @override
-  String get homePlanProgressCurrentPlan => 'Current plan';
-
-  @override
-  String get homePlanProgressEmpty => 'No plan progress to show yet.';
-
-  @override
-  String homePlanProgressValue(int completed, int total) {
-    return '$completed of $total sessions completed';
-  }
-
-  @override
-  String homePlanProgressPercent(int percent) {
-    return '$percent% complete';
-  }
-
-  @override
-  String get homeUpcomingWeekTitle => 'Coming up this week';
-
-  @override
-  String get homeUpcomingWeekEmpty =>
-      'No sessions scheduled for the next 7 days.';
-
-  @override
-  String get homeWorkoutPlanTitle => 'Workout plan';
-
-  @override
-  String get homeWorkoutPlanSubtitle =>
-      'Review your assigned plan and upcoming sessions.';
-
-  @override
-  String get homeTraineeFeedbackTitle => 'Trainee feedback';
-
-  @override
-  String get homeTraineeFeedbackSubtitle =>
-      'Share updates with your coach after sessions.';
-
-  @override
-  String get homeCoachTipTitle => 'Coach tip';
-
-  @override
-  String get homeCoachTipPlaceholder =>
-      'Your coach\'s latest tip will appear here.';
 
   @override
   String get workoutPlanTitle => 'Workout plan';
@@ -545,25 +325,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get traineeFeedbackQuestionHint =>
       'Share anything going well or that needs attention.';
-
-  @override
-  String get traineeFeedbackHighlightsLabel => 'Highlights';
-
-  @override
-  String get traineeFeedbackHighlightsHint => 'What felt good or went well?';
-
-  @override
-  String get traineeFeedbackChallengesLabel => 'Challenges';
-
-  @override
-  String get traineeFeedbackChallengesHint =>
-      'What felt difficult or needs adjustment?';
-
-  @override
-  String get traineeFeedbackNotesLabel => 'Coach notes';
-
-  @override
-  String get traineeFeedbackNotesHint => 'Anything else to share?';
 
   @override
   String get traineeFeedbackSubmit => 'Send feedback';
@@ -623,9 +384,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get defaultExerciseName => 'Exercise';
 
   @override
-  String get generalNotes => 'General notes';
-
-  @override
   String get trainingHeaderExercise => 'Exercise';
 
   @override
@@ -633,39 +391,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get trainingHeaderReps => 'Repetitions';
-
-  @override
-  String get trainingHeaderRest => 'Rest';
-
-  @override
-  String get trainingHeaderIntensity => 'Intensity';
-
-  @override
-  String get trainingHeaderNotes => 'Notes';
-
-  @override
-  String get trainingNotesLabel => 'Exercise notes';
-
-  @override
-  String get trainingTraineeNotesLabel => 'Trainee notes';
-
-  @override
-  String get trainingNotesSave => 'Save notes';
-
-  @override
-  String get trainingNotesSaved => 'Notes saved';
-
-  @override
-  String trainingNotesError(Object error) {
-    return 'Unable to save notes: $error';
-  }
-
-  @override
-  String get trainingNotesUnavailable =>
-      'Cannot update notes for this exercise.';
-
-  @override
-  String get trainingOpenTracker => 'Open tracker';
 
   @override
   String get trainingTodayTitle => 'Today\'s Workout';
@@ -677,12 +402,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trainingWorkoutCompleted => 'Workout Completed';
 
   @override
-  String get trainingMarkComplete => 'Mark day as complete';
-
-  @override
-  String get trainingMarkIncomplete => 'Mark day as incomplete';
-
-  @override
   String get trainingCompletionSaved => 'Workout day updated';
 
   @override
@@ -692,9 +411,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get trainingCompletionUnavailable => 'Cannot update this workout day.';
-
-  @override
-  String get trainingExerciseCompletedLabel => 'Exercise completed';
 
   @override
   String get trainingExerciseCompletionSaved => 'Exercise updated';
@@ -744,19 +460,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileUsername => 'Username';
 
   @override
-  String get profileLastUpdated => 'Last updated';
-
-  @override
-  String get profileValueUnavailable => 'Not available';
-
-  @override
-  String get profileTimezone => 'Time zone';
-
-  @override
   String get profileNotSet => 'Not set';
-
-  @override
-  String get profileUnitSystem => 'Unit system';
 
   @override
   String get profileWeight => 'Weight';
@@ -913,9 +617,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileEdit => 'Edit profile';
 
   @override
-  String get profileComingSoon => 'Coming soon';
-
-  @override
   String get profileEditSubtitle => 'Update your personal details';
 
   @override
@@ -937,24 +638,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileEditWeightInvalid => 'Enter a valid positive weight.';
 
   @override
-  String get profileEditTimezoneLabel => 'Time zone';
-
-  @override
-  String get profileEditTimezoneHint => 'Example: Europe/Rome';
-
-  @override
-  String get profileEditUnitSystemLabel => 'Preferred unit system';
-
-  @override
-  String get profileEditUnitSystemNotSet => 'Not specified';
-
-  @override
-  String get profileEditUnitSystemMetric => 'Metric (kg, cm)';
-
-  @override
-  String get profileEditUnitSystemImperial => 'Imperial (lb, in)';
-
-  @override
   String get profileEditCancel => 'Cancel';
 
   @override
@@ -967,9 +650,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String profileEditError(Object error) {
     return 'Unable to update profile: $error';
   }
-
-  @override
-  String get featureUnavailable => 'Feature not available yet.';
 
   @override
   String get logout => 'Log out';
@@ -1066,181 +746,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get passwordResetSubmit => 'Update password';
 
   @override
-  String get exerciseAddDialogTitle => 'Add exercise';
-
-  @override
-  String get exerciseNameLabel => 'Exercise name';
-
-  @override
-  String get quickAddValuesLabel => 'Quick add values';
-
-  @override
-  String get quickAddValuesHelper =>
-      'Comma separated repetitions (e.g. 1,5,10)';
-
-  @override
   String get cancel => 'Cancel';
 
   @override
   String get add => 'Add';
 
   @override
-  String get save => 'Save';
-
-  @override
-  String get exerciseNameMissing => 'Please provide a name.';
-
-  @override
-  String get exerciseTargetRepsLabel => 'Target reps';
-
-  @override
-  String get exerciseTargetRepsHelper => 'Optional total goal for the session';
-
-  @override
-  String get exerciseRestDurationLabel => 'Rest duration (seconds)';
-
-  @override
-  String get exerciseRestDurationHelper => 'Optional countdown timer preset';
-
-  @override
-  String get exerciseTrackerEmpty => 'No exercises yet. Tap + to add one!';
-
-  @override
-  String get exerciseAddButton => 'Add exercise';
-
-  @override
-  String get exercisePushUps => 'Push-ups';
-
-  @override
-  String get exercisePullUps => 'Pull-ups';
-
-  @override
-  String get exerciseChinUps => 'Chin-ups';
-
-  @override
-  String exerciseTotalReps(int count) {
-    return '$count total reps';
-  }
-
-  @override
-  String exerciseGoalProgress(int logged, int goal) {
-    return '$logged / $goal reps logged';
-  }
-
-  @override
-  String exerciseRestFinished(String exercise) {
-    return 'Rest finished for $exercise!';
-  }
-
-  @override
-  String get exerciseSetRestDuration => 'Set rest duration';
-
-  @override
-  String get exerciseDurationSecondsLabel => 'Duration (seconds)';
-
-  @override
-  String get restTimerLabel => 'Rest timer';
-
-  @override
-  String get setDuration => 'Set duration';
-
-  @override
-  String get undoLastSet => 'Undo last set';
-
-  @override
-  String get custom => 'Custom';
-
-  @override
-  String get reset => 'Reset';
-
-  @override
-  String get logRepsTitle => 'Log reps';
-
-  @override
-  String get repetitionsLabel => 'Repetitions';
-
-  @override
-  String get positiveNumberError => 'Enter a positive number.';
-
-  @override
-  String repsChip(int count) {
-    return '$count reps';
-  }
-
-  @override
-  String goalCount(int count) {
-    return 'Goal: $count';
-  }
-
-  @override
-  String get repGoalReached => 'Rep goal reached!';
-
-  @override
-  String get pause => 'Pause';
-
-  @override
   String get start => 'Start';
-
-  @override
-  String seriesCount(int count) {
-    return 'Sets: $count';
-  }
-
-  @override
-  String get resetReps => 'Reset reps';
-
-  @override
-  String get emomTrackerTitle => 'EMOM tracker';
-
-  @override
-  String get emomTrackerSubtitle =>
-      'Guided every-minute sets with prep countdown.';
-
-  @override
-  String get emomTrackerDescription =>
-      'Configure sets, reps, and intervals to stay on pace each minute.';
-
-  @override
-  String get emomSetsLabel => 'Total sets';
-
-  @override
-  String get emomRepsLabel => 'Reps per set';
-
-  @override
-  String get emomIntervalLabel => 'Interval (seconds)';
-
-  @override
-  String get emomStartButton => 'Start EMOM';
-
-  @override
-  String get emomResetButton => 'Reset session';
-
-  @override
-  String get emomSessionComplete => 'EMOM complete';
-
-  @override
-  String emomCurrentSet(int current, int total) {
-    return 'Set $current of $total';
-  }
-
-  @override
-  String emomRepsPerSet(int count) {
-    return '$count reps per set';
-  }
-
-  @override
-  String get emomFinishedMessage => 'Nice work! You hit every minute.';
-
-  @override
-  String get emomTimeRemainingLabel => 'Time remaining this minute';
-
-  @override
-  String emomPrepHeadline(int set) {
-    return 'Get ready for set $set';
-  }
-
-  @override
-  String get emomPrepSubhead => 'The next set starts after this countdown.';
 
   @override
   String get timerTitle => 'Timer';
@@ -1288,27 +800,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get countdownResetButton => 'Stop timer';
-
-  @override
-  String get weekdayMonday => 'Monday';
-
-  @override
-  String get weekdayTuesday => 'Tuesday';
-
-  @override
-  String get weekdayWednesday => 'Wednesday';
-
-  @override
-  String get weekdayThursday => 'Thursday';
-
-  @override
-  String get weekdayFriday => 'Friday';
-
-  @override
-  String get weekdaySaturday => 'Saturday';
-
-  @override
-  String get weekdaySunday => 'Sunday';
 
   @override
   String weekNumber(int week) {
@@ -1404,37 +895,3 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get termScaricoDescription =>
       'Last week of the program to prepare for max attempts.';
-
-  @override
-  String get noCameras => 'No cameras available';
-
-  @override
-  String cameraInitFailed(Object error) {
-    return 'Camera init failed: $error';
-  }
-
-  @override
-  String get poseDetected => 'Pose detected';
-
-  @override
-  String get processing => 'Processing…';
-
-  @override
-  String get idle => 'Idle';
-
-  @override
-  String get cameraFront => 'front';
-
-  @override
-  String get cameraBack => 'back';
-
-  @override
-  String hudMetrics(String fps, String milliseconds, int landmarks) {
-    return 'fps: $fps  ms: $milliseconds  lmks: $landmarks';
-  }
-
-  @override
-  String hudOrientation(String rotation, String camera, String format) {
-    return 'rot: $rotation  cam: $camera  fmt: $format';
-  }
-}

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -307,232 +307,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Sali in verticale contro il muro o in equilibrio libero e mantieni una linea lunga con le punte tese.';
 
   @override
-  String get settingsComingSoon =>
-      'Le impostazioni saranno presto disponibili.';
-
-  @override
-  String get settingsGeneralSection => 'Generali';
-
-  @override
-  String get settingsDailyReminder => 'Promemoria allenamento quotidiano';
-
-  @override
-  String get settingsDailyReminderDescription =>
-      'Ricevi un promemoria per iniziare ad allenarti ogni giorno.';
-
-  @override
-  String get settingsReminderTime => 'Orario promemoria';
-
-  @override
-  String get settingsReminderNotSet => 'Non impostato';
-
-  @override
-  String get settingsSoundEffects => 'Effetti sonori';
-
-  @override
-  String get settingsSoundEffectsDescription =>
-      'Riproduci brevi suoni durante la registrazione delle ripetizioni.';
-
-  @override
-  String get settingsHapticFeedback => 'Feedback aptico';
-
-  @override
-  String get settingsHapticFeedbackDescription =>
-      'Leggera vibrazione per le azioni importanti.';
-
-  @override
-  String get settingsTrainingSection => 'Preferenze di allenamento';
-
-  @override
-  String get settingsUnitSystem => 'Sistema di unità';
-
-  @override
-  String get settingsUnitsMetric => 'Metrico (kg)';
-
-  @override
-  String get settingsUnitsImperial => 'Imperiale (lb)';
-
-  @override
-  String get settingsRestTimer => 'Timer di recupero predefinito';
-
-  @override
-  String get settingsRestTimerDescription =>
-      'Usato quando avvii un timer di recupero dagli allenamenti.';
-
-  @override
-  String settingsRestTimerMinutes(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '# minuti',
-      one: '# minuto',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String settingsRestTimerMinutesSeconds(int minutes, int seconds) {
-    String _temp0 = intl.Intl.pluralLogic(
-      minutes,
-      locale: localeName,
-      other: '# minuti',
-      one: '# minuto',
-    );
-    String _temp1 = intl.Intl.pluralLogic(
-      seconds,
-      locale: localeName,
-      other: '# secondi',
-      one: '# secondo',
-    );
-    return '$_temp0 e $_temp1';
-  }
-
-  @override
-  String settingsRestTimerSeconds(int count) {
-    String _temp0 = intl.Intl.pluralLogic(
-      count,
-      locale: localeName,
-      other: '# secondi',
-      one: '# secondo',
-    );
-    return '$_temp0';
-  }
-
-  @override
-  String get settingsDataSection => 'Dati e privacy';
-
-  @override
-  String get settingsClearCache => 'Cancella allenamenti salvati';
-
-  @override
-  String get settingsClearCacheDescription =>
-      'Rimuovi gli allenamenti memorizzati su questo dispositivo.';
-
-  @override
-  String get settingsClearCacheSuccess => 'Allenamenti locali rimossi.';
-
-  @override
-  String get settingsExportData => 'Esporta riepilogo allenamenti';
-
-  @override
-  String get settingsExportDataDescription =>
-      'Ricevi via email un CSV delle ultime sessioni.';
-
-  @override
-  String get settingsExportDataSuccess =>
-      'Richiesta di esportazione inviata. Controlla la casella di posta a breve.';
-
-  @override
-  String get settingsSupportSection => 'Supporto';
-
-  @override
-  String get settingsContactCoach => 'Contatta il tuo coach';
-
-  @override
-  String get settingsContactCoachDescription =>
-      'Invia un messaggio rapido per chiedere modifiche.';
-
-  @override
-  String get settingsContactCoachHint => 'Dicci come possiamo aiutarti.';
-
-  @override
-  String get settingsContactCoachSuccess => 'Messaggio inviato al coach.';
-
-  @override
-  String get settingsSendMessage => 'Invia messaggio';
-
-  @override
-  String get settingsAppVersion => 'Versione app';
-
-  @override
-  String settingsAppVersionValue(Object version) {
-    return 'Versione $version';
-  }
-
-  @override
-  String get exerciseTrackerTitle => 'Tracker esercizi';
-
-  @override
-  String get poseEstimationTitle => 'Stima postura';
-
-  @override
   String get homeLoadErrorTitle => 'Impossibile caricare gli allenamenti';
 
   @override
   String get retry => 'Riprova';
-
-  @override
-  String get homeCalendarTitle => 'Calendario allenamenti';
-
-  @override
-  String get homeCalendarSubtitle =>
-      'I giorni di allenamento sono evidenziati.';
-
-  @override
-  String get homeScheduleTitle => 'Focus settimanale';
-
-  @override
-  String get homeScheduleSubtitle =>
-      'Rimani sul pezzo con le prossime sessioni.';
-
-  @override
-  String get homeNextWorkoutTitle => 'Prossimo allenamento';
-
-  @override
-  String get homeNextWorkoutEmpty => 'Nessun allenamento programmato.';
-
-  @override
-  String get homeWorkoutsThisWeekTitle => 'Questa settimana';
-
-  @override
-  String get homeWorkoutsThisMonthTitle => 'Questo mese';
-
-  @override
-  String get homePlanProgressTitle => 'Progresso complessivo del piano';
-
-  @override
-  String get homePlanProgressCurrentPlan => 'Piano attuale';
-
-  @override
-  String get homePlanProgressEmpty => 'Nessun progresso del piano da mostrare.';
-
-  @override
-  String homePlanProgressValue(int completed, int total) {
-    return '$completed di $total sessioni completate';
-  }
-
-  @override
-  String homePlanProgressPercent(int percent) {
-    return '$percent% completato';
-  }
-
-  @override
-  String get homeUpcomingWeekTitle => 'In arrivo questa settimana';
-
-  @override
-  String get homeUpcomingWeekEmpty =>
-      'Nessuna sessione programmata nei prossimi 7 giorni.';
-
-  @override
-  String get homeWorkoutPlanTitle => 'Piano di allenamento';
-
-  @override
-  String get homeWorkoutPlanSubtitle =>
-      'Rivedi il piano assegnato e le prossime sessioni.';
-
-  @override
-  String get homeTraineeFeedbackTitle => 'Feedback atleta';
-
-  @override
-  String get homeTraineeFeedbackSubtitle =>
-      'Condividi aggiornamenti con il tuo coach dopo le sessioni.';
-
-  @override
-  String get homeCoachTipTitle => 'Consiglio del coach';
-
-  @override
-  String get homeCoachTipPlaceholder =>
-      'Qui troverai l\'ultimo consiglio del tuo coach.';
 
   @override
   String get workoutPlanTitle => 'Piano di allenamento';
@@ -550,26 +328,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get traineeFeedbackQuestionHint =>
       'Condividi cosa sta andando bene o cosa richiede attenzione.';
-
-  @override
-  String get traineeFeedbackHighlightsLabel => 'Punti forti';
-
-  @override
-  String get traineeFeedbackHighlightsHint =>
-      'Cosa è andato bene o ti è piaciuto?';
-
-  @override
-  String get traineeFeedbackChallengesLabel => 'Difficoltà';
-
-  @override
-  String get traineeFeedbackChallengesHint =>
-      'Cosa è stato difficile o da adattare?';
-
-  @override
-  String get traineeFeedbackNotesLabel => 'Note per il coach';
-
-  @override
-  String get traineeFeedbackNotesHint => 'Hai altro da condividere?';
 
   @override
   String get traineeFeedbackSubmit => 'Invia feedback';
@@ -629,9 +387,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get defaultExerciseName => 'Esercizio';
 
   @override
-  String get generalNotes => 'Note generali';
-
-  @override
   String get trainingHeaderExercise => 'Esercizio';
 
   @override
@@ -641,39 +396,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trainingHeaderReps => 'Ripetizioni';
 
   @override
-  String get trainingHeaderRest => 'Recupero';
-
-  @override
-  String get trainingHeaderIntensity => 'Intensità';
-
-  @override
-  String get trainingHeaderNotes => 'Note';
-
-  @override
-  String get trainingNotesLabel => 'Note dell\'esercizio';
-
-  @override
-  String get trainingTraineeNotesLabel => 'Note del tirocinante';
-
-  @override
-  String get trainingNotesSave => 'Salva note';
-
-  @override
-  String get trainingNotesSaved => 'Note salvate';
-
-  @override
-  String trainingNotesError(Object error) {
-    return 'Impossibile salvare le note: $error';
-  }
-
-  @override
-  String get trainingNotesUnavailable =>
-      'Impossibile aggiornare le note per questo esercizio.';
-
-  @override
-  String get trainingOpenTracker => 'Apri tracker';
-
-  @override
   String get trainingTodayTitle => 'Allenamento di oggi';
 
   @override
@@ -681,12 +403,6 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get trainingWorkoutCompleted => 'Allenamento completato';
-
-  @override
-  String get trainingMarkComplete => 'Segna giorno come completato';
-
-  @override
-  String get trainingMarkIncomplete => 'Segna giorno come incompleto';
 
   @override
   String get trainingCompletionSaved => 'Allenamento aggiornato';
@@ -699,9 +415,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get trainingCompletionUnavailable =>
       'Impossibile aggiornare questo giorno di allenamento.';
-
-  @override
-  String get trainingExerciseCompletedLabel => 'Esercizio completato';
 
   @override
   String get trainingExerciseCompletionSaved => 'Esercizio aggiornato';
@@ -751,19 +464,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileUsername => 'Username';
 
   @override
-  String get profileLastUpdated => 'Ultimo aggiornamento';
-
-  @override
-  String get profileValueUnavailable => 'Non disponibile';
-
-  @override
-  String get profileTimezone => 'Fuso orario';
-
-  @override
   String get profileNotSet => 'Non impostato';
-
-  @override
-  String get profileUnitSystem => 'Unità di misura';
 
   @override
   String get profileWeight => 'Peso';
@@ -921,9 +622,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileEdit => 'Modifica profilo';
 
   @override
-  String get profileComingSoon => 'Presto disponibile';
-
-  @override
   String get profileEditSubtitle => 'Aggiorna le tue informazioni personali';
 
   @override
@@ -945,24 +643,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileEditWeightInvalid => 'Inserisci un peso valido e positivo.';
 
   @override
-  String get profileEditTimezoneLabel => 'Fuso orario';
-
-  @override
-  String get profileEditTimezoneHint => 'Esempio: Europe/Rome';
-
-  @override
-  String get profileEditUnitSystemLabel => 'Unità di misura preferita';
-
-  @override
-  String get profileEditUnitSystemNotSet => 'Non specificato';
-
-  @override
-  String get profileEditUnitSystemMetric => 'Metrico (kg, cm)';
-
-  @override
-  String get profileEditUnitSystemImperial => 'Imperiale (lb, in)';
-
-  @override
   String get profileEditCancel => 'Annulla';
 
   @override
@@ -975,9 +655,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String profileEditError(Object error) {
     return 'Impossibile aggiornare il profilo: $error';
   }
-
-  @override
-  String get featureUnavailable => 'Funzionalità non ancora disponibile.';
 
   @override
   String get logout => 'Logout';
@@ -1075,186 +752,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get passwordResetSubmit => 'Aggiorna password';
 
   @override
-  String get exerciseAddDialogTitle => 'Aggiungi esercizio';
-
-  @override
-  String get exerciseNameLabel => 'Nome esercizio';
-
-  @override
-  String get quickAddValuesLabel => 'Valori rapidi';
-
-  @override
-  String get quickAddValuesHelper =>
-      'Ripetizioni separate da virgola (es. 1,5,10)';
-
-  @override
   String get cancel => 'Annulla';
 
   @override
   String get add => 'Aggiungi';
 
   @override
-  String get save => 'Salva';
-
-  @override
-  String get exerciseNameMissing => 'Inserisci un nome.';
-
-  @override
-  String get exerciseTargetRepsLabel => 'Ripetizioni obiettivo';
-
-  @override
-  String get exerciseTargetRepsHelper =>
-      'Obiettivo totale opzionale per la sessione';
-
-  @override
-  String get exerciseRestDurationLabel => 'Durata recupero (secondi)';
-
-  @override
-  String get exerciseRestDurationHelper =>
-      'Preset opzionale per il conto alla rovescia';
-
-  @override
-  String get exerciseTrackerEmpty =>
-      'Ancora nessun esercizio. Tocca + per aggiungerne uno!';
-
-  @override
-  String get exerciseAddButton => 'Aggiungi esercizio';
-
-  @override
-  String get exercisePushUps => 'Push-up';
-
-  @override
-  String get exercisePullUps => 'Trazioni alla sbarra';
-
-  @override
-  String get exerciseChinUps => 'Trazioni a presa inversa';
-
-  @override
-  String exerciseTotalReps(int count) {
-    return '$count ripetizioni totali';
-  }
-
-  @override
-  String exerciseGoalProgress(int logged, int goal) {
-    return '$logged / $goal ripetizioni registrate';
-  }
-
-  @override
-  String exerciseRestFinished(String exercise) {
-    return 'Recupero terminato per $exercise!';
-  }
-
-  @override
-  String get exerciseSetRestDuration => 'Imposta durata recupero';
-
-  @override
-  String get exerciseDurationSecondsLabel => 'Durata (secondi)';
-
-  @override
-  String get restTimerLabel => 'Timer di recupero';
-
-  @override
-  String get setDuration => 'Imposta durata';
-
-  @override
-  String get undoLastSet => 'Annulla ultima serie';
-
-  @override
-  String get custom => 'Personalizzato';
-
-  @override
-  String get reset => 'Reimposta';
-
-  @override
-  String get logRepsTitle => 'Registra ripetizioni';
-
-  @override
-  String get repetitionsLabel => 'Ripetizioni';
-
-  @override
-  String get positiveNumberError => 'Inserisci un numero positivo.';
-
-  @override
-  String repsChip(int count) {
-    return '$count ripetizioni';
-  }
-
-  @override
-  String goalCount(int count) {
-    return 'Obiettivo: $count';
-  }
-
-  @override
-  String get repGoalReached => 'Obiettivo ripetizioni raggiunto!';
-
-  @override
-  String get pause => 'Pausa';
-
-  @override
   String get start => 'Avvia';
-
-  @override
-  String seriesCount(int count) {
-    return 'Serie: $count';
-  }
-
-  @override
-  String get resetReps => 'Azzera ripetizioni';
-
-  @override
-  String get emomTrackerTitle => 'Tracker EMOM';
-
-  @override
-  String get emomTrackerSubtitle =>
-      'Serie ogni minuto con conto alla rovescia.';
-
-  @override
-  String get emomTrackerDescription =>
-      'Configura serie, ripetizioni e intervalli per restare sul ritmo ogni minuto.';
-
-  @override
-  String get emomSetsLabel => 'Serie totali';
-
-  @override
-  String get emomRepsLabel => 'Ripetizioni per serie';
-
-  @override
-  String get emomIntervalLabel => 'Intervallo (secondi)';
-
-  @override
-  String get emomStartButton => 'Avvia EMOM';
-
-  @override
-  String get emomResetButton => 'Reimposta sessione';
-
-  @override
-  String get emomSessionComplete => 'EMOM completato';
-
-  @override
-  String emomCurrentSet(int current, int total) {
-    return 'Serie $current di $total';
-  }
-
-  @override
-  String emomRepsPerSet(int count) {
-    return '$count ripetizioni per serie';
-  }
-
-  @override
-  String get emomFinishedMessage =>
-      'Ottimo lavoro! Hai rispettato ogni minuto.';
-
-  @override
-  String get emomTimeRemainingLabel => 'Tempo rimanente in questo minuto';
-
-  @override
-  String emomPrepHeadline(int set) {
-    return 'Preparati per la serie $set';
-  }
-
-  @override
-  String get emomPrepSubhead =>
-      'La prossima serie parte alla fine del conto alla rovescia.';
 
   @override
   String get timerTitle => 'Timer';
@@ -1303,27 +807,6 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get countdownResetButton => 'Ferma timer';
-
-  @override
-  String get weekdayMonday => 'Lunedì';
-
-  @override
-  String get weekdayTuesday => 'Martedì';
-
-  @override
-  String get weekdayWednesday => 'Mercoledì';
-
-  @override
-  String get weekdayThursday => 'Giovedì';
-
-  @override
-  String get weekdayFriday => 'Venerdì';
-
-  @override
-  String get weekdaySaturday => 'Sabato';
-
-  @override
-  String get weekdaySunday => 'Domenica';
 
   @override
   String weekNumber(int week) {
@@ -1419,37 +902,3 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get termScaricoDescription =>
       'Ultima settimana della scheda per prepararsi ai massimali.';
-
-  @override
-  String get noCameras => 'Nessuna fotocamera disponibile';
-
-  @override
-  String cameraInitFailed(Object error) {
-    return 'Inizializzazione fotocamera fallita: $error';
-  }
-
-  @override
-  String get poseDetected => 'Posa rilevata';
-
-  @override
-  String get processing => 'Elaborazione…';
-
-  @override
-  String get idle => 'In attesa';
-
-  @override
-  String get cameraFront => 'frontale';
-
-  @override
-  String get cameraBack => 'posteriore';
-
-  @override
-  String hudMetrics(String fps, String milliseconds, int landmarks) {
-    return 'fps: $fps  ms: $milliseconds  lmks: $landmarks';
-  }
-
-  @override
-  String hudOrientation(String rotation, String camera, String format) {
-    return 'rot: $rotation  cam: $camera  fmt: $format';
-  }
-}


### PR DESCRIPTION
### Motivation
- Remove translation keys that are no longer referenced in the codebase to reduce clutter and prevent stale / unused localization strings.
- Keep generated localization classes in sync with the actual used keys to avoid dead APIs and reduce generated code size.

### Description
- Removed ~154 unused keys from both `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb`, including associated placeholder/plural entries where applicable.
- Pruned the generated localization interface `lib/l10n/app_localizations.dart` to remove getters and methods for the removed keys.
- Updated the language implementations `lib/l10n/app_localizations_en.dart` and `lib/l10n/app_localizations_it.dart` to remove overrides for the deleted keys so they match the new ARB contents.
- Kept all referenced localization keys, supported locales, and the lookup delegate logic intact.

### Testing
- Ran a Python script that scanned Dart sources and `lib/l10n/app_en.arb` to identify unreferenced keys and reported `unused 154`, then applied the pruning to ARB and generated files; the script completed successfully.
- Ran `rg`/search checks to verify the removed keys are no longer present in the updated ARB and generated localization files; the searches returned no matches for the removed keys.
- No unit tests or CI jobs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773baa83808333906df05d10afb5b6)