### PR TITLE
Separate translation tables for exercise guides and terminology

### DIFF
--- a/lib/data/exercise_translations.dart
+++ b/lib/data/exercise_translations.dart
@@ -1,0 +1,264 @@
+class ExerciseGuideStrings {
+  const ExerciseGuideStrings({
+    required this.name,
+    required this.focus,
+    required this.tip,
+    required this.description,
+  });
+
+  final String name;
+  final String focus;
+  final String tip;
+  final String description;
+
+  static ExerciseGuideStrings fallback(String slug) {
+    return ExerciseGuideStrings(
+      name: slug,
+      focus: '',
+      tip: '',
+      description: '',
+    );
+  }
+}
+
+class ExerciseGuideTranslations {
+  static const Map<String, Map<String, ExerciseGuideStrings>> _translations = {
+    'en': {
+      'pullup': ExerciseGuideStrings(
+        name: 'Pull-up',
+        focus: 'Lats, biceps, grip',
+        tip: 'Drive elbows toward your ribs and keep your ribs tucked to avoid swinging.',
+        description:
+            'Start from a hollow body hang, then pull until your chin clears the bar. Control the descent for stronger reps.',
+      ),
+      'chinup': ExerciseGuideStrings(
+        name: 'Chin-up',
+        focus: 'Lats, biceps, grip',
+        tip:
+            'Keep your shoulders down and drive your elbows toward your ribs to stay strong at the top.',
+        description:
+            'Start from a dead hang with palms facing you, pull until your chin clears the bar, then lower under control.',
+      ),
+      'pushup': ExerciseGuideStrings(
+        name: 'Push-up',
+        focus: 'Chest, triceps, core',
+        tip: 'Squeeze your glutes and keep a straight line from head to heels.',
+        description:
+            'Lower with elbows at roughly 45° to your torso, touch your chest lightly, then press back up without letting hips sag.',
+      ),
+      'bodyweight-squat': ExerciseGuideStrings(
+        name: 'Bodyweight squat',
+        focus: 'Quads, glutes, core',
+        tip: 'Push your knees out as you descend and keep your heels planted.',
+        description:
+            'Sit the hips back and down until thighs are at least parallel. Drive evenly through the whole foot to stand tall.',
+      ),
+      'glute-bridge': ExerciseGuideStrings(
+        name: 'Glute bridge',
+        focus: 'Glutes, hamstrings, core',
+        tip: 'Exhale as you lift and avoid arching your lower back at the top.',
+        description:
+            'Lie on your back with knees bent, drive through your heels to lift hips until thighs and torso align, then lower with control.',
+      ),
+      'hanging-leg-raise': ExerciseGuideStrings(
+        name: 'Hanging leg raise',
+        focus: 'Abdominals, hip flexors, grip',
+        tip: 'Initiate each rep by engaging your lats to steady the torso.',
+        description:
+            'From a dead hang, lift your legs together until they reach hip height or higher. Lower slowly to keep tension.',
+      ),
+      'muscle-up': ExerciseGuideStrings(
+        name: 'Muscle-up',
+        focus: 'Lats, chest, triceps, transition strength',
+        tip: 'Pull high to your upper chest and keep the bar close to reduce the swing.',
+        description:
+            'From a controlled hang, explode into a high pull, transition the wrists over the bar, and press to lockout.',
+      ),
+      'straight-bar-dip': ExerciseGuideStrings(
+        name: 'Straight bar dip',
+        focus: 'Chest, triceps, shoulders',
+        tip: 'Keep elbows tucked and press down while leaning slightly forward.',
+        description:
+            'Start on top of the bar with locked elbows, lower under control until shoulders dip below elbows, then drive back up.',
+      ),
+      'dips': ExerciseGuideStrings(
+        name: 'Dips',
+        focus: 'Chest, triceps, shoulders',
+        tip: 'Lean slightly forward and keep shoulders packed to protect the joints.',
+        description:
+            'Start locked out on parallel bars, lower until shoulders dip below elbows, then press back to a strong lockout.',
+      ),
+      'australian-row': ExerciseGuideStrings(
+        name: 'Australian row',
+        focus: 'Upper back, biceps, core',
+        tip: 'Brace your core and keep a straight line from shoulders to heels.',
+        description:
+            'Set the bar at waist height, hang underneath, and row your chest to the bar with elbows tight.',
+      ),
+      'pike-pushup': ExerciseGuideStrings(
+        name: 'Pike push-up',
+        focus: 'Shoulders, triceps, core',
+        tip: 'Keep hips high and lower your head to a spot just in front of your hands.',
+        description:
+            'From a pike position, bend elbows to bring the head down, then press back to a strong lockout.',
+      ),
+      'hollow-hold': ExerciseGuideStrings(
+        name: 'Hollow body hold',
+        focus: 'Core, hip flexors, posture',
+        tip: 'Press your lower back into the floor and keep your ribs tucked.',
+        description:
+            'Lie on your back, lift shoulders and legs, and hold a banana shape with straight arms overhead.',
+      ),
+      'plank': ExerciseGuideStrings(
+        name: 'Plank',
+        focus: 'Core, shoulders, glutes',
+        tip: "Squeeze glutes and keep your ribs tucked so the hips don't sag.",
+        description:
+            'Set forearms under shoulders, extend legs long, and hold a straight line from head to heels while breathing steadily.',
+      ),
+      'l-sit': ExerciseGuideStrings(
+        name: 'L-sit',
+        focus: 'Core, hip flexors, triceps',
+        tip: 'Push the floor away, lock elbows, and keep knees straight.',
+        description:
+            'From parallel bars or the floor, lift your legs to hip height and hold a tight L position.',
+      ),
+      'handstand': ExerciseGuideStrings(
+        name: 'Handstand hold',
+        focus: 'Shoulders, core, balance',
+        tip: 'Stack wrists, shoulders, and hips while squeezing your glutes.',
+        description:
+            'Kick or press up to a wall or free balance and hold a tall line with toes pointed.',
+      ),
+    },
+    'it': {
+      'pullup': ExerciseGuideStrings(
+        name: 'Trazioni',
+        focus: 'Dorsali, bicipiti, presa',
+        tip:
+            'Spingi i gomiti verso le costole e mantieni le costole in dentro per evitare oscillazioni.',
+        description:
+            'Parti da una posizione hollow in sospensione, poi tira fino a superare la sbarra con il mento. Controlla la discesa per ripetizioni più solide.',
+      ),
+      'chinup': ExerciseGuideStrings(
+        name: 'Chin-up',
+        focus: 'Dorsali, bicipiti, presa',
+        tip:
+            'Mantieni le spalle basse e spingi i gomiti verso le costole per restare forte in cima.',
+        description:
+            'Parti da sospensione con i palmi verso di te, tira fino a superare la sbarra con il mento, poi scendi in controllo.',
+      ),
+      'pushup': ExerciseGuideStrings(
+        name: 'Piegamenti',
+        focus: 'Petto, tricipiti, core',
+        tip: 'Contrai i glutei e tieni una linea dritta dalla testa ai talloni.',
+        description:
+            'Scendi con gomiti a circa 45° rispetto al busto, tocca leggermente il petto e risali senza lasciare cadere i fianchi.',
+      ),
+      'bodyweight-squat': ExerciseGuideStrings(
+        name: 'Squat a corpo libero',
+        focus: 'Quadricipiti, glutei, core',
+        tip: 'Spingi le ginocchia verso l’esterno mentre scendi e tieni i talloni a terra.',
+        description:
+            'Porta le anche indietro e in basso fino a quando le cosce sono almeno parallele. Spingi in modo uniforme su tutto il piede per risalire.',
+      ),
+      'glute-bridge': ExerciseGuideStrings(
+        name: 'Ponte glutei',
+        focus: 'Glutei, femorali, core',
+        tip: 'Espira mentre sali ed evita di inarcare la schiena in alto.',
+        description:
+            'Sdraiati con ginocchia piegate, spingi sui talloni per sollevare le anche finché cosce e busto sono allineati, poi scendi in controllo.',
+      ),
+      'hanging-leg-raise': ExerciseGuideStrings(
+        name: 'Sollevamento gambe alla sbarra',
+        focus: 'Addome, flessori dell’anca, presa',
+        tip: 'Inizia ogni ripetizione attivando i dorsali per stabilizzare il torso.',
+        description:
+            'Da sospensione, solleva le gambe unite fino all’altezza delle anche o più. Scendi lentamente per mantenere tensione.',
+      ),
+      'muscle-up': ExerciseGuideStrings(
+        name: 'Muscle-up',
+        focus: 'Dorsali, petto, tricipiti, forza di transizione',
+        tip: 'Tira alto verso la parte alta del petto e tieni la sbarra vicina per ridurre l’oscillazione.',
+        description:
+            'Da una sospensione controllata esplodi in una tirata alta, passa con i polsi sopra la sbarra e spingi fino al blocco.',
+      ),
+      'straight-bar-dip': ExerciseGuideStrings(
+        name: 'Dip alla sbarra',
+        focus: 'Petto, tricipiti, spalle',
+        tip: 'Tieni i gomiti stretti e spingi verso il basso inclinando leggermente il busto in avanti.',
+        description:
+            'Inizia sopra la sbarra con gomiti bloccati, scendi in controllo finché le spalle scendono sotto i gomiti, poi risali con decisione.',
+      ),
+      'dips': ExerciseGuideStrings(
+        name: 'Dip alle parallele',
+        focus: 'Petto, tricipiti, spalle',
+        tip: 'Inclina leggermente il busto e tieni le spalle compatte per proteggere le articolazioni.',
+        description:
+            'Parti in posizione di blocco sulle parallele, scendi finché le spalle scendono sotto i gomiti, poi risali fino al blocco.',
+      ),
+      'australian-row': ExerciseGuideStrings(
+        name: 'Rematore australiano',
+        focus: 'Dorso alto, bicipiti, core',
+        tip: 'Contrai il core e mantieni una linea dritta da spalle a talloni.',
+        description:
+            'Regola la sbarra all’altezza della vita, appenditi sotto e tira il petto verso la sbarra con gomiti stretti.',
+      ),
+      'pike-pushup': ExerciseGuideStrings(
+        name: 'Piegamenti in pike',
+        focus: 'Spalle, tricipiti, core',
+        tip: 'Mantieni i fianchi alti e abbassa la testa verso un punto davanti alle mani.',
+        description:
+            'Da posizione pike, piega i gomiti per portare la testa verso il basso, poi risali fino al blocco.',
+      ),
+      'hollow-hold': ExerciseGuideStrings(
+        name: 'Tenuta hollow body',
+        focus: 'Core, flessori dell’anca, postura',
+        tip: 'Premi la zona lombare a terra e tieni le costole in dentro.',
+        description:
+            'Sdraiati, solleva spalle e gambe e mantieni la posizione a banana con braccia tese sopra la testa.',
+      ),
+      'plank': ExerciseGuideStrings(
+        name: 'Plank',
+        focus: 'Core, spalle, glutei',
+        tip: 'Contrai i glutei e tieni le costole in dentro per evitare il cedimento dei fianchi.',
+        description:
+            'Appoggia gli avambracci sotto le spalle, estendi le gambe e mantieni una linea dritta dalla testa ai talloni respirando in modo costante.',
+      ),
+      'l-sit': ExerciseGuideStrings(
+        name: 'L-sit',
+        focus: 'Core, flessori dell’anca, tricipiti',
+        tip: 'Spingi il pavimento, blocca i gomiti e tieni le ginocchia tese.',
+        description:
+            'Da parallele o da terra, solleva le gambe all’altezza delle anche e mantieni una L compatta.',
+      ),
+      'handstand': ExerciseGuideStrings(
+        name: 'Tenuta in verticale',
+        focus: 'Spalle, core, equilibrio',
+        tip: 'Allinea polsi, spalle e anche mentre contrai i glutei.',
+        description:
+            'Calcia o sali in verticale al muro o in equilibrio libero e mantieni una linea alta con le punte tese.',
+      ),
+    },
+  };
+
+  static String _normalizeLocale(String locale) {
+    if (locale.isEmpty) return 'en';
+    return locale.split('_').first.toLowerCase();
+  }
+
+  static ExerciseGuideStrings forSlug(String slug, String locale) {
+    final normalizedLocale = _normalizeLocale(locale);
+    final byLocale = _translations[normalizedLocale];
+    final fallbackLocale = _translations['en'];
+    return byLocale?[slug] ??
+        fallbackLocale?[slug] ??
+        ExerciseGuideStrings.fallback(slug);
+  }
+
+  static String? nameForSlug(String slug, String locale) {
+    final normalizedLocale = _normalizeLocale(locale);
+    return _translations[normalizedLocale]?[slug]?.name ??
+        _translations['en']?[slug]?.name;
+  }
+}

