### PR TITLE
Link home screen header to trainee data

### DIFF
--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -1,31 +1,65 @@
 import 'package:flutter/material.dart';
 
-class HomeContent extends StatelessWidget {
+import '../l10n/app_localizations.dart';
+import 'profile.dart';
+
+class HomeContent extends StatefulWidget {
   const HomeContent({super.key});
 
   @override
+  State<HomeContent> createState() => _HomeContentState();
+}
+
+class _HomeContentState extends State<HomeContent> {
+  late Future<UserProfileData> _profileFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _profileFuture = getUserData();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return ListView(
-      padding: const EdgeInsets.fromLTRB(16, 20, 16, 24),
-      children: const [
-        _HomeHeader(),
-        SizedBox(height: 16),
-        _ProgressCard(),
-        SizedBox(height: 16),
-        _GoalsCard(),
-        SizedBox(height: 16),
-        _ActionButtons(),
-        SizedBox(height: 16),
-        _StrengthLevelCard(),
-        SizedBox(height: 16),
-        _SkillProgressCard(),
-      ],
+    final l10n = AppLocalizations.of(context)!;
+    return FutureBuilder<UserProfileData>(
+      future: _profileFuture,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+        final displayName = data?.displayName(l10n) ?? l10n.profileFallbackName;
+        final initials = data?.initials(l10n) ?? '';
+        return ListView(
+          padding: const EdgeInsets.fromLTRB(16, 20, 16, 24),
+          children: [
+            _HomeHeader(
+              displayName: displayName,
+              initials: initials,
+            ),
+            const SizedBox(height: 16),
+            const _ProgressCard(),
+            const SizedBox(height: 16),
+            const _GoalsCard(),
+            const SizedBox(height: 16),
+            const _ActionButtons(),
+            const SizedBox(height: 16),
+            const _StrengthLevelCard(),
+            const SizedBox(height: 16),
+            const _SkillProgressCard(),
+          ],
+        );
+      },
     );
   }
 }
 
 class _HomeHeader extends StatelessWidget {
-  const _HomeHeader();
+  const _HomeHeader({
+    required this.displayName,
+    required this.initials,
+  });
+
+  final String displayName;
+  final String initials;
 
   @override
   Widget build(BuildContext context) {
@@ -34,35 +68,46 @@ class _HomeHeader extends StatelessWidget {
       children: [
         Expanded(
           child: Text(
-            'Hi, Alex!',
+            'Hi, $displayName!',
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.w700,
             ),
           ),
         ),
-        const _AvatarChip(),
+        _AvatarChip(initials: initials),
       ],
     );
   }
 }
 
 class _AvatarChip extends StatelessWidget {
-  const _AvatarChip();
+  const _AvatarChip({required this.initials});
+
+  final String initials;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final avatarText = initials.isEmpty ? null : initials;
     return CircleAvatar(
       radius: 18,
       backgroundColor: theme.colorScheme.primaryContainer,
       child: CircleAvatar(
         radius: 16,
         backgroundColor: theme.colorScheme.surface,
-        child: Icon(
-          Icons.person,
-          color: theme.colorScheme.onSurfaceVariant,
-          size: 18,
-        ),
+        child: avatarText == null
+            ? Icon(
+                Icons.person,
+                color: theme.colorScheme.onSurfaceVariant,
+                size: 18,
+              )
+            : Text(
+                avatarText,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
       ),
     );
   }


### PR DESCRIPTION
### Motivation
- Personalize the home screen header by showing the signed-in trainee's name and initials in the greeting/avatar.

### Description
- Convert `HomeContent` from a `StatelessWidget` to a `StatefulWidget` and load the trainee profile using `getUserData` in `initState`.
- Render the content with a `FutureBuilder<UserProfileData>` and extract `displayName` and `initials` to be used in the header.
- Update `_HomeHeader` to accept `displayName` and `initials`, and change `_AvatarChip` to display initials text when available instead of the generic person icon.
- Add imports for `../l10n/app_localizations.dart` and `profile.dart` and update `lib/pages/home_content.dart` accordingly.

### Testing
- No automated tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977547429e883338327dd2b7a96d5fd)