### PR TITLE
Add Exercises CRUD to admin portal

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -62,6 +62,10 @@
                     <span>{{ t('sections.program') }}</span>
                     <span class="nav-badge">{{ current ? 1 : 0 }}</span>
                 </button>
+                <button :class="{active: activeSection==='exercises'}" @click="activeSection='exercises'">
+                    <span>{{ t('sections.exercises') }}</span>
+                    <span class="nav-badge">{{ exercises.length }}</span>
+                </button>
             </nav>
             <div class="sidebar-footer">
                 <div class="user-chip">
@@ -947,6 +951,123 @@
                     </template>
                 </div>
 
+            </div>
+
+            <div class="section-panel exercises-panel" :class="{active: activeSection==='exercises'}">
+                <div class="overview-grid">
+                    <div class="card">
+                        <div class="overview-card-header">
+                            <div class="stack">
+                                <h3>{{ t('sections.exercises') }}</h3>
+                                <span class="muted small">{{ t('exercises.available') }}</span>
+                            </div>
+                        </div>
+                        <div class="exercise-form-grid">
+                            <label class="stack small">
+                                <span class="muted small">{{ t('labels.name') }}</span>
+                                <input v-model="exerciseForm.name" :placeholder="t('placeholders.exerciseName')" />
+                            </label>
+                            <label class="stack small">
+                                <span class="muted small">{{ t('labels.slug') }}</span>
+                                <input v-model="exerciseForm.slug" :placeholder="t('placeholders.slugExample')" />
+                            </label>
+                            <label class="stack small">
+                                <span class="muted small">{{ t('labels.difficulty') }}</span>
+                                <select v-model="exerciseForm.difficulty">
+                                    <option v-for="option in exerciseDifficultyOptions" :key="option" :value="option">
+                                        {{ formatDifficultyLabel(option) }}
+                                    </option>
+                                </select>
+                            </label>
+                            <label class="stack small">
+                                <span class="muted small">{{ t('labels.sortOrder') }}</span>
+                                <input v-model.number="exerciseForm.sort_order" type="number" min="1" />
+                            </label>
+                        </div>
+                        <div class="exercise-form-actions">
+                            <button class="btn primary" type="button" @click="createExercise" :disabled="creatingExercise">
+                                {{ t('actions.add') }}
+                            </button>
+                            <button class="btn ghost" type="button" @click="resetExerciseForm" :disabled="creatingExercise">
+                                {{ t('actions.reset') }}
+                            </button>
+                            <span v-if="creatingExercise" class="muted small">{{ t('status.savingExercise') }}</span>
+                        </div>
+                    </div>
+                    <div class="card">
+                        <div class="overview-card-header">
+                            <div class="stack">
+                                <h3>{{ t('exercises.available') }}</h3>
+                                <span class="muted small">{{ t('labels.exercisesCount', { count: filteredExercises.length }) }}</span>
+                            </div>
+                            <div class="exercise-toolbar">
+                                <label class="stack small">
+                                    <span class="muted small">{{ t('placeholders.filterExercises') }}</span>
+                                    <input v-model="exerciseFilter" :placeholder="t('placeholders.filterExercises')" />
+                                </label>
+                                <button class="small" type="button" @click="loadExercises" :disabled="loadingExercises">
+                                    {{ t('actions.refresh') }}
+                                </button>
+                            </div>
+                        </div>
+                        <div v-if="loadingExercises" class="muted small">{{ t('status.loadingExercises') }}</div>
+                        <div v-else-if="exercisesError" class="muted small">{{ exercisesError }}</div>
+                        <div v-else-if="filteredExercises.length===0" class="muted small">{{ t('exercises.none') }}</div>
+                        <div v-else class="plan-builder-table-wrap">
+                            <table class="plan-builder-table">
+                                <thead>
+                                <tr>
+                                    <th>{{ t('labels.name') }}</th>
+                                    <th>{{ t('labels.slug') }}</th>
+                                    <th>{{ t('labels.difficulty') }}</th>
+                                    <th>{{ t('labels.sortOrder') }}</th>
+                                    <th>{{ t('labels.createdAt') }}</th>
+                                    <th></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr v-for="exercise in filteredExercises" :key="exercise.id">
+                                    <td>
+                                        <input v-model="exerciseEdits[exercise.id].name" :placeholder="t('placeholders.exerciseName')" />
+                                    </td>
+                                    <td>
+                                        <input v-model="exerciseEdits[exercise.id].slug" :placeholder="t('placeholders.slugExample')" />
+                                    </td>
+                                    <td>
+                                        <select v-model="exerciseEdits[exercise.id].difficulty">
+                                            <option v-for="option in exerciseDifficultyOptions" :key="option" :value="option">
+                                                {{ formatDifficultyLabel(option) }}
+                                            </option>
+                                        </select>
+                                    </td>
+                                    <td>
+                                        <input v-model.number="exerciseEdits[exercise.id].sort_order" type="number" min="1" />
+                                    </td>
+                                    <td>{{ formatDate(exercise.created_at) }}</td>
+                                    <td class="exercise-actions">
+                                        <button
+                                            class="btn"
+                                            type="button"
+                                            @click="saveExercise(exercise)"
+                                            :disabled="exerciseSaving[exercise.id]"
+                                        >
+                                            {{ t('actions.save') }}
+                                        </button>
+                                        <button
+                                            class="btn ghost"
+                                            type="button"
+                                            @click="deleteExercise(exercise)"
+                                            :disabled="exerciseSaving[exercise.id]"
+                                        >
+                                            {{ t('actions.delete') }}
+                                        </button>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
             </div>
         </main>
     </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -189,6 +189,10 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .history-meta{display:flex;justify-content:space-between;align-items:center;color:var(--muted)}
 .exercise-log-item{border:1px solid var(--line);border-radius:12px;padding:12px;background:#f8fafc}
 .dashboard-burndown-card{grid-column:1/-1}
+.exercise-form-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px;margin-top:12px}
+.exercise-form-actions{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-top:12px}
+.exercise-actions{display:flex;flex-wrap:wrap;gap:8px}
+.exercise-toolbar{display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap}
 .burndown-chart-wrap{display:flex;flex-direction:column;gap:16px;margin-top:12px}
 .burndown-chart{width:100%;height:260px;background:#f8fafc;border-radius:16px;border:1px solid var(--line);padding:12px;box-sizing:border-box}
 .burndown-legend{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -59,6 +59,9 @@ export const translations = {
       id: 'ID',
       status: 'Status',
       createdAt: 'Created at',
+      slug: 'Slug',
+      difficulty: 'Difficulty',
+      sortOrder: 'Sort order',
       startsAt: 'Starts at',
       endsAt: 'Ends at',
       notes: 'Notes',
@@ -173,6 +176,7 @@ export const translations = {
       workoutTitle: 'Workout title',
       filterExercises: 'Type to filter exercises',
       setsExample: 'e.g. 12x20 kg, 10x22 kg',
+      slugExample: 'e.g. push-ups',
     },
     exercises: {
       available: 'Available exercises',
@@ -206,6 +210,7 @@ export const translations = {
       loadingPayments: 'Loading payments…',
       loadingCompletedExercises: 'Loading completed exercises…',
       updatingPaymentAmount: 'Updating payment amount…',
+      loadingExercises: 'Loading exercises…',
     },
     plans: {
       title: 'Workout plans',
@@ -364,6 +369,9 @@ export const translations = {
       id: 'ID',
       status: 'Stato',
       createdAt: 'Creato il',
+      slug: 'Slug',
+      difficulty: 'Difficoltà',
+      sortOrder: 'Ordine',
       startsAt: 'Inizio',
       endsAt: 'Fine',
       notes: 'Note',
@@ -479,6 +487,7 @@ export const translations = {
       workoutTitle: 'Titolo workout',
       filterExercises: 'Digita per filtrare gli esercizi',
       setsExample: 'es. 12x20 kg, 10x22 kg',
+      slugExample: 'es. push-ups',
     },
     exercises: {
       available: 'Esercizi disponibili',
@@ -512,6 +521,7 @@ export const translations = {
       loadingPayments: 'Caricamento pagamenti…',
       loadingCompletedExercises: 'Caricamento esercizi completati…',
       updatingPaymentAmount: 'Aggiornamento importo pagamento…',
+      loadingExercises: 'Caricamento esercizi…',
     },
     plans: {
       title: 'Piani allenamento',


### PR DESCRIPTION
### Motivation
- Provide admins a way to manage the canonical `exercises` table from the admin UI (create, list, edit, delete and filter exercises).

### Description
- Add exercise state and CRUD handlers to the admin logic (`loadExercises`, `createExercise`, `saveExercise`, `deleteExercise`, slug normalization and edit-state management) in `backend/admin/app.js` and call `loadExercises` during bootstrap.
- Add an Exercises navigation item and full management panel with create form, filter, and editable table UI in `backend/admin/index.html`.
- Add CSS helpers for the exercise form/table (`backend/admin/styles.css`).
- Add translation keys and placeholders for exercise fields and status messages in `backend/admin/translations.js`.

### Testing
- Launched a local static server with `python -m http.server 4173` and exercised the UI by loading `http://127.0.0.1:4173/index.html` with Playwright to capture a screenshot; the page loaded and the screenshot artifact was produced successfully.
- No unit or integration tests were added; manual/visual smoke test via the screenshot succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697754fa122083339b1cc70febf4de46)