### PR TITLE
Add Supabase profile photo support

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -109,6 +109,7 @@ CREATE TABLE public.trainees (
   name text NOT NULL,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   weight numeric,
+  profile_image_url text,
   CONSTRAINT trainees_pkey PRIMARY KEY (id),
   CONSTRAINT trainees_id_fkey FOREIGN KEY (id) REFERENCES auth.users(id)
 );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -325,6 +325,7 @@
   "profileEditWeightLabel": "Weight",
   "profileEditWeightHint": "Enter your weight in kg (optional)",
   "profileEditWeightInvalid": "Enter a valid positive weight.",
+  "profilePhotoEdit": "Change photo",
   "profileEditCancel": "Cancel",
   "profileEditSave": "Save changes",
   "profileEditSuccess": "Profile updated successfully",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -325,6 +325,7 @@
   "profileEditWeightLabel": "Peso",
   "profileEditWeightHint": "Inserisci il tuo peso in kg (opzionale)",
   "profileEditWeightInvalid": "Inserisci un peso valido e positivo.",
+  "profilePhotoEdit": "Cambia foto",
   "profileEditCancel": "Annulla",
   "profileEditSave": "Salva modifiche",
   "profileEditSuccess": "Profilo aggiornato correttamente",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1346,6 +1346,12 @@ abstract class AppLocalizations {
   /// **'Inserisci un peso valido e positivo.'**
   String get profileEditWeightInvalid;
 
+  /// No description provided for @profilePhotoEdit.
+  ///
+  /// In it, this message translates to:
+  /// **'Cambia foto'**
+  String get profilePhotoEdit;
+
   /// No description provided for @profileEditCancel.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -713,6 +713,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileEditWeightInvalid => 'Enter a valid positive weight.';
 
   @override
+  String get profilePhotoEdit => 'Change photo';
+
+  @override
   String get profileEditCancel => 'Cancel';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -719,6 +719,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileEditWeightInvalid => 'Inserisci un peso valido e positivo.';
 
   @override
+  String get profilePhotoEdit => 'Cambia foto';
+
+  @override
   String get profileEditCancel => 'Annulla';
 
   @override

--- a/lib/model/trainee.dart
+++ b/lib/model/trainee.dart
@@ -3,11 +3,13 @@ class Trainee {
   final String id;
   final String? name;
   final double? weight;
+  final String? profileImageUrl;
 
   const Trainee({
     required this.id,
     this.name,
     this.weight,
+    this.profileImageUrl,
   });
 
   factory Trainee.fromMap(Map<String, dynamic> map) {
@@ -15,6 +17,7 @@ class Trainee {
       id: map['id'] as String,
       name: map['name'] as String?,
       weight: (map['weight'] as num?)?.toDouble(),
+      profileImageUrl: map['profile_image_url'] as String?,
     );
   }
 
@@ -23,6 +26,7 @@ class Trainee {
       'id': id,
       'name': name,
       'weight': weight,
+      'profile_image_url': profileImageUrl,
     };
   }
 
@@ -30,11 +34,13 @@ class Trainee {
     String? id,
     String? name,
     double? weight,
+    String? profileImageUrl,
   }) {
     return Trainee(
       id: id ?? this.id,
       name: name ?? this.name,
       weight: weight ?? this.weight,
+      profileImageUrl: profileImageUrl ?? this.profileImageUrl,
     );
   }
 
@@ -42,7 +48,8 @@ class Trainee {
   String toString() => 'Profiles(${{
         'id': id,
         'name': name,
-        'weight': weight
+        'weight': weight,
+        'profileImageUrl': profileImageUrl,
       }})';
 
   @override
@@ -52,13 +59,15 @@ class Trainee {
       runtimeType == other.runtimeType &&
       id == other.id &&
       name == other.name &&
-      weight == other.weight;
+      weight == other.weight &&
+      profileImageUrl == other.profileImageUrl;
 
   @override
   int get hashCode =>
       Object.hashAll([
         id,
         name,
-        weight
+        weight,
+        profileImageUrl,
       ]);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   fl_chart: ^1.1.1
   app_links: ^6.0.0
   intl: ^0.20.2
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
- Allow users to upload, store and display a profile picture backed by Supabase storage and persisted on the trainee record.

### Description
- Add `profile_image_url` to the database schema (`db/database.sql`) and to the `Trainee` model (`lib/model/trainee.dart`).
- Load `profile_image_url` in `getUserData()` and render a `CircleAvatar` on the profile page (`lib/pages/profile.dart`).
- Add an edit flow that uses `image_picker` to pick an image, uploads it to Supabase storage (`avatars` bucket) with `uploadBinary`, obtains a public URL with `getPublicUrl`, and saves the URL to the `trainees` row on update (`lib/pages/profile.dart`).
- Add `image_picker` to `pubspec.yaml` and add localized label strings for the photo action in English and Italian (`lib/l10n/*.arb` and generated localization files).

### Testing
- Attempted to run `flutter --version` to validate the environment, but the command failed because Flutter is not available in this environment (so UI/runtime tests were not executed).
- No automated unit/widget tests were run as part of this change due to the lack of a Flutter toolchain in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cdea385948333a2b9a17674226758)