### PR TITLE
Move exercise guide metadata into database seed

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -20,6 +20,15 @@ CREATE TABLE public.exercises (
   CONSTRAINT exercises_slug_key UNIQUE (slug),
   CONSTRAINT exercises_name_key UNIQUE (name)
 );
+CREATE TABLE public.exercise_guides (
+  slug text NOT NULL,
+  difficulty text NOT NULL DEFAULT 'beginner'::text,
+  default_unlocked boolean NOT NULL DEFAULT false,
+  accent text NOT NULL,
+  sort_order integer NOT NULL DEFAULT 1,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT exercise_guides_pkey PRIMARY KEY (slug)
+);
 CREATE TABLE public.terminology (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   term_key text NOT NULL,
@@ -138,3 +147,22 @@ CREATE TABLE public.workout_plans (
   notes text,
   CONSTRAINT workout_plans_pkey PRIMARY KEY (id)
 );
+
+INSERT INTO public.exercise_guides
+  (slug, difficulty, default_unlocked, accent, sort_order)
+VALUES
+  ('pullup', 'intermediate', false, '#2196F3', 1),
+  ('chinup', 'intermediate', false, '#03A9F4', 2),
+  ('pushup', 'beginner', true, '#FF9800', 3),
+  ('bodyweight-squat', 'beginner', true, '#4CAF50', 4),
+  ('glute-bridge', 'beginner', true, '#8BC34A', 5),
+  ('hanging-leg-raise', 'intermediate', false, '#9C27B0', 6),
+  ('muscle-up', 'advanced', false, '#009688', 7),
+  ('straight-bar-dip', 'intermediate', false, '#FF5722', 8),
+  ('dips', 'intermediate', false, '#F44336', 9),
+  ('australian-row', 'beginner', true, '#3F51B5', 10),
+  ('pike-pushup', 'intermediate', false, '#FFC107', 11),
+  ('hollow-hold', 'beginner', true, '#795548', 12),
+  ('plank', 'beginner', true, '#607D8B', 13),
+  ('l-sit', 'intermediate', false, '#03A9F4', 14),
+  ('handstand', 'advanced', false, '#673AB7', 15);

--- a/lib/model/exercise_guide.dart
+++ b/lib/model/exercise_guide.dart
@@ -50,156 +50,180 @@ class ExerciseGuide {
     );
   }
 
