### PR TITLE
Localize home, timer and related UI strings; add l10n keys

### DIFF
--- a/lib/components/progress_card.dart
+++ b/lib/components/progress_card.dart
@@ -1,6 +1,8 @@
 import 'package:calisync/components/section_card.dart';
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
+
 class ProgressCard extends StatelessWidget {
   const ProgressCard({
     super.key
@@ -8,13 +10,17 @@ class ProgressCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
+    const workoutsCompleted = 245;
+    const hoursTrained = 75;
+    const minutesTrained = 30;
     return SectionCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Progress',
+            l10n.homeProgressTitle,
             style: theme.textTheme.titleMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
               fontWeight: FontWeight.w600,
@@ -25,16 +31,16 @@ class ProgressCard extends StatelessWidget {
             children: [
               Expanded(
                 child: _StatTile(
-                  value: '245',
-                  label: 'Workouts',
+                  value: workoutsCompleted.toString(),
+                  label: l10n.homeProgressWorkoutsLabel,
                   icon: Icons.fitness_center,
                 ),
               ),
               const SizedBox(width: 12),
               Expanded(
                 child: _StatTile(
-                  value: '75h 30m',
-                  label: 'Time Trained',
+                  value: l10n.homeProgressTimeValue(hoursTrained, minutesTrained),
+                  label: l10n.homeProgressTimeTrainedLabel,
                   icon: Icons.timer,
                 ),
               ),
@@ -99,4 +105,3 @@ class _StatTile extends StatelessWidget {
     );
   }
 }
-

--- a/lib/components/skill_progress_card.dart
+++ b/lib/components/skill_progress_card.dart
@@ -1,18 +1,23 @@
 import 'package:calisync/components/section_card.dart';
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
+
 class SkillProgressCard extends StatelessWidget {
   const SkillProgressCard({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
+    const unlockedSkills = 5;
+    const totalSkills = 8;
     return SectionCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            'Skill Progress',
+            l10n.homeSkillProgressTitle,
             style: theme.textTheme.titleMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -21,14 +26,14 @@ class SkillProgressCard extends StatelessWidget {
           Row(
             children: [
               Text(
-                '5 / 8',
+                l10n.homeSkillProgressValue(unlockedSkills, totalSkills),
                 style: theme.textTheme.headlineSmall?.copyWith(
                   fontWeight: FontWeight.w700,
                 ),
               ),
               const SizedBox(width: 8),
               Text(
-                'Skills Unlocked',
+                l10n.homeSkillProgressLabel,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),

--- a/lib/components/strength_level_card.dart
+++ b/lib/components/strength_level_card.dart
@@ -1,11 +1,14 @@
 import 'package:calisync/components/section_card.dart';
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
+
 class StrengthLevelCard extends StatelessWidget {
   const StrengthLevelCard({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     return SectionCard(
       child: Row(
@@ -15,7 +18,7 @@ class StrengthLevelCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Strength Level',
+                  l10n.homeStrengthLevelTitle,
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -29,7 +32,7 @@ class StrengthLevelCard extends StatelessWidget {
                     ),
                     const SizedBox(width: 6),
                     Text(
-                      'Advanced',
+                      l10n.difficultyAdvanced,
                       style: theme.textTheme.titleLarge?.copyWith(
                         fontWeight: FontWeight.w700,
                       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -17,6 +17,7 @@
   "onboardingGetStarted": "Get started",
   "guidesTitle": "Skills",
   "guidesSubtitle": "Unlock new skills as you master the basics.",
+  "guidesLoadError": "Unable to load skill guides right now.",
   "guidesPrimaryFocus": "Primary focus",
   "guidesCoachTip": "Coach tip",
   "skillsLockedLabel": "Locked",
@@ -90,6 +91,43 @@
   "retry": "Retry",
   "homeCoachTipTitle": "Coach Tip",
   "homeCoachTipPlaceholder": "Your coach's latest tip will appear here.",
+  "homeGreeting": "Hi, {name}!",
+  "@homeGreeting": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "homeViewStats": "View Stats",
+  "homeProgressTitle": "Progress",
+  "homeProgressWorkoutsLabel": "Workouts",
+  "homeProgressTimeTrainedLabel": "Time Trained",
+  "homeProgressTimeValue": "{hours}h {minutes}m",
+  "@homeProgressTimeValue": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "homeSkillProgressTitle": "Skill Progress",
+  "homeSkillProgressValue": "{unlocked} / {total}",
+  "@homeSkillProgressValue": {
+    "placeholders": {
+      "unlocked": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "homeSkillProgressLabel": "Skills Unlocked",
+  "homeStrengthLevelTitle": "Strength Level",
   "workoutPlanTitle": "Workout plan",
   "traineeFeedbackTitle": "Trainee feedback",
   "traineeFeedbackSubtitle": "Tell your coach how you're feeling and how the plan is going.",
@@ -120,11 +158,20 @@
   "unauthenticated": "User not authenticated",
   "defaultExerciseName": "Exercise",
   "trainingHeaderExercise": "Exercise",
+  "trainingHeaderExercises": "Exercises",
   "trainingHeaderSets": "Sets",
   "trainingHeaderReps": "Repetitions",
   "trainingTodayTitle": "Today's Workout",
   "trainingStartWorkout": "Start Workout",
   "trainingWorkoutCompleted": "Workout Completed",
+  "trainingDurationMinutes": "{minutes} min",
+  "@trainingDurationMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "trainingCompletionSaved": "Workout day updated",
   "trainingCompletionError": "Unable to update workout: {error}",
   "@trainingCompletionError": {
@@ -341,6 +388,35 @@
   "add": "Add",
   "start": "Start",
   "timerTitle": "Timer",
+  "timerExercisePushUps": "Push-ups",
+  "timerExercisePullUps": "Pull-ups",
+  "timerExerciseSquats": "Squats",
+  "timerExercisePlank": "Plank",
+  "timerPhaseWork": "WORK",
+  "timerPhaseRest": "REST",
+  "timerWorkDurationLabel": "Work duration",
+  "timerRestDurationLabel": "Rest duration",
+  "timerControlSkip": "SKIP",
+  "timerControlPause": "PAUSE",
+  "timerControlPlay": "PLAY",
+  "timerControlReset": "RESET",
+  "timerAdjustDecrease": "-10s",
+  "timerAdjustIncrease": "+10s",
+  "timerNextPlaceholder": "Next: --",
+  "timerNextLabel": "Next: {name} · Set {current}/{total}",
+  "@timerNextLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "amrapTimerTitle": "AMRAP timer",
   "amrapTimerSubtitle": "Push through as many rounds as possible.",
   "amrapTimerDescription": "Set the total duration and track the remaining time.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -17,6 +17,7 @@
   "onboardingGetStarted": "Inizia",
   "guidesTitle": "Skill",
   "guidesSubtitle": "Sblocca nuove skill man mano che impari le basi.",
+  "guidesLoadError": "Impossibile caricare le guide delle skill al momento.",
   "guidesPrimaryFocus": "Focus principale",
   "guidesCoachTip": "Consiglio del coach",
   "skillsLockedLabel": "Bloccato",
@@ -90,6 +91,43 @@
   "retry": "Riprova",
   "homeCoachTipTitle": "Consiglio del coach",
   "homeCoachTipPlaceholder": "Qui troverai l'ultimo consiglio del tuo coach.",
+  "homeGreeting": "Ciao, {name}!",
+  "@homeGreeting": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "homeViewStats": "Vedi statistiche",
+  "homeProgressTitle": "Progressi",
+  "homeProgressWorkoutsLabel": "Allenamenti",
+  "homeProgressTimeTrainedLabel": "Tempo di allenamento",
+  "homeProgressTimeValue": "{hours}h {minutes}m",
+  "@homeProgressTimeValue": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "homeSkillProgressTitle": "Progressi skill",
+  "homeSkillProgressValue": "{unlocked} / {total}",
+  "@homeSkillProgressValue": {
+    "placeholders": {
+      "unlocked": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "homeSkillProgressLabel": "Skill sbloccate",
+  "homeStrengthLevelTitle": "Livello di forza",
   "workoutPlanTitle": "Piano di allenamento",
   "traineeFeedbackTitle": "Feedback atleta",
   "traineeFeedbackSubtitle": "Racconta al tuo coach come ti senti e come procede il piano.",
@@ -120,11 +158,20 @@
   "unauthenticated": "Utente non autenticato",
   "defaultExerciseName": "Esercizio",
   "trainingHeaderExercise": "Esercizio",
+  "trainingHeaderExercises": "Esercizi",
   "trainingHeaderSets": "Serie",
   "trainingHeaderReps": "Ripetizioni",
   "trainingTodayTitle": "Allenamento di oggi",
   "trainingStartWorkout": "Inizia allenamento",
   "trainingWorkoutCompleted": "Allenamento completato",
+  "trainingDurationMinutes": "{minutes} min",
+  "@trainingDurationMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
   "trainingCompletionSaved": "Allenamento aggiornato",
   "trainingCompletionError": "Impossibile aggiornare l'allenamento: {error}",
   "@trainingCompletionError": {
@@ -341,6 +388,35 @@
   "add": "Aggiungi",
   "start": "Avvia",
   "timerTitle": "Timer",
+  "timerExercisePushUps": "Piegamenti",
+  "timerExercisePullUps": "Trazioni",
+  "timerExerciseSquats": "Squat",
+  "timerExercisePlank": "Plank",
+  "timerPhaseWork": "LAVORO",
+  "timerPhaseRest": "RECUPERO",
+  "timerWorkDurationLabel": "Durata lavoro",
+  "timerRestDurationLabel": "Durata recupero",
+  "timerControlSkip": "SALTA",
+  "timerControlPause": "PAUSA",
+  "timerControlPlay": "AVVIA",
+  "timerControlReset": "RESET",
+  "timerAdjustDecrease": "-10s",
+  "timerAdjustIncrease": "+10s",
+  "timerNextPlaceholder": "Prossimo: --",
+  "timerNextLabel": "Prossimo: {name} · Serie {current}/{total}",
+  "@timerNextLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
   "amrapTimerTitle": "Timer AMRAP",
   "amrapTimerSubtitle": "Spingi per quante più serie possibile.",
   "amrapTimerDescription": "Imposta la durata totale e tieni il tempo rimanente.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -206,6 +206,12 @@ abstract class AppLocalizations {
   /// **'Sblocca nuove skill man mano che impari le basi.'**
   String get guidesSubtitle;
 
+  /// No description provided for @guidesLoadError.
+  ///
+  /// In it, this message translates to:
+  /// **'Impossibile caricare le guide delle skill al momento.'**
+  String get guidesLoadError;
+
   /// No description provided for @guidesPrimaryFocus.
   ///
   /// In it, this message translates to:
@@ -644,6 +650,66 @@ abstract class AppLocalizations {
   /// **'Qui troverai l\'ultimo consiglio del tuo coach.'**
   String get homeCoachTipPlaceholder;
 
+  /// No description provided for @homeGreeting.
+  ///
+  /// In it, this message translates to:
+  /// **'Ciao, {name}!'**
+  String homeGreeting(String name);
+
+  /// No description provided for @homeViewStats.
+  ///
+  /// In it, this message translates to:
+  /// **'Vedi statistiche'**
+  String get homeViewStats;
+
+  /// No description provided for @homeProgressTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Progressi'**
+  String get homeProgressTitle;
+
+  /// No description provided for @homeProgressWorkoutsLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Allenamenti'**
+  String get homeProgressWorkoutsLabel;
+
+  /// No description provided for @homeProgressTimeTrainedLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Tempo di allenamento'**
+  String get homeProgressTimeTrainedLabel;
+
+  /// No description provided for @homeProgressTimeValue.
+  ///
+  /// In it, this message translates to:
+  /// **'{hours}h {minutes}m'**
+  String homeProgressTimeValue(int hours, int minutes);
+
+  /// No description provided for @homeSkillProgressTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Progressi skill'**
+  String get homeSkillProgressTitle;
+
+  /// No description provided for @homeSkillProgressValue.
+  ///
+  /// In it, this message translates to:
+  /// **'{unlocked} / {total}'**
+  String homeSkillProgressValue(int unlocked, int total);
+
+  /// No description provided for @homeSkillProgressLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Skill sbloccate'**
+  String get homeSkillProgressLabel;
+
+  /// No description provided for @homeStrengthLevelTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Livello di forza'**
+  String get homeStrengthLevelTitle;
+
   /// No description provided for @workoutPlanTitle.
   ///
   /// In it, this message translates to:
@@ -782,6 +848,12 @@ abstract class AppLocalizations {
   /// **'Esercizio'**
   String get trainingHeaderExercise;
 
+  /// No description provided for @trainingHeaderExercises.
+  ///
+  /// In it, this message translates to:
+  /// **'Esercizi'**
+  String get trainingHeaderExercises;
+
   /// No description provided for @trainingHeaderSets.
   ///
   /// In it, this message translates to:
@@ -811,6 +883,12 @@ abstract class AppLocalizations {
   /// In it, this message translates to:
   /// **'Allenamento completato'**
   String get trainingWorkoutCompleted;
+
+  /// No description provided for @trainingDurationMinutes.
+  ///
+  /// In it, this message translates to:
+  /// **'{minutes} min'**
+  String trainingDurationMinutes(int minutes);
 
   /// No description provided for @trainingCompletionSaved.
   ///
@@ -1435,6 +1513,102 @@ abstract class AppLocalizations {
   /// In it, this message translates to:
   /// **'Timer'**
   String get timerTitle;
+
+  /// No description provided for @timerExercisePushUps.
+  ///
+  /// In it, this message translates to:
+  /// **'Piegamenti'**
+  String get timerExercisePushUps;
+
+  /// No description provided for @timerExercisePullUps.
+  ///
+  /// In it, this message translates to:
+  /// **'Trazioni'**
+  String get timerExercisePullUps;
+
+  /// No description provided for @timerExerciseSquats.
+  ///
+  /// In it, this message translates to:
+  /// **'Squat'**
+  String get timerExerciseSquats;
+
+  /// No description provided for @timerExercisePlank.
+  ///
+  /// In it, this message translates to:
+  /// **'Plank'**
+  String get timerExercisePlank;
+
+  /// No description provided for @timerPhaseWork.
+  ///
+  /// In it, this message translates to:
+  /// **'LAVORO'**
+  String get timerPhaseWork;
+
+  /// No description provided for @timerPhaseRest.
+  ///
+  /// In it, this message translates to:
+  /// **'RECUPERO'**
+  String get timerPhaseRest;
+
+  /// No description provided for @timerWorkDurationLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Durata lavoro'**
+  String get timerWorkDurationLabel;
+
+  /// No description provided for @timerRestDurationLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Durata recupero'**
+  String get timerRestDurationLabel;
+
+  /// No description provided for @timerControlSkip.
+  ///
+  /// In it, this message translates to:
+  /// **'SALTA'**
+  String get timerControlSkip;
+
+  /// No description provided for @timerControlPause.
+  ///
+  /// In it, this message translates to:
+  /// **'PAUSA'**
+  String get timerControlPause;
+
+  /// No description provided for @timerControlPlay.
+  ///
+  /// In it, this message translates to:
+  /// **'AVVIA'**
+  String get timerControlPlay;
+
+  /// No description provided for @timerControlReset.
+  ///
+  /// In it, this message translates to:
+  /// **'RESET'**
+  String get timerControlReset;
+
+  /// No description provided for @timerAdjustDecrease.
+  ///
+  /// In it, this message translates to:
+  /// **'-10s'**
+  String get timerAdjustDecrease;
+
+  /// No description provided for @timerAdjustIncrease.
+  ///
+  /// In it, this message translates to:
+  /// **'+10s'**
+  String get timerAdjustIncrease;
+
+  /// No description provided for @timerNextPlaceholder.
+  ///
+  /// In it, this message translates to:
+  /// **'Prossimo: --'**
+  String get timerNextPlaceholder;
+
+  /// No description provided for @timerNextLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Prossimo: {name} · Serie {current}/{total}'**
+  String timerNextLabel(String name, int current, int total);
 
   /// No description provided for @amrapTimerTitle.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -66,6 +66,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get guidesSubtitle => 'Unlock new skills as you master the basics.';
 
   @override
+  String get guidesLoadError => 'Unable to load skill guides right now.';
+
+  @override
   String get guidesPrimaryFocus => 'Primary focus';
 
   @override
@@ -317,6 +320,42 @@ class AppLocalizationsEn extends AppLocalizations {
       'Your coach\'s latest tip will appear here.';
 
   @override
+  String homeGreeting(String name) {
+    return 'Hi, $name!';
+  }
+
+  @override
+  String get homeViewStats => 'View Stats';
+
+  @override
+  String get homeProgressTitle => 'Progress';
+
+  @override
+  String get homeProgressWorkoutsLabel => 'Workouts';
+
+  @override
+  String get homeProgressTimeTrainedLabel => 'Time Trained';
+
+  @override
+  String homeProgressTimeValue(int hours, int minutes) {
+    return '${hours}h ${minutes}m';
+  }
+
+  @override
+  String get homeSkillProgressTitle => 'Skill Progress';
+
+  @override
+  String homeSkillProgressValue(int unlocked, int total) {
+    return '$unlocked / $total';
+  }
+
+  @override
+  String get homeSkillProgressLabel => 'Skills Unlocked';
+
+  @override
+  String get homeStrengthLevelTitle => 'Strength Level';
+
+  @override
   String get workoutPlanTitle => 'Workout plan';
 
   @override
@@ -394,6 +433,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get trainingHeaderExercise => 'Exercise';
 
   @override
+  String get trainingHeaderExercises => 'Exercises';
+
+  @override
   String get trainingHeaderSets => 'Sets';
 
   @override
@@ -407,6 +449,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get trainingWorkoutCompleted => 'Workout Completed';
+
+  @override
+  String trainingDurationMinutes(int minutes) {
+    return '$minutes min';
+  }
 
   @override
   String get trainingCompletionSaved => 'Workout day updated';
@@ -763,6 +810,56 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get timerTitle => 'Timer';
+
+  @override
+  String get timerExercisePushUps => 'Push-ups';
+
+  @override
+  String get timerExercisePullUps => 'Pull-ups';
+
+  @override
+  String get timerExerciseSquats => 'Squats';
+
+  @override
+  String get timerExercisePlank => 'Plank';
+
+  @override
+  String get timerPhaseWork => 'WORK';
+
+  @override
+  String get timerPhaseRest => 'REST';
+
+  @override
+  String get timerWorkDurationLabel => 'Work duration';
+
+  @override
+  String get timerRestDurationLabel => 'Rest duration';
+
+  @override
+  String get timerControlSkip => 'SKIP';
+
+  @override
+  String get timerControlPause => 'PAUSE';
+
+  @override
+  String get timerControlPlay => 'PLAY';
+
+  @override
+  String get timerControlReset => 'RESET';
+
+  @override
+  String get timerAdjustDecrease => '-10s';
+
+  @override
+  String get timerAdjustIncrease => '+10s';
+
+  @override
+  String get timerNextPlaceholder => 'Next: --';
+
+  @override
+  String timerNextLabel(String name, int current, int total) {
+    return 'Next: $name · Set $current/$total';
+  }
 
   @override
   String get amrapTimerTitle => 'AMRAP timer';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -67,6 +67,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Sblocca nuove skill man mano che impari le basi.';
 
   @override
+  String get guidesLoadError =>
+      'Impossibile caricare le guide delle skill al momento.';
+
+  @override
   String get guidesPrimaryFocus => 'Focus principale';
 
   @override
@@ -320,6 +324,42 @@ class AppLocalizationsIt extends AppLocalizations {
       'Qui troverai l\'ultimo consiglio del tuo coach.';
 
   @override
+  String homeGreeting(String name) {
+    return 'Ciao, $name!';
+  }
+
+  @override
+  String get homeViewStats => 'Vedi statistiche';
+
+  @override
+  String get homeProgressTitle => 'Progressi';
+
+  @override
+  String get homeProgressWorkoutsLabel => 'Allenamenti';
+
+  @override
+  String get homeProgressTimeTrainedLabel => 'Tempo di allenamento';
+
+  @override
+  String homeProgressTimeValue(int hours, int minutes) {
+    return '${hours}h ${minutes}m';
+  }
+
+  @override
+  String get homeSkillProgressTitle => 'Progressi skill';
+
+  @override
+  String homeSkillProgressValue(int unlocked, int total) {
+    return '$unlocked / $total';
+  }
+
+  @override
+  String get homeSkillProgressLabel => 'Skill sbloccate';
+
+  @override
+  String get homeStrengthLevelTitle => 'Livello di forza';
+
+  @override
   String get workoutPlanTitle => 'Piano di allenamento';
 
   @override
@@ -397,6 +437,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get trainingHeaderExercise => 'Esercizio';
 
   @override
+  String get trainingHeaderExercises => 'Esercizi';
+
+  @override
   String get trainingHeaderSets => 'Serie';
 
   @override
@@ -410,6 +453,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get trainingWorkoutCompleted => 'Allenamento completato';
+
+  @override
+  String trainingDurationMinutes(int minutes) {
+    return '$minutes min';
+  }
 
   @override
   String get trainingCompletionSaved => 'Allenamento aggiornato';
@@ -769,6 +817,56 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get timerTitle => 'Timer';
+
+  @override
+  String get timerExercisePushUps => 'Piegamenti';
+
+  @override
+  String get timerExercisePullUps => 'Trazioni';
+
+  @override
+  String get timerExerciseSquats => 'Squat';
+
+  @override
+  String get timerExercisePlank => 'Plank';
+
+  @override
+  String get timerPhaseWork => 'LAVORO';
+
+  @override
+  String get timerPhaseRest => 'RECUPERO';
+
+  @override
+  String get timerWorkDurationLabel => 'Durata lavoro';
+
+  @override
+  String get timerRestDurationLabel => 'Durata recupero';
+
+  @override
+  String get timerControlSkip => 'SALTA';
+
+  @override
+  String get timerControlPause => 'PAUSA';
+
+  @override
+  String get timerControlPlay => 'AVVIA';
+
+  @override
+  String get timerControlReset => 'RESET';
+
+  @override
+  String get timerAdjustDecrease => '-10s';
+
+  @override
+  String get timerAdjustIncrease => '+10s';
+
+  @override
+  String get timerNextPlaceholder => 'Prossimo: --';
+
+  @override
+  String timerNextLabel(String name, int current, int total) {
+    return 'Prossimo: $name · Serie $current/$total';
+  }
 
   @override
   String get amrapTimerTitle => 'Timer AMRAP';

--- a/lib/pages/exercise_guides.dart
+++ b/lib/pages/exercise_guides.dart
@@ -85,7 +85,7 @@ class _ExerciseGuidesPageState extends State<ExerciseGuidesPage> {
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 12),
                 child: Text(
-                  'Unable to load skill guides right now.',
+                  l10n.guidesLoadError,
                   style: Theme.of(context).textTheme.bodyMedium,
                 ),
               )

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -107,12 +107,13 @@ class _HomeHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     return Row(
       children: [
         Expanded(
           child: Text(
-            'Hi, $displayName!',
+            l10n.homeGreeting(displayName),
             style: theme.textTheme.headlineSmall?.copyWith(
               fontWeight: FontWeight.w700,
             ),
@@ -165,24 +166,24 @@ class _ActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     return Row(
       children: [
         Expanded(
           child: FilledButton(
             onPressed: onOpenPlan,
-            child: const Text('Start Workout'),
+            child: Text(l10n.trainingStartWorkout),
           ),
         ),
         const SizedBox(width: 12),
         Expanded(
           child: OutlinedButton(
             onPressed: () {},
-            child: const Text('View Stats'),
+            child: Text(l10n.homeViewStats),
           ),
         ),
       ],
     );
   }
 }
-
 

--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -811,16 +811,30 @@ class _MaxTestBottomSheet extends StatefulWidget {
 class _MaxTestBottomSheetState extends State<_MaxTestBottomSheet> {
   final _formKey = GlobalKey<FormState>();
   final _valueController = TextEditingController();
-  final _unitController = TextEditingController(text: 'reps');
+  final _unitController = TextEditingController();
   String? _selectedExercise;
   DateTime _selectedDate = DateTime.now();
   bool _isSaving = false;
+  bool _didSetDefaultUnit = false;
 
   @override
   void dispose() {
     _valueController.dispose();
     _unitController.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didSetDefaultUnit) {
+      return;
+    }
+    final l10n = AppLocalizations.of(context)!;
+    if (_unitController.text.trim().isEmpty) {
+      _unitController.text = l10n.profileMaxTestsDefaultUnit;
+    }
+    _didSetDefaultUnit = true;
   }
 
   @override

--- a/lib/pages/max_tests_menu.dart
+++ b/lib/pages/max_tests_menu.dart
@@ -58,8 +58,9 @@ class _MaxTestsMenuPageState extends State<MaxTestsMenuPage> {
 
         if (snapshot.hasError) {
           final rawError = snapshot.error.toString();
-          final errorText =
-              rawError.contains('user-not-authenticated') ? l10n.userNotFound : rawError;
+          final errorText = rawError.contains('user-not-authenticated')
+              ? l10n.unauthenticated
+              : rawError;
           return Center(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -53,7 +53,7 @@ class UserProfileData {
 Future<UserProfileData> getUserData() async {
   final user = supabase.auth.currentUser;
   if (user == null) {
-    throw Exception('Utente non autenticato');
+    throw Exception('user-not-authenticated');
   }
 
   final profileResponse = await supabase
@@ -159,8 +159,11 @@ class _ProfilePageState extends State<ProfilePage> {
 
             if (snapshot.hasError) {
               final rawError = snapshot.error.toString();
-              final errorText =
-                  rawError.contains('user-not-found') ? l10n.userNotFound : rawError;
+              final errorText = rawError.contains('user-not-authenticated')
+                  ? l10n.unauthenticated
+                  : rawError.contains('user-not-found')
+                      ? l10n.userNotFound
+                      : rawError;
               return Center(
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/lib/pages/timer.dart
+++ b/lib/pages/timer.dart
@@ -3,7 +3,26 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import '../l10n/app_localizations.dart';
+
 enum IntervalPhase { work, rest }
+
+enum TimerExercise { pushUps, pullUps, squats, plank }
+
+extension TimerExerciseLabel on TimerExercise {
+  String label(AppLocalizations l10n) {
+    switch (this) {
+      case TimerExercise.pushUps:
+        return l10n.timerExercisePushUps;
+      case TimerExercise.pullUps:
+        return l10n.timerExercisePullUps;
+      case TimerExercise.squats:
+        return l10n.timerExerciseSquats;
+      case TimerExercise.plank:
+        return l10n.timerExercisePlank;
+    }
+  }
+}
 
 class TimerPage extends StatefulWidget {
   const TimerPage({super.key});
@@ -29,10 +48,10 @@ class _TimerPageState extends State<TimerPage> {
   int _nextSet = 1;
 
   final List<_ExercisePlan> _exercisePlan = const [
-    _ExercisePlan(name: 'Push-ups', totalSets: 3),
-    _ExercisePlan(name: 'Pull-ups', totalSets: 3),
-    _ExercisePlan(name: 'Squats', totalSets: 4),
-    _ExercisePlan(name: 'Plank', totalSets: 2),
+    _ExercisePlan(exercise: TimerExercise.pushUps, totalSets: 3),
+    _ExercisePlan(exercise: TimerExercise.pullUps, totalSets: 3),
+    _ExercisePlan(exercise: TimerExercise.squats, totalSets: 4),
+    _ExercisePlan(exercise: TimerExercise.plank, totalSets: 2),
   ];
 
   @override
@@ -167,19 +186,24 @@ class _TimerPageState extends State<TimerPage> {
     return '${minutes.toString().padLeft(2, '0')}:${remainingSeconds.toString().padLeft(2, '0')}';
   }
 
-  String _nextExerciseLabel() {
+  String _nextExerciseLabel(AppLocalizations l10n) {
     if (_exercisePlan.isEmpty) {
-      return 'Next: --';
+      return l10n.timerNextPlaceholder;
     }
     final plan = _exercisePlan[_nextExerciseIndex];
-    return 'Next: ${plan.name} · Set $_nextSet/${plan.totalSets}';
+    return l10n.timerNextLabel(
+      plan.exercise.label(l10n),
+      _nextSet,
+      plan.totalSets,
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final isWork = _phase == IntervalPhase.work;
-    final phaseLabel = isWork ? 'WORK' : 'REST';
+    final phaseLabel = isWork ? l10n.timerPhaseWork : l10n.timerPhaseRest;
     final phaseColor = isWork ? const Color(0xFFFF8A3D) : const Color(0xFF3D8BFF);
     final progress = _currentPhaseDuration == 0
         ? 0.0
@@ -245,7 +269,7 @@ class _TimerPageState extends State<TimerPage> {
                     ),
                     const SizedBox(height: 24),
                     _TimerConfigRow(
-                      title: 'Work duration',
+                      title: l10n.timerWorkDurationLabel,
                       value: _formatSeconds(_workDurationSeconds),
                       onDecrease: () =>
                           _adjustPhaseDuration(IntervalPhase.work, -10),
@@ -254,7 +278,7 @@ class _TimerPageState extends State<TimerPage> {
                     ),
                     const SizedBox(height: 12),
                     _TimerConfigRow(
-                      title: 'Rest duration',
+                      title: l10n.timerRestDurationLabel,
                       value: _formatSeconds(_restDurationSeconds),
                       onDecrease: () =>
                           _adjustPhaseDuration(IntervalPhase.rest, -10),
@@ -266,20 +290,20 @@ class _TimerPageState extends State<TimerPage> {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         _ControlButton(
-                          label: 'SKIP',
+                          label: l10n.timerControlSkip,
                           icon: Icons.skip_next,
                           onPressed: _skipPhase,
                         ),
                         const SizedBox(width: 16),
                         _ControlButton(
-                          label: _isRunning ? 'PAUSE' : 'PLAY',
+                          label: _isRunning ? l10n.timerControlPause : l10n.timerControlPlay,
                           icon: _isRunning ? Icons.pause : Icons.play_arrow,
                           onPressed: _toggleRunning,
                           isPrimary: true,
                         ),
                         const SizedBox(width: 16),
                         _ControlButton(
-                          label: 'RESET',
+                          label: l10n.timerControlReset,
                           icon: Icons.restart_alt,
                           onPressed: _resetPhase,
                         ),
@@ -287,7 +311,7 @@ class _TimerPageState extends State<TimerPage> {
                     ),
                     const SizedBox(height: 20),
                     Text(
-                      _nextExerciseLabel(),
+                      _nextExerciseLabel(l10n),
                       style: theme.textTheme.titleMedium?.copyWith(
                         color: theme.colorScheme.onSurfaceVariant,
                         fontWeight: FontWeight.w500,
@@ -351,12 +375,12 @@ class _TimerConfigRow extends StatelessWidget {
           Row(
             children: [
               _ConfigAdjustButton(
-                label: '-10s',
+                label: AppLocalizations.of(context)!.timerAdjustDecrease,
                 onPressed: onDecrease,
               ),
               const SizedBox(width: 8),
               _ConfigAdjustButton(
-                label: '+10s',
+                label: AppLocalizations.of(context)!.timerAdjustIncrease,
                 onPressed: onIncrease,
               ),
             ],
@@ -395,11 +419,11 @@ class _ConfigAdjustButton extends StatelessWidget {
 }
 
 class _ExercisePlan {
-  final String name;
+  final TimerExercise exercise;
   final int totalSets;
 
   const _ExercisePlan({
-    required this.name,
+    required this.exercise,
     required this.totalSets,
   });
 }

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -102,7 +102,7 @@ class _TrainingState extends State<Training> {
                             ),
                           ),
                           Text(
-                            '45 min',
+                            l10n.trainingDurationMinutes(45),
                             style: textTheme.bodyMedium?.copyWith(
                               color: Colors.white70,
                               fontWeight: FontWeight.w600,
@@ -120,7 +120,7 @@ class _TrainingState extends State<Training> {
                           ),
                           const SizedBox(width: 6),
                           Text(
-                            '${_exercises.length} ${l10n.trainingHeaderExercise}${_exercises.length == 1 ? '' : 's'}',
+                            '${_exercises.length} ${_exercises.length == 1 ? l10n.trainingHeaderExercise : l10n.trainingHeaderExercises}',
                             style: textTheme.bodySmall?.copyWith(
                               color: Colors.white60,
                             ),


### PR DESCRIPTION
### Motivation
- Replace hard-coded UI strings in the app with localized lookups so the home dashboard, timer, training and related components use the app's localization system. 
- Add missing localization resources and small UX fixes (default unit handling, unauthenticated error handling) to keep messages consistent across locales.

### Description
- Replaced hard-coded strings with `AppLocalizations` lookups in: `lib/pages/home_content.dart`, `lib/components/progress_card.dart`, `lib/components/skill_progress_card.dart`, `lib/components/strength_level_card.dart`, `lib/pages/timer.dart`, `lib/pages/training.dart`, and `lib/pages/exercise_guides.dart`.
- Introduced timer-specific localization and UI changes: added `TimerExercise` enum and `TimerExerciseLabel` extension, used localized phase labels, control labels, next-exercise text, and adjust buttons in `lib/pages/timer.dart`.
- Added new localization keys and placeholders to `lib/l10n/app_en.arb` and `lib/l10n/app_it.arb`, and updated generated localization interfaces/implementations in `lib/l10n/app_localizations.dart`, `lib/l10n/app_localizations_en.dart`, and `lib/l10n/app_localizations_it.dart` (new getters and parameterized messages for greeting, progress values, timer strings, training durations, guides load error, etc.).
- Improved error and default-value handling: standardized the unauthenticated exception to `user-not-authenticated` and updated error text handling in `lib/pages/profile.dart` and `lib/pages/max_tests_menu.dart`, and set the default max-test unit from localized resource in `lib/pages/max_tests.dart`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a09f5d2fc8333944946bf353e2c8c)