### PR TITLE
Add private trainer notes to admin (trainer-only notes tied to trainee_trainers)

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -572,6 +572,20 @@
                                 </div>
                                 <div class="muted small" v-if="coachTipSaving">{{ t('status.savingCoachTip') }}</div>
                             </div>
+                            <div class="data-block" v-if="currentTrainer">
+                                <span class="muted small">{{ t('program.trainerNotesTitle') }}</span>
+                                <textarea
+                                    v-model="trainerNotesDraft"
+                                    :placeholder="t('program.trainerNotesPlaceholder')"
+                                    :disabled="trainerNotesSaving"
+                                ></textarea>
+                                <div style="display:flex;justify-content:flex-end;gap:8px;flex-wrap:wrap">
+                                    <button class="small" type="button" @click="saveTrainerNotes" :disabled="trainerNotesSaving">
+                                        {{ t('actions.save') }}
+                                    </button>
+                                </div>
+                                <div class="muted small" v-if="trainerNotesSaving">{{ t('status.savingTrainerNotes') }}</div>
+                            </div>
                         </div>
                     </div>
 

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -163,6 +163,8 @@ export const translations = {
       maxTestsTitle: 'Max tests',
       coachTipTitle: 'Coach tip',
       coachTipPlaceholder: 'Share a short tip for this trainee.',
+      trainerNotesTitle: 'Trainer notes',
+      trainerNotesPlaceholder: 'Private notes only visible to you.',
       plansTitle: 'Plans assigned',
       plansSubtitle: 'Current workout plans for this trainee.',
       paymentsTitle: 'Payments done',
@@ -219,6 +221,7 @@ export const translations = {
       updatingTrainer: 'Updating trainer assignment…',
       noProgress: 'No progress logged yet.',
       savingCoachTip: 'Saving coach tip…',
+      savingTrainerNotes: 'Saving trainer notes…',
       loadingMaxTests: 'Loading max tests…',
       loadingPayments: 'Loading payments…',
       loadingCompletedExercises: 'Loading completed exercises…',
@@ -297,6 +300,9 @@ export const translations = {
       loadMaxTests: 'Failed to load max tests.',
       loadMaxTestsWithMessage: 'Failed to load max tests: {message}',
       updateCoachTip: 'Failed to update coach tip.',
+      updateTrainerNotes: 'Failed to update trainer notes.',
+      trainerNotesUnavailable:
+        'Trainer notes are only available for trainer accounts.',
       loadCompletedExercises: 'Failed to load completed exercises.',
     },
     confirm: {
@@ -487,6 +493,8 @@ export const translations = {
       maxTestsTitle: 'Test massimali',
       coachTipTitle: 'Consiglio del coach',
       coachTipPlaceholder: 'Condividi un breve consiglio per questo allievo.',
+      trainerNotesTitle: 'Note del coach',
+      trainerNotesPlaceholder: 'Note private visibili solo a te.',
       plansTitle: 'Piani assegnati',
       plansSubtitle: 'Piani di allenamento correnti per questo allievo.',
       paymentsTitle: 'Pagamenti effettuati',
@@ -543,6 +551,7 @@ export const translations = {
       updatingTrainer: 'Aggiornamento assegnazione trainer…',
       noProgress: 'Nessun progresso registrato.',
       savingCoachTip: 'Salvataggio consiglio…',
+      savingTrainerNotes: 'Salvataggio note…',
       loadingMaxTests: 'Caricamento test massimali…',
       loadingPayments: 'Caricamento pagamenti…',
       loadingCompletedExercises: 'Caricamento esercizi completati…',
@@ -621,6 +630,9 @@ export const translations = {
       loadMaxTests: 'Impossibile caricare i test massimali.',
       loadMaxTestsWithMessage: 'Impossibile caricare i test massimali: {message}',
       updateCoachTip: 'Impossibile aggiornare il consiglio del coach.',
+      updateTrainerNotes: 'Impossibile aggiornare le note del coach.',
+      trainerNotesUnavailable:
+        'Le note del coach sono disponibili solo per gli account trainer.',
       loadCompletedExercises: 'Impossibile caricare gli esercizi completati.',
     },
     confirm: {

--- a/db/database.sql
+++ b/db/database.sql
@@ -99,6 +99,7 @@ CREATE TABLE public.trainee_trainers (
   trainer_id uuid NOT NULL,
   assigned_at timestamp with time zone NOT NULL DEFAULT now(),
   coach_tip text,
+  trainer_notes text,
   CONSTRAINT trainee_trainers_pkey PRIMARY KEY (id),
   CONSTRAINT trainee_trainers_trainee_id_fkey FOREIGN KEY (trainee_id) REFERENCES public.trainees(id),
   CONSTRAINT trainee_trainers_trainer_id_fkey FOREIGN KEY (trainer_id) REFERENCES public.trainers(id)
@@ -138,4 +139,3 @@ CREATE TABLE public.workout_plans (
   notes text,
   CONSTRAINT workout_plans_pkey PRIMARY KEY (id)
 );
-


### PR DESCRIPTION
### Motivation
- Allow trainers to add private notes for a trainee that are only visible to the trainer on the admin trainee overview.

### Description
- Add a `trainer_notes` column to the `trainee_trainers` table schema in `db/database.sql` to persist trainer-only notes.
- Load `trainer_notes` from `trainee_trainers` in `backend/admin/app.js` and surface the currently-relevant assignment's `trainer_notes` on each trainee record via the `loadUsers` mapping logic.
- Add reactive state and save logic with `trainerNotesDraft`, `trainerNotesSaving`, and a `saveTrainerNotes` function that updates `trainee_trainers` for the current `trainer_id` and `trainee_id` in `backend/admin/app.js`.
- Show a trainer-only notes UI block in the trainee overview (`backend/admin/index.html`) that is conditional on `currentTrainer`, and wire it to `trainerNotesDraft`/`saveTrainerNotes`.
- Add i18n keys and messages for the new UI and errors in `backend/admin/translations.js` (English and Italian) and add relevant status/error translations.

### Testing
- Ran a headless browser smoke test by serving `backend/admin` on a local HTTP server and executing a Playwright script that loaded `index.html` and saved a screenshot, which completed successfully. 
- No unit or integration test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ccea3615c83338482a90cf92016d1)