### PR TITLE
Add fromSlug helper for exercise guide strings

### DIFF
--- a/lib/data/exercise_translations.dart
+++ b/lib/data/exercise_translations.dart
@@ -1,3 +1,5 @@
+import '../l10n/app_localizations.dart';
+
 class ExerciseGuideStrings {
   const ExerciseGuideStrings({
     required this.name,
@@ -18,6 +20,10 @@ class ExerciseGuideStrings {
       tip: '',
       description: '',
     );
+  }
+
+  static ExerciseGuideStrings fromSlug(String slug, AppLocalizations l10n) {
+    return ExerciseGuideTranslations.forSlug(slug, l10n.localeName);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a convenience helper to resolve localized exercise guide strings using an `AppLocalizations` instance; no skills were used.

### Description
- Add `import '../l10n/app_localizations.dart'` and a static `ExerciseGuideStrings.fromSlug(String slug, AppLocalizations l10n)` that delegates to `ExerciseGuideTranslations.forSlug(slug, l10n.localeName)` in `lib/data/exercise_translations.dart`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775d41992c8333a6e5db878f6bf3de)