--- a/lib/data/terminology_translations.dart
+++ b/lib/data/terminology_translations.dart
@@ -1,0 +1,201 @@
+class TerminologyTranslation {
+  const TerminologyTranslation({
+    required this.termKey,
+    required this.title,
+    required this.description,
+    required this.sortOrder,
+  });
+
+  final String termKey;
+  final String title;
+  final String description;
+  final int sortOrder;
+}
+
+class TerminologyTranslations {
+  static const Map<String, List<TerminologyTranslation>> _translations = {
+    'en': [
+      TerminologyTranslation(
+        termKey: 'reps',
+        title: 'Reps',
+        description: 'Number of times you perform an exercise consecutively.',
+        sortOrder: 1,
+      ),
+      TerminologyTranslation(
+        termKey: 'set',
+        title: 'Set',
+        description:
+            'A group of repetitions. For example: 3 sets of 10 reps means 30 repetitions total divided into 3 groups.',
+        sortOrder: 2,
+      ),
+      TerminologyTranslation(
+        termKey: 'rt',
+        title: 'RT',
+        description:
+            'Total Repetitions: perform all the reps with your preferred sets, reps, and tempo (if not specified).',
+        sortOrder: 3,
+      ),
+      TerminologyTranslation(
+        termKey: 'amrap',
+        title: 'AMRAP',
+        description:
+            'As Many Reps As Possible: perform as many reps as you can in a given time.',
+        sortOrder: 4,
+      ),
+      TerminologyTranslation(
+        termKey: 'emom',
+        title: 'EMOM',
+        description:
+            'Every Minute on the Minute: start a set every minute. Rest during the remaining time.',
+        sortOrder: 5,
+      ),
+      TerminologyTranslation(
+        termKey: 'ramping',
+        title: 'Ramping',
+        description: 'Method where the load increases with each set.',
+        sortOrder: 6,
+      ),
+      TerminologyTranslation(
+        termKey: 'mav',
+        title: 'MAV',
+        description:
+            'Massima Alzata Veloce: perform as many reps as possible with a load while keeping control and good speed.',
+        sortOrder: 7,
+      ),
+      TerminologyTranslation(
+        termKey: 'isokinetic',
+        title: 'Isokinetic',
+        description: 'Exercises performed at a constant speed.',
+        sortOrder: 8,
+      ),
+      TerminologyTranslation(
+        termKey: 'tut',
+        title: 'TUT',
+        description:
+            'Indicates how long a repetition should last. You can manage the duration of each phase.',
+        sortOrder: 9,
+      ),
+      TerminologyTranslation(
+        termKey: 'iso',
+        title: 'ISO',
+        description:
+            'Indicates a pause at a specific point of the repetition.',
+        sortOrder: 10,
+      ),
+      TerminologyTranslation(
+        termKey: 'som',
+        title: 'SOM',
+        description: 'Indicates the duration of each phase of the repetition.',
+        sortOrder: 11,
+      ),
+      TerminologyTranslation(
+        termKey: 'deload',
+        title: 'Deload',
+        description: 'Last week of the program to prepare for max attempts.',
+        sortOrder: 12,
+      ),
+    ],
+    'it': [
+      TerminologyTranslation(
+        termKey: 'reps',
+        title: 'Reps (Ripetizioni)',
+        description: 'Numero di volte che esegui un esercizio consecutivamente.',
+        sortOrder: 1,
+      ),
+      TerminologyTranslation(
+        termKey: 'set',
+        title: 'Set (Serie)',
+        description:
+            'Un gruppo di ripetizioni. Es: 3 serie da 10 reps significa 30 ripetizioni totali, divise in 3 gruppi.',
+        sortOrder: 2,
+      ),
+      TerminologyTranslation(
+        termKey: 'rt',
+        title: 'RT',
+        description:
+            'Ripetizioni Totali: indica che devi fare tutte quelle reps, con libera scelta di serie, ripetizioni e tempo (se non indicato).',
+        sortOrder: 3,
+      ),
+      TerminologyTranslation(
+        termKey: 'amrap',
+        title: 'AMRAP',
+        description:
+            'As Many Reps As Possible: esegui quante più ripetizioni possibili in un tempo determinato.',
+        sortOrder: 4,
+      ),
+      TerminologyTranslation(
+        termKey: 'emom',
+        title: 'EMOM',
+        description:
+            'Every Minute On Minute: inizi un set ogni minuto. Il tempo restante serve per riposare.',
+        sortOrder: 5,
+      ),
+      TerminologyTranslation(
+        termKey: 'ramping',
+        title: 'Ramping',
+        description: 'Metodo che prevede un incremento del peso ad ogni serie',
+        sortOrder: 6,
+      ),
+      TerminologyTranslation(
+        termKey: 'mav',
+        title: 'MAV',
+        description:
+            'Massima Alzata Veloce: si riferisce a una metodologia in cui si cerca di eseguire il maggior numero di ripetizioni possibili con un carico, mantenendo sempre il controllo del movimento e una buona velocità di esecuzione.',
+        sortOrder: 7,
+      ),
+      TerminologyTranslation(
+        termKey: 'isokinetic',
+        title: 'Isocinetici',
+        description: 'Esercizi svolti a velocità costante.',
+        sortOrder: 8,
+      ),
+      TerminologyTranslation(
+        termKey: 'tut',
+        title: 'TUT',
+        description:
+            'Indica quanto deve durare una ripetizione. Puoi gestire tu la durata di ogni fase della rep.',
+        sortOrder: 9,
+      ),
+      TerminologyTranslation(
+        termKey: 'iso',
+        title: 'ISO',
+        description:
+            "Indica il fermo a un punto specifico dell'esecuzione della rep",
+        sortOrder: 10,
+      ),
+      TerminologyTranslation(
+        termKey: 'som',
+        title: 'SOM',
+        description: 'Indica la durata di ogni fase della ripetizione.',
+        sortOrder: 11,
+      ),
+      TerminologyTranslation(
+        termKey: 'deload',
+        title: 'Scarico',
+        description: 'Ultima settimana della scheda per prepararsi ai massimali.',
+        sortOrder: 12,
+      ),
+    ],
+  };
+
+  static String _normalizeLocale(String locale) {
+    if (locale.isEmpty) return 'en';
+    return locale.split('_').first.toLowerCase();
+  }
+
+  static List<TerminologyTranslation> listForLocale(String locale) {
+    final normalized = _normalizeLocale(locale);
+    return _translations[normalized] ?? _translations['en'] ?? const [];
+  }
+
+  static TerminologyTranslation? lookup(String termKey, String locale) {
+    final normalizedKey = termKey.trim().toLowerCase();
+    if (normalizedKey.isEmpty) return null;
+    for (final entry in listForLocale(locale)) {
+      if (entry.termKey == normalizedKey) {
+        return entry;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/model/exercise_guide.dart
+++ b/lib/model/exercise_guide.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../data/exercise_translations.dart';
 import '../l10n/app_localizations.dart';
 
 enum Difficulty { beginner, intermediate, advanced }
@@ -52,10 +53,10 @@ class ExerciseGuide {
 
   static ExerciseGuide fromDatabase(
     Map<String, dynamic> row,
-    AppLocalizations l10n,
+    String localeName,
   ) {
     final slug = row['slug'] as String;
-    final strings = ExerciseGuideStrings.fromSlug(slug, l10n);
+    final strings = ExerciseGuideTranslations.forSlug(slug, localeName);
     return ExerciseGuide(
       id: slug,
       name: strings.name,
@@ -91,139 +92,5 @@ class ExerciseGuide {
       return Colors.blueGrey;
     }
     return Color(colorValue);
-  }
-}
-
-class ExerciseGuideStrings {
-  const ExerciseGuideStrings({
-    required this.name,
-    required this.focus,
-    required this.tip,
-    required this.description,
-  });
-
-  final String name;
-  final String focus;
-  final String tip;
-  final String description;
-
-  static ExerciseGuideStrings fromSlug(
-    String slug,
-    AppLocalizations l10n,
-  ) {
-    switch (slug) {
-      case 'pullup':
-        return ExerciseGuideStrings(
-          name: l10n.guidesPullupName,
-          focus: l10n.guidesPullupFocus,
-          tip: l10n.guidesPullupTip,
-          description: l10n.guidesPullupDescription,
-        );
-      case 'chinup':
-        return ExerciseGuideStrings(
-          name: l10n.guidesChinUpName,
-          focus: l10n.guidesChinUpFocus,
-          tip: l10n.guidesChinUpTip,
-          description: l10n.guidesChinUpDescription,
-        );
-      case 'pushup':
-        return ExerciseGuideStrings(
-          name: l10n.guidesPushupName,
-          focus: l10n.guidesPushupFocus,
-          tip: l10n.guidesPushupTip,
-          description: l10n.guidesPushupDescription,
-        );
-      case 'bodyweight-squat':
-        return ExerciseGuideStrings(
-          name: l10n.guidesBodyweightSquatName,
-          focus: l10n.guidesBodyweightSquatFocus,
-          tip: l10n.guidesBodyweightSquatTip,
-          description: l10n.guidesBodyweightSquatDescription,
-        );
-      case 'glute-bridge':
-        return ExerciseGuideStrings(
-          name: l10n.guidesGluteBridgeName,
-          focus: l10n.guidesGluteBridgeFocus,
-          tip: l10n.guidesGluteBridgeTip,
-          description: l10n.guidesGluteBridgeDescription,
-        );
-      case 'hanging-leg-raise':
-        return ExerciseGuideStrings(
-          name: l10n.guidesHangingLegRaiseName,
-          focus: l10n.guidesHangingLegRaiseFocus,
-          tip: l10n.guidesHangingLegRaiseTip,
-          description: l10n.guidesHangingLegRaiseDescription,
-        );
-      case 'muscle-up':
-        return ExerciseGuideStrings(
-          name: l10n.guidesMuscleUpName,
-          focus: l10n.guidesMuscleUpFocus,
-          tip: l10n.guidesMuscleUpTip,
-          description: l10n.guidesMuscleUpDescription,
-        );
-      case 'straight-bar-dip':
-        return ExerciseGuideStrings(
-          name: l10n.guidesStraightBarDipName,
-          focus: l10n.guidesStraightBarDipFocus,
-          tip: l10n.guidesStraightBarDipTip,
-          description: l10n.guidesStraightBarDipDescription,
-        );
-      case 'dips':
-        return ExerciseGuideStrings(
-          name: l10n.guidesDipsName,
-          focus: l10n.guidesDipsFocus,
-          tip: l10n.guidesDipsTip,
-          description: l10n.guidesDipsDescription,
-        );
-      case 'australian-row':
-        return ExerciseGuideStrings(
-          name: l10n.guidesAustralianRowName,
-          focus: l10n.guidesAustralianRowFocus,
-          tip: l10n.guidesAustralianRowTip,
-          description: l10n.guidesAustralianRowDescription,
-        );
-      case 'pike-pushup':
-        return ExerciseGuideStrings(
-          name: l10n.guidesPikePushUpName,
-          focus: l10n.guidesPikePushUpFocus,
-          tip: l10n.guidesPikePushUpTip,
-          description: l10n.guidesPikePushUpDescription,
-        );
-      case 'hollow-hold':
-        return ExerciseGuideStrings(
-          name: l10n.guidesHollowHoldName,
-          focus: l10n.guidesHollowHoldFocus,
-          tip: l10n.guidesHollowHoldTip,
-          description: l10n.guidesHollowHoldDescription,
-        );
-      case 'plank':
-        return ExerciseGuideStrings(
-          name: l10n.guidesPlankName,
-          focus: l10n.guidesPlankFocus,
-          tip: l10n.guidesPlankTip,
-          description: l10n.guidesPlankDescription,
-        );
-      case 'l-sit':
-        return ExerciseGuideStrings(
-          name: l10n.guidesLSitName,
-          focus: l10n.guidesLSitFocus,
-          tip: l10n.guidesLSitTip,
-          description: l10n.guidesLSitDescription,
-        );
-      case 'handstand':
-        return ExerciseGuideStrings(
-          name: l10n.guidesHandstandName,
-          focus: l10n.guidesHandstandFocus,
-          tip: l10n.guidesHandstandTip,
-          description: l10n.guidesHandstandDescription,
-        );
-      default:
-        return ExerciseGuideStrings(
-          name: slug,
-          focus: '',
-          tip: '',
-          description: '',
-        );
-    }
   }
 }

--- a/lib/model/terminology_entry.dart
+++ b/lib/model/terminology_entry.dart
@@ -1,4 +1,5 @@
 import 'package:supabase_flutter/supabase_flutter.dart';
+import '../data/terminology_translations.dart';
 
 class TerminologyEntry {
   const TerminologyEntry({
@@ -25,6 +26,20 @@ class TerminologyEntry {
       term: data['title']?.toString() ?? '',
       description: data['description']?.toString() ?? '',
       sortOrder: (data['sort_order'] as int?) ?? 0,
+    );
+  }
+
+  factory TerminologyEntry.fromTranslation(
+    TerminologyTranslation translation,
+    String locale,
+  ) {
+    return TerminologyEntry(
+      id: translation.termKey,
+      termKey: translation.termKey,
+      locale: locale,
+      term: translation.title,
+      description: translation.description,
+      sortOrder: translation.sortOrder,
     );
   }
 

--- a/lib/pages/exercise_guides.dart
+++ b/lib/pages/exercise_guides.dart
@@ -32,7 +32,9 @@ class _ExerciseGuidesPageState extends State<ExerciseGuidesPage> {
         .select('slug, difficulty, default_unlocked, accent')
         .order('sort_order', ascending: true);
     final rows = (response as List<dynamic>).cast<Map<String, dynamic>>();
-    return rows.map((row) => ExerciseGuide.fromDatabase(row, l10n)).toList();
+    return rows
+        .map((row) => ExerciseGuide.fromDatabase(row, l10n.localeName))
+        .toList();
   }
 
   @override

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../components/plan_expired_gate.dart';
+import '../data/exercise_translations.dart';
+import '../data/terminology_translations.dart';
 import '../l10n/app_localizations.dart';
 
 class Training extends StatefulWidget {
@@ -356,8 +358,23 @@ class _ExerciseCard extends StatelessWidget {
       decoration: isCompleted ? TextDecoration.lineThrough : null,
     );
 
-    final hasTerminology = exercise.terminology.isNotEmpty;
-    final hasSkills = exercise.skills.isNotEmpty;
+    final localizedTerminology = exercise.terminology
+        .map(
+          (term) =>
+              TerminologyTranslations.lookup(term, l10n.localeName)?.title ??
+              term,
+        )
+        .toList();
+    final localizedSkills = exercise.skills
+        .map(
+          (skill) =>
+              ExerciseGuideTranslations.nameForSlug(skill, l10n.localeName) ??
+              skill,
+        )
+        .toList();
+
+    final hasTerminology = localizedTerminology.isNotEmpty;
+    final hasSkills = localizedSkills.isNotEmpty;
 
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 8),
@@ -410,14 +427,14 @@ class _ExerciseCard extends StatelessWidget {
                         if (hasTerminology)
                           _InfoChips(
                             title: l10n.terminologyTitle,
-                            items: exercise.terminology,
+                            items: localizedTerminology,
                           ),
                         if (hasTerminology && hasSkills)
                           const SizedBox(height: 8),
                         if (hasSkills)
                           _InfoChips(
                             title: l10n.guidesTitle,
-                            items: exercise.skills,
+                            items: localizedSkills,
                           ),
                       ],
                     ],


### PR DESCRIPTION
### Motivation
- Move exercise guide and terminology strings out of ad-hoc places and into dedicated, locale-aware translation tables to enable easier maintenance and to provide local fallbacks when remote data is missing.

### Description
- Add `lib/data/exercise_translations.dart` and `lib/data/terminology_translations.dart` containing in-code translation tables and lookup helpers for exercise guides and terminology respectively.
- Refactor exercise guide construction to use `ExerciseGuideTranslations.forSlug(...)` by changing `ExerciseGuide.fromDatabase` to accept a `localeName` and removing the previous inline mapping logic from `lib/model/exercise_guide.dart`.
- Update pages to consume the new tables: `lib/pages/exercise_guides.dart` now passes `l10n.localeName` into guide hydration, `lib/pages/training.dart` localizes terminology and skill names for chips using the new translation helpers, and `lib/pages/terminology.dart` falls back to the in-code terminology list when Supabase entries are missing or fetch fails.
- Add `TerminologyEntry.fromTranslation` factory in `lib/model/terminology_entry.dart` to construct entries from the new in-code terminology entries.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697758242f248333959b2665b095e0a0)