### PR TITLE
Expose exercise terminology and skills on workout cards

### DIFF
--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -6,6 +6,8 @@ class WorkoutExercise {
   final String? name;
   final String? notes;
   final String? traineeNotes;
+  final List<String> terminology;
+  final List<String> skills;
   final int? position;
   final bool isCompleted;
 
@@ -14,6 +16,8 @@ class WorkoutExercise {
     this.id,
     this.notes,
     this.traineeNotes,
+    this.terminology = const [],
+    this.skills = const [],
     this.position,
     this.isCompleted = false,
   });

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -228,6 +228,8 @@ class _TrainingState extends State<Training> {
           notes: exercise.notes,
           traineeNotes: exercise.traineeNotes,
           position: exercise.position,
+          terminology: exercise.terminology,
+          skills: exercise.skills,
           isCompleted: newValue,
         );
         _completionChanged = true;
@@ -354,6 +356,9 @@ class _ExerciseCard extends StatelessWidget {
       decoration: isCompleted ? TextDecoration.lineThrough : null,
     );
 
+    final hasTerminology = exercise.terminology.isNotEmpty;
+    final hasSkills = exercise.skills.isNotEmpty;
+
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 8),
       decoration: BoxDecoration(
@@ -400,6 +405,21 @@ class _ExerciseCard extends StatelessWidget {
                           color: Colors.white60,
                         ),
                       ),
+                      if (hasTerminology || hasSkills) ...[
+                        const SizedBox(height: 10),
+                        if (hasTerminology)
+                          _InfoChips(
+                            title: l10n.terminologyTitle,
+                            items: exercise.terminology,
+                          ),
+                        if (hasTerminology && hasSkills)
+                          const SizedBox(height: 8),
+                        if (hasSkills)
+                          _InfoChips(
+                            title: l10n.guidesTitle,
+                            items: exercise.skills,
+                          ),
+                      ],
                     ],
                   ),
                 ),
@@ -421,6 +441,61 @@ class _ExerciseCard extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _InfoChips extends StatelessWidget {
+  final String title;
+  final List<String> items;
+
+  const _InfoChips({
+    required this.title,
+    required this.items,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: textTheme.labelSmall?.copyWith(
+            color: Colors.white70,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Wrap(
+          spacing: 6,
+          runSpacing: 6,
+          children: items
+              .map(
+                (item) => DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.08),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 4,
+                    ),
+                    child: Text(
+                      item,
+                      style: textTheme.labelSmall?.copyWith(
+                        color: Colors.white70,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ),
+              )
+              .toList(),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Surface exercise `terminology` and `skills` metadata on the workout page so users can discover related concepts and progress markers directly on exercise cards. 
- Preserve and surface those metadata values when updating exercise completion so information is not lost during state changes.

### Description
- Added `terminology` and `skills` fields to the `WorkoutExercise` model with defaults (`lib/model/workout_day.dart`).
- Extended the days query selection to request `terminology` and `skills`, added a `parseStringList` helper, handled both string and array shapes (and nested `exercise` object shapes), and populated the new fields when building `WorkoutExercise` instances (`lib/pages/workout_plan_page.dart`).
- Rendered terminology and skills as labeled chips in the exercise UI by updating `_ExerciseCard` to conditionally show them and introducing a reusable `_InfoChips` widget, and ensured `_toggleExerciseCompletion` preserves these fields when updating local state (`lib/pages/training.dart`).

### Testing
- No automated tests were run in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69774276d1288333b63119b2316427aa)