-  static List<ExerciseGuide> buildGuides(AppLocalizations l10n) => [
-        ExerciseGuide(
-          id: 'pullup',
+  static ExerciseGuide fromDatabase(
+    Map<String, dynamic> row,
+    AppLocalizations l10n,
+  ) {
+    final slug = row['slug'] as String;
+    final strings = ExerciseGuideStrings.fromSlug(slug, l10n);
+    return ExerciseGuide(
+      id: slug,
+      name: strings.name,
+      difficulty: _difficultyFromString(row['difficulty'] as String?),
+      isUnlocked: row['default_unlocked'] as bool? ?? false,
+      focus: strings.focus,
+      tip: strings.tip,
+      description: strings.description,
+      accent: _accentFromHex(row['accent'] as String?),
+    );
+  }
+
+  static Difficulty _difficultyFromString(String? value) {
+    switch (value) {
+      case 'intermediate':
+        return Difficulty.intermediate;
+      case 'advanced':
+        return Difficulty.advanced;
+      case 'beginner':
+      default:
+        return Difficulty.beginner;
+    }
+  }
+
+  static Color _accentFromHex(String? value) {
+    if (value == null || value.isEmpty) {
+      return Colors.blueGrey;
+    }
+    final normalized = value.replaceAll('#', '').replaceAll('0x', '');
+    final hex = normalized.length == 6 ? 'FF$normalized' : normalized;
+    final colorValue = int.tryParse(hex, radix: 16);
+    if (colorValue == null) {
+      return Colors.blueGrey;
+    }
+    return Color(colorValue);
+  }
+}
+
+class ExerciseGuideStrings {
+  const ExerciseGuideStrings({
+    required this.name,
+    required this.focus,
+    required this.tip,
+    required this.description,
+  });
+
+  final String name;
+  final String focus;
+  final String tip;
+  final String description;
+
+  static ExerciseGuideStrings fromSlug(
+    String slug,
+    AppLocalizations l10n,
+  ) {
+    switch (slug) {
+      case 'pullup':
+        return ExerciseGuideStrings(
           name: l10n.guidesPullupName,
-          difficulty: Difficulty.intermediate,
-          isUnlocked: false,
           focus: l10n.guidesPullupFocus,
           tip: l10n.guidesPullupTip,
           description: l10n.guidesPullupDescription,
-          accent: Colors.blue,
-        ),
-        ExerciseGuide(
-          id: 'chinup',
+        );
+      case 'chinup':
+        return ExerciseGuideStrings(
           name: l10n.guidesChinUpName,
-          difficulty: Difficulty.intermediate,
-          isUnlocked: false,
           focus: l10n.guidesChinUpFocus,
           tip: l10n.guidesChinUpTip,
           description: l10n.guidesChinUpDescription,
-          accent: Colors.lightBlue,
-        ),
-        ExerciseGuide(
-          id: 'pushup',
+        );
+      case 'pushup':
+        return ExerciseGuideStrings(
           name: l10n.guidesPushupName,
-          difficulty: Difficulty.beginner,
-          isUnlocked: true,
           focus: l10n.guidesPushupFocus,
           tip: l10n.guidesPushupTip,
           description: l10n.guidesPushupDescription,
-          accent: Colors.orange,
-        ),
-        ExerciseGuide(
-          id: 'bodyweight-squat',
+        );
+      case 'bodyweight-squat':
+        return ExerciseGuideStrings(
           name: l10n.guidesBodyweightSquatName,
-          difficulty: Difficulty.beginner,
-          isUnlocked: true,
           focus: l10n.guidesBodyweightSquatFocus,
           tip: l10n.guidesBodyweightSquatTip,
           description: l10n.guidesBodyweightSquatDescription,
-          accent: Colors.green,
-        ),
-        ExerciseGuide(
-          id: 'glute-bridge',
+        );
+      case 'glute-bridge':
+        return ExerciseGuideStrings(
           name: l10n.guidesGluteBridgeName,
-          difficulty: Difficulty.beginner,
-          isUnlocked: true,
           focus: l10n.guidesGluteBridgeFocus,
           tip: l10n.guidesGluteBridgeTip,
           description: l10n.guidesGluteBridgeDescription,
-          accent: Colors.lightGreen,
-        ),
-        ExerciseGuide(
-          id: 'hanging-leg-raise',
+        );
+      case 'hanging-leg-raise':
+        return ExerciseGuideStrings(
           name: l10n.guidesHangingLegRaiseName,
-          difficulty: Difficulty.intermediate,
-          isUnlocked: false,
           focus: l10n.guidesHangingLegRaiseFocus,
           tip: l10n.guidesHangingLegRaiseTip,
           description: l10n.guidesHangingLegRaiseDescription,
-          accent: Colors.purple,
-        ),
-        ExerciseGuide(
-          id: 'muscle-up',
+        );
+      case 'muscle-up':
+        return ExerciseGuideStrings(
           name: l10n.guidesMuscleUpName,
-          difficulty: Difficulty.advanced,
-          isUnlocked: false,
           focus: l10n.guidesMuscleUpFocus,
           tip: l10n.guidesMuscleUpTip,
           description: l10n.guidesMuscleUpDescription,
-          accent: Colors.teal,
-        ),
-        ExerciseGuide(
-          id: 'straight-bar-dip',
+        );
+      case 'straight-bar-dip':
+        return ExerciseGuideStrings(
           name: l10n.guidesStraightBarDipName,
-          difficulty: Difficulty.intermediate,
-          isUnlocked: false,
           focus: l10n.guidesStraightBarDipFocus,
           tip: l10n.guidesStraightBarDipTip,
           description: l10n.guidesStraightBarDipDescription,
-          accent: Colors.deepOrange,
-        ),
-        ExerciseGuide(
-          id: 'dips',
+        );
+      case 'dips':
+        return ExerciseGuideStrings(
           name: l10n.guidesDipsName,
-          difficulty: Difficulty.intermediate,
-          isUnlocked: false,
           focus: l10n.guidesDipsFocus,
           tip: l10n.guidesDipsTip,
           description: l10n.guidesDipsDescription,
-          accent: Colors.red,
-        ),
-        ExerciseGuide(
-          id: 'australian-row',
+        );
+      case 'australian-row':
+        return ExerciseGuideStrings(
           name: l10n.guidesAustralianRowName,
-          difficulty: Difficulty.beginner,
-          isUnlocked: true,
           focus: l10n.guidesAustralianRowFocus,
           tip: l10n.guidesAustralianRowTip,
           description: l10n.guidesAustralianRowDescription,
-          accent: Colors.indigo,
-        ),
-        ExerciseGuide(
-          id: 'pike-pushup',
+        );
+      case 'pike-pushup':
+        return ExerciseGuideStrings(
           name: l10n.guidesPikePushUpName,
-          difficulty: Difficulty.intermediate,
-          isUnlocked: false,
           focus: l10n.guidesPikePushUpFocus,
           tip: l10n.guidesPikePushUpTip,
           description: l10n.guidesPikePushUpDescription,
-          accent: Colors.amber,
-        ),
-        ExerciseGuide(
-          id: 'hollow-hold',
+        );
+      case 'hollow-hold':
+        return ExerciseGuideStrings(
           name: l10n.guidesHollowHoldName,
-          difficulty: Difficulty.beginner,
-          isUnlocked: true,
           focus: l10n.guidesHollowHoldFocus,
           tip: l10n.guidesHollowHoldTip,
           description: l10n.guidesHollowHoldDescription,
-          accent: Colors.brown,
-        ),
-        ExerciseGuide(
-          id: 'plank',
+        );
+      case 'plank':
+        return ExerciseGuideStrings(
           name: l10n.guidesPlankName,
-          difficulty: Difficulty.beginner,
-          isUnlocked: true,
           focus: l10n.guidesPlankFocus,
           tip: l10n.guidesPlankTip,
           description: l10n.guidesPlankDescription,
-          accent: Colors.blueGrey,
-        ),
-        ExerciseGuide(
-          id: 'l-sit',
+        );
+      case 'l-sit':
+        return ExerciseGuideStrings(
           name: l10n.guidesLSitName,
-          difficulty: Difficulty.intermediate,
-          isUnlocked: false,
           focus: l10n.guidesLSitFocus,
           tip: l10n.guidesLSitTip,
           description: l10n.guidesLSitDescription,
-          accent: Colors.lightBlue,
-        ),
-        ExerciseGuide(
-          id: 'handstand',
+        );
+      case 'handstand':
+        return ExerciseGuideStrings(
           name: l10n.guidesHandstandName,
-          difficulty: Difficulty.advanced,
-          isUnlocked: false,
           focus: l10n.guidesHandstandFocus,
           tip: l10n.guidesHandstandTip,
           description: l10n.guidesHandstandDescription,
-          accent: Colors.deepPurple,
-        ),
-      ];
+        );
+      default:
+        return ExerciseGuideStrings(
+          name: slug,
+          focus: '',
+          tip: '',
+          description: '',
+        );
+    }
+  }
 }


### PR DESCRIPTION
### Motivation

- Centralize exercise guide metadata in the database so guide records can be managed and seeded from SQL instead of being hardcoded in the app.
- Load localized strings at runtime while keeping canonical guide attributes (slug, difficulty, default unlocked, accent, sort order) in the DB.

### Description

- Add a new `exercise_guides` table and seed rows in `db/database.sql` with `slug`, `difficulty`, `default_unlocked`, `accent`, and `sort_order` values.
- Replace the previous hardcoded guide list by adding `ExerciseGuide.fromDatabase(..)` to `lib/model/exercise_guide.dart`, plus helper methods `_difficultyFromString` and `_accentFromHex` to parse DB fields and produce `Difficulty` and `Color` values.
- Move localization responsibility to `ExerciseGuideStrings.fromSlug(..)` which maps each `slug` to localized name/focus/tip/description via `AppLocalizations` while keeping content keys in `lib/l10n`.
- Update `lib/pages/exercise_guides.dart` to fetch records from Supabase (`exercise_guides`), cache per-locale, and render guides via a `FutureBuilder` with loading and error states.

### Testing

- No automated tests were executed as part of this change; no test suite was run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697753dacc3c8333982b1e5b05fbef64)