### PR TITLE
Move terminology content to database

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -20,6 +20,42 @@ CREATE TABLE public.exercises (
   CONSTRAINT exercises_slug_key UNIQUE (slug),
   CONSTRAINT exercises_name_key UNIQUE (name)
 );
+CREATE TABLE public.terminology (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  term_key text NOT NULL,
+  locale text NOT NULL,
+  title text NOT NULL,
+  description text NOT NULL,
+  sort_order integer NOT NULL DEFAULT 1,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT terminology_pkey PRIMARY KEY (id),
+  CONSTRAINT terminology_unique UNIQUE (term_key, locale)
+);
+INSERT INTO public.terminology (term_key, locale, title, description, sort_order) VALUES
+  ('reps', 'en', 'Reps', 'Number of times you perform an exercise consecutively.', 1),
+  ('set', 'en', 'Set', 'A group of repetitions. For example: 3 sets of 10 reps means 30 repetitions total divided into 3 groups.', 2),
+  ('rt', 'en', 'RT', 'Total Repetitions: perform all the reps with your preferred sets, reps, and tempo (if not specified).', 3),
+  ('amrap', 'en', 'AMRAP', 'As Many Reps As Possible: perform as many reps as you can in a given time.', 4),
+  ('emom', 'en', 'EMOM', 'Every Minute on the Minute: start a set every minute. Rest during the remaining time.', 5),
+  ('ramping', 'en', 'Ramping', 'Method where the load increases with each set.', 6),
+  ('mav', 'en', 'MAV', 'Massima Alzata Veloce: perform as many reps as possible with a load while keeping control and good speed.', 7),
+  ('isokinetic', 'en', 'Isokinetic', 'Exercises performed at a constant speed.', 8),
+  ('tut', 'en', 'TUT', 'Indicates how long a repetition should last. You can manage the duration of each phase.', 9),
+  ('iso', 'en', 'ISO', 'Indicates a pause at a specific point of the repetition.', 10),
+  ('som', 'en', 'SOM', 'Indicates the duration of each phase of the repetition.', 11),
+  ('deload', 'en', 'Deload', 'Last week of the program to prepare for max attempts.', 12),
+  ('reps', 'it', 'Reps (Ripetizioni)', 'Numero di volte che esegui un esercizio consecutivamente.', 1),
+  ('set', 'it', 'Set (Serie)', 'Un gruppo di ripetizioni. Es: 3 serie da 10 reps significa 30 ripetizioni totali, divise in 3 gruppi.', 2),
+  ('rt', 'it', 'RT', 'Ripetizioni Totali: indica che devi fare tutte quelle reps, con libera scelta di serie, ripetizioni e tempo (se non indicato).', 3),
+  ('amrap', 'it', 'AMRAP', 'As Many Reps As Possible: esegui quante più ripetizioni possibili in un tempo determinato.', 4),
+  ('emom', 'it', 'EMOM', 'Every Minute On Minute: inizi un set ogni minuto. Il tempo restante serve per riposare.', 5),
+  ('ramping', 'it', 'Ramping', 'Metodo che prevede un incremento del peso ad ogni serie', 6),
+  ('mav', 'it', 'MAV', 'Massima Alzata Veloce: si riferisce a una metodologia in cui si cerca di eseguire il maggior numero di ripetizioni possibili con un carico, mantenendo sempre il controllo del movimento e una buona velocità di esecuzione.', 7),
+  ('isokinetic', 'it', 'Isocinetici', 'Esercizi svolti a velocità costante.', 8),
+  ('tut', 'it', 'TUT', 'Indica quanto deve durare una ripetizione. Puoi gestire tu la durata di ogni fase della rep.', 9),
+  ('iso', 'it', 'ISO', 'Indica il fermo a un punto specifico dell''esecuzione della rep', 10),
+  ('som', 'it', 'SOM', 'Indica la durata di ogni fase della ripetizione.', 11),
+  ('deload', 'it', 'Scarico', 'Ultima settimana della scheda per prepararsi ai massimali.', 12);
 CREATE TABLE public.trainee_exercise_unlocks (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   trainee_id uuid NOT NULL,

--- a/lib/pages/terminology.dart
+++ b/lib/pages/terminology.dart
@@ -1,94 +1,200 @@
 import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
 
-class TerminologyPage extends StatelessWidget {
+class TerminologyEntry {
+  const TerminologyEntry({
+    required this.term,
+    required this.description,
+    required this.sortOrder,
+  });
+
+  final String term;
+  final String description;
+  final int sortOrder;
+
+  factory TerminologyEntry.fromMap(Map<String, dynamic> data) {
+    return TerminologyEntry(
+      term: data['title']?.toString() ?? '',
+      description: data['description']?.toString() ?? '',
+      sortOrder: (data['sort_order'] as int?) ?? 0,
+    );
+  }
+}
+
+class TerminologyPage extends StatefulWidget {
   const TerminologyPage({super.key});
+
+  @override
+  State<TerminologyPage> createState() => _TerminologyPageState();
+}
+
+class _TerminologyPageState extends State<TerminologyPage> {
+  Future<List<TerminologyEntry>>? _terminologyFuture;
+  String? _localeCode;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final locale = Localizations.localeOf(context).languageCode;
+    if (_localeCode != locale) {
+      _localeCode = locale;
+      _terminologyFuture = _loadTerminology(locale);
+    }
+  }
+
+  Future<List<TerminologyEntry>> _loadTerminology(String locale) async {
+    final client = Supabase.instance.client;
+    final items = await _fetchTerminology(client, locale);
+    if (items.isEmpty && locale != 'en') {
+      return _fetchTerminology(client, 'en');
+    }
+    return items;
+  }
+
+  Future<List<TerminologyEntry>> _fetchTerminology(
+    SupabaseClient client,
+    String locale,
+  ) async {
+    final response = await client
+        .from('terminology')
+        .select('title, description, sort_order')
+        .eq('locale', locale)
+        .order('sort_order', ascending: true);
+
+    final items = (response as List?)?.cast<Map<String, dynamic>>() ?? [];
+    return items.map(TerminologyEntry.fromMap).toList();
+  }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final termini = [
-      {'termine': l10n.termRepsTitle, 'descrizione': l10n.termRepsDescription},
-      {'termine': l10n.termSetTitle, 'descrizione': l10n.termSetDescription},
-      {'termine': l10n.termRtTitle, 'descrizione': l10n.termRtDescription},
-      {'termine': l10n.termAmrapTitle, 'descrizione': l10n.termAmrapDescription},
-      {'termine': l10n.termEmomTitle, 'descrizione': l10n.termEmomDescription},
-      {'termine': l10n.termRampingTitle, 'descrizione': l10n.termRampingDescription},
-      {'termine': l10n.termMavTitle, 'descrizione': l10n.termMavDescription},
-      {'termine': l10n.termIsocineticiTitle, 'descrizione': l10n.termIsocineticiDescription},
-      {'termine': l10n.termTutTitle, 'descrizione': l10n.termTutDescription},
-      {'termine': l10n.termIsoTitle, 'descrizione': l10n.termIsoDescription},
-      {'termine': l10n.termSomTitle, 'descrizione': l10n.termSomDescription},
-      {'termine': l10n.termScaricoTitle, 'descrizione': l10n.termScaricoDescription},
-    ];
-    return CustomScrollView(
-      slivers: [
-        SliverPadding(
-          padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
-          sliver: SliverToBoxAdapter(
-            child: Text(
-              l10n.terminologyTitle,
-              style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
-            ),
-          ),
+    final titleSliver = SliverPadding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+      sliver: SliverToBoxAdapter(
+        child: Text(
+          l10n.terminologyTitle,
+          style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
         ),
-        SliverPadding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-          sliver: SliverList.separated(
-            itemCount: termini.length,
-            itemBuilder: (context, index) {
-              final termine = termini[index];
-              return DecoratedBox(
-                decoration: BoxDecoration(
-                  color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: colorScheme.outlineVariant),
+      ),
+    );
+
+    return FutureBuilder<List<TerminologyEntry>>(
+      future: _terminologyFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return CustomScrollView(
+            slivers: [
+              titleSliver,
+              const SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ],
+          );
+        }
+
+        if (snapshot.hasError) {
+          return CustomScrollView(
+            slivers: [
+              titleSliver,
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(
+                      l10n.unexpectedError(snapshot.error.toString()),
+                      style: theme.textTheme.bodyMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
                 ),
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.center,
+              ),
+            ],
+          );
+        }
+
+        final terms = snapshot.data ?? const [];
+        if (terms.isEmpty) {
+          return CustomScrollView(
+            slivers: [
+              titleSliver,
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: Center(
+                  child: Text(
+                    l10n.profileNoData,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
+              ),
+            ],
+          );
+        }
+
+        return CustomScrollView(
+          slivers: [
+            titleSliver,
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+              sliver: SliverList.separated(
+                itemCount: terms.length,
+                itemBuilder: (context, index) {
+                  final entry = terms[index];
+                  return DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(16),
+                      border: Border.all(color: colorScheme.outlineVariant),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          CircleAvatar(
-                            radius: 18,
-                            backgroundColor: colorScheme.primaryContainer,
-                            child: Icon(
-                              Icons.fitness_center,
-                              size: 18,
-                              color: colorScheme.onPrimaryContainer,
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Text(
-                              termine['termine']!,
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.w700,
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              CircleAvatar(
+                                radius: 18,
+                                backgroundColor: colorScheme.primaryContainer,
+                                child: Icon(
+                                  Icons.fitness_center,
+                                  size: 18,
+                                  color: colorScheme.onPrimaryContainer,
+                                ),
                               ),
-                            ),
+                              const SizedBox(width: 12),
+                              Expanded(
+                                child: Text(
+                                  entry.term,
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            entry.description,
+                            style: theme.textTheme.bodyMedium?.copyWith(height: 1.4),
                           ),
                         ],
                       ),
-                      const SizedBox(height: 12),
-                      Text(
-                        termine['descrizione']!,
-                        style: theme.textTheme.bodyMedium?.copyWith(height: 1.4),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-            separatorBuilder: (context, index) => const SizedBox(height: 12),
-          ),
-        ),
-      ],
+                    ),
+                  );
+                },
+                separatorBuilder: (context, index) => const SizedBox(height: 12),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Move static terminology content into the database so entries can be managed per-locale and loaded at runtime with locale fallback.

### Description
- Add a `terminology` table in `db/database.sql` with `term_key`, `locale`, `title`, `description`, `sort_order`, a unique constraint and seeded English and Italian rows.
- Replace the hard-coded terminology list in `lib/pages/terminology.dart` with a `TerminologyEntry` model and Supabase queries that select `title`, `description`, and `sort_order` for the current locale.
- Convert `TerminologyPage` to a stateful widget that detects the locale, fetches entries via `Supabase.instance.client`, falls back to English when a locale has no rows, and renders loading, empty and error states using `FutureBuilder` while preserving existing UI styling.
- Add `supabase_flutter` usage in the page and ordering by `sort_order` to maintain the intended display order.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69773b0120908333b2d679346893af29)