### PR TITLE
Add TerminologyEntry model and fetch helper

### DIFF
--- a/lib/model/terminology_entry.dart
+++ b/lib/model/terminology_entry.dart
@@ -1,0 +1,44 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class TerminologyEntry {
+  const TerminologyEntry({
+    required this.id,
+    required this.termKey,
+    required this.locale,
+    required this.term,
+    required this.description,
+    required this.sortOrder,
+  });
+
+  final String id;
+  final String termKey;
+  final String locale;
+  final String term;
+  final String description;
+  final int sortOrder;
+
+  factory TerminologyEntry.fromMap(Map<String, dynamic> data) {
+    return TerminologyEntry(
+      id: data['id']?.toString() ?? '',
+      termKey: data['term_key']?.toString() ?? '',
+      locale: data['locale']?.toString() ?? '',
+      term: data['title']?.toString() ?? '',
+      description: data['description']?.toString() ?? '',
+      sortOrder: (data['sort_order'] as int?) ?? 0,
+    );
+  }
+
+  static Future<List<TerminologyEntry>> fetchByLocale(
+    SupabaseClient client,
+    String locale,
+  ) async {
+    final response = await client
+        .from('terminology')
+        .select('id, term_key, locale, title, description, sort_order')
+        .eq('locale', locale)
+        .order('sort_order', ascending: true);
+
+    final items = (response as List?)?.cast<Map<String, dynamic>>() ?? [];
+    return items.map(TerminologyEntry.fromMap).toList();
+  }
+}

--- a/lib/pages/terminology.dart
+++ b/lib/pages/terminology.dart
@@ -2,26 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
-
-class TerminologyEntry {
-  const TerminologyEntry({
-    required this.term,
-    required this.description,
-    required this.sortOrder,
-  });
-
-  final String term;
-  final String description;
-  final int sortOrder;
-
-  factory TerminologyEntry.fromMap(Map<String, dynamic> data) {
-    return TerminologyEntry(
-      term: data['title']?.toString() ?? '',
-      description: data['description']?.toString() ?? '',
-      sortOrder: (data['sort_order'] as int?) ?? 0,
-    );
-  }
-}
+import '../model/terminology_entry.dart';
 
 class TerminologyPage extends StatefulWidget {
   const TerminologyPage({super.key});
@@ -46,25 +27,11 @@ class _TerminologyPageState extends State<TerminologyPage> {
 
   Future<List<TerminologyEntry>> _loadTerminology(String locale) async {
     final client = Supabase.instance.client;
-    final items = await _fetchTerminology(client, locale);
+    final items = await TerminologyEntry.fetchByLocale(client, locale);
     if (items.isEmpty && locale != 'en') {
-      return _fetchTerminology(client, 'en');
+      return TerminologyEntry.fetchByLocale(client, 'en');
     }
     return items;
-  }
-
-  Future<List<TerminologyEntry>> _fetchTerminology(
-    SupabaseClient client,
-    String locale,
-  ) async {
-    final response = await client
-        .from('terminology')
-        .select('title, description, sort_order')
-        .eq('locale', locale)
-        .order('sort_order', ascending: true);
-
-    final items = (response as List?)?.cast<Map<String, dynamic>>() ?? [];
-    return items.map(TerminologyEntry.fromMap).toList();
   }
 
   @override


### PR DESCRIPTION
### Motivation
- Align terminology fetching with the database schema (`terminology` table) by centralizing mapping of `id`, `term_key`, `locale`, `title`, `description`, and `sort_order` into a model.
- Remove duplicated parsing/fetch logic from the UI and provide a reusable data-layer helper for future usage.

### Description
- Add `lib/model/terminology_entry.dart` which defines `TerminologyEntry` with fields `id`, `termKey`, `locale`, `term`, `description`, and `sortOrder`, a `fromMap` factory, and a `fetchByLocale` Supabase helper that queries `terminology` by `locale` and orders by `sort_order`.
- Update `lib/pages/terminology.dart` to import `TerminologyEntry` and replace the inline model and direct query with calls to `TerminologyEntry.fetchByLocale`, preserving the fallback to English when a locale has no entries.
- Keep the UI behavior unchanged while moving DB access and mapping into the shared model helper.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977425ad4648333bdab60e65936c460)