### PR TITLE
Add week grouping to workout editor

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -660,6 +660,22 @@ import {
         return formatWeekDayLabel(week, dayCode);
       };
 
+      const templateWeekGroups = computed(() => {
+        const daysPerWeek = templateDayCount.value || dayCodeOptions.length;
+        const list = programTemplateDays.value || [];
+        const groups = [];
+        list.forEach((day, index) => {
+          const week = Math.floor(index / daysPerWeek) + 1;
+          let group = groups.find((item) => item.week === week);
+          if (!group) {
+            group = { week, days: [] };
+            groups.push(group);
+          }
+          group.days.push({ day, index });
+        });
+        return groups;
+      });
+
       function resetDayForm() {
         newDayWeek.value = 1;
         newDayCode.value = 'A';
@@ -2342,6 +2358,7 @@ import {
         templateExerciseOptions,
         templatePlanName,
         programTemplateDays,
+        templateWeekGroups,
         selectedTemplateDay,
         selectedTemplateSlot,
         activeTemplateDay,

--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -854,21 +854,30 @@
                                             </button>
                                         </div>
                                         <div class="workout-days">
-                                            <button
-                                                v-for="(day, dayIndex) in programTemplateDays"
-                                                :key="day.id"
-                                                class="workout-day-item"
-                                                :class="{ active: dayIndex === selectedTemplateDay }"
-                                                type="button"
-                                                @click="selectTemplateDay(dayIndex)"
+                                            <div
+                                                v-for="group in templateWeekGroups"
+                                                :key="`week-${group.week}`"
+                                                class="workout-week-group"
                                             >
-                                                <div class="stack">
-                                                    <strong>{{ templateDayLabel(dayIndex) }}</strong>
-                                                    <span class="muted small">
-                                                        {{ day.title || t('placeholders.workoutTitle') }}
-                                                    </span>
+                                                <div class="workout-week-header">
+                                                    {{ t('labels.weekNumber', { week: group.week }) }}
                                                 </div>
-                                            </button>
+                                                <button
+                                                    v-for="entry in group.days"
+                                                    :key="entry.day.id"
+                                                    class="workout-day-item"
+                                                    :class="{ active: entry.index === selectedTemplateDay }"
+                                                    type="button"
+                                                    @click="selectTemplateDay(entry.index)"
+                                                >
+                                                    <div class="stack">
+                                                        <strong>{{ templateDayLabel(entry.index) }}</strong>
+                                                        <span class="muted small">
+                                                            {{ entry.day.title || t('placeholders.workoutTitle') }}
+                                                        </span>
+                                                    </div>
+                                                </button>
+                                            </div>
                                         </div>
                                         <label class="stack small workout-day-title">
                                             <span class="muted small">{{ t('labels.title') }}</span>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -141,6 +141,8 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .workout-card-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
 .workout-card-header h4{margin:0;font-size:16px;color:#3d2c3f}
 .workout-days,.workout-activity-list{display:flex;flex-direction:column;gap:10px}
+.workout-week-group{display:flex;flex-direction:column;gap:8px}
+.workout-week-header{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.08em;color:#64748b;padding:4px 8px}
 .workout-day-item,.workout-activity-item{border:1px solid transparent;background:#f8fafc;border-radius:16px;padding:12px;display:flex;align-items:center;justify-content:space-between;gap:12px;text-align:left}
 .workout-day-item.active,.workout-activity-item.active{border-color:#2fb3ff;background:#fff}
 .workout-day-item strong,.workout-activity-item strong{color:#3d2c3f}


### PR DESCRIPTION
### Motivation
- Improve discoverability of template days by grouping them by week in the admin workout editor.

### Description
- Render template days grouped by week in the workout editor UI by updating `backend/admin/index.html` to iterate `templateWeekGroups` and show a week header. 
- Add a `computed` property `templateWeekGroups` in `backend/admin/app.js` to build week groups from `programTemplateDays`. 
- Expose `templateWeekGroups` in the app return object and add minimal styles in `backend/admin/styles.css` for `.workout-week-group` and `.workout-week-header`.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script to load `index.html` and capture a screenshot, which completed successfully. 
- No unit tests were added or modified for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ccb90ecf48333a173f4a84491242e)