### PR TITLE
Show profile avatar on home header and add theme settings link on profile

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -319,6 +319,8 @@
   "profileMaxTestsShowLess": "Show fewer attempts",
   "profileEdit": "Edit profile",
   "profileEditSubtitle": "Update your personal details",
+  "profileThemeSettingsTitle": "Theme colors",
+  "profileThemeSettingsSubtitle": "Choose the app color theme",
   "profileEditTitle": "Edit profile",
   "profileEditFullNameLabel": "Full name",
   "profileEditFullNameHint": "How should we call you?",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -319,6 +319,8 @@
   "profileMaxTestsShowLess": "Mostra meno tentativi",
   "profileEdit": "Modifica profilo",
   "profileEditSubtitle": "Aggiorna le tue informazioni personali",
+  "profileThemeSettingsTitle": "Colori del tema",
+  "profileThemeSettingsSubtitle": "Scegli il colore del tema dell'app",
   "profileEditTitle": "Modifica profilo",
   "profileEditFullNameLabel": "Nome completo",
   "profileEditFullNameHint": "Come vuoi essere chiamato?",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1310,6 +1310,18 @@ abstract class AppLocalizations {
   /// **'Aggiorna le tue informazioni personali'**
   String get profileEditSubtitle;
 
+  /// No description provided for @profileThemeSettingsTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Colori del tema'**
+  String get profileThemeSettingsTitle;
+
+  /// No description provided for @profileThemeSettingsSubtitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Scegli il colore del tema dell'app'**
+  String get profileThemeSettingsSubtitle;
+
   /// No description provided for @profileEditTitle.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -695,6 +695,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileEditSubtitle => 'Update your personal details';
 
   @override
+  String get profileThemeSettingsTitle => 'Theme colors';
+
+  @override
+  String get profileThemeSettingsSubtitle => 'Choose the app color theme';
+
+  @override
   String get profileEditTitle => 'Edit profile';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -701,6 +701,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileEditSubtitle => 'Aggiorna le tue informazioni personali';
 
   @override
+  String get profileThemeSettingsTitle => 'Colori del tema';
+
+  @override
+  String get profileThemeSettingsSubtitle => 'Scegli il colore del tema dell\'app';
+
+  @override
   String get profileEditTitle => 'Modifica profilo';
 
   @override

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -59,12 +59,14 @@ class _HomeContentState extends State<HomeContent> {
         final data = snapshot.data;
         final displayName = data?.displayName(l10n) ?? l10n.profileFallbackName;
         final initials = data?.initials(l10n) ?? '';
+        final avatarUrl = data?.profile?.profileImageUrl?.trim();
         return ListView(
           padding: const EdgeInsets.fromLTRB(16, 20, 16, 24),
           children: [
             _HomeHeader(
               displayName: displayName,
               initials: initials,
+              imageUrl: (avatarUrl == null || avatarUrl.isEmpty) ? null : avatarUrl,
             ),
             const SizedBox(height: 16),
             const ProgressCard(),
@@ -100,10 +102,12 @@ class _HomeHeader extends StatelessWidget {
   const _HomeHeader({
     required this.displayName,
     required this.initials,
+    required this.imageUrl,
   });
 
   final String displayName;
   final String initials;
+  final String? imageUrl;
 
   @override
   Widget build(BuildContext context) {
@@ -119,20 +123,22 @@ class _HomeHeader extends StatelessWidget {
             ),
           ),
         ),
-        _AvatarChip(initials: initials),
+        _AvatarChip(initials: initials, imageUrl: imageUrl),
       ],
     );
   }
 }
 
 class _AvatarChip extends StatelessWidget {
-  const _AvatarChip({required this.initials});
+  const _AvatarChip({required this.initials, required this.imageUrl});
 
   final String initials;
+  final String? imageUrl;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final avatarUrl = imageUrl?.trim();
     final avatarText = initials.isEmpty ? null : initials;
     return CircleAvatar(
       radius: 18,
@@ -140,19 +146,24 @@ class _AvatarChip extends StatelessWidget {
       child: CircleAvatar(
         radius: 16,
         backgroundColor: theme.colorScheme.surface,
-        child: avatarText == null
-            ? Icon(
-                Icons.person,
-                color: theme.colorScheme.onSurfaceVariant,
-                size: 18,
-              )
-            : Text(
-                avatarText,
-                style: theme.textTheme.labelMedium?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
+        backgroundImage: avatarUrl == null || avatarUrl.isEmpty
+            ? null
+            : NetworkImage(avatarUrl),
+        child: avatarUrl == null || avatarUrl.isEmpty
+            ? (avatarText == null
+                ? Icon(
+                    Icons.person,
+                    color: theme.colorScheme.onSurfaceVariant,
+                    size: 18,
+                  )
+                : Text(
+                    avatarText,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ))
+            : null,
       ),
     );
   }
@@ -186,4 +197,3 @@ class _ActionButtons extends StatelessWidget {
     );
   }
 }
-

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -9,6 +9,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
 import 'login.dart';
+import 'settings.dart';
 
 final supabase = Supabase.instance.client;
 
@@ -300,6 +301,20 @@ class _ProfilePageState extends State<ProfilePage> {
                       title: Text(l10n.profileEdit),
                       subtitle: Text(l10n.profileEditSubtitle),
                       onTap: () => _showEditProfile(data),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Card(
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    child: ListTile(
+                      leading: const Icon(Icons.palette_outlined),
+                      title: Text(l10n.profileThemeSettingsTitle),
+                      subtitle: Text(l10n.profileThemeSettingsSubtitle),
+                      onTap: () {
+                        Navigator.of(context).push(
+                          MaterialPageRoute(builder: (context) => const SettingsPage()),
+                        );
+                      },
                     ),
                   ),
                   const SizedBox(height: 12),


### PR DESCRIPTION
### Motivation
- Surface the user profile avatar on the app home header when a profile image is present so users see their photo instead of only initials or an icon.
- Make theme color controls reachable from the profile page by adding a settings entry point and localization for the new labels.

### Description
- Home header now reads `profile.profileImageUrl` and passes a trimmed `imageUrl` into the header; the avatar widget uses `NetworkImage` when present and falls back to initials/icon otherwise (changes in `lib/pages/home_content.dart`).
- `_HomeHeader` and `_AvatarChip` signatures updated to accept an optional `imageUrl` parameter and render the image when available (changes in `lib/pages/home_content.dart`).
- Profile page adds a new `ListTile` linking to `SettingsPage` and imports `settings.dart` to provide a direct entry to theme controls (changes in `lib/pages/profile.dart`).
- Localization keys and generated localization files were updated to include `profileThemeSettingsTitle` and `profileThemeSettingsSubtitle` for English and Italian (changes in `lib/l10n/app_en.arb`, `lib/l10n/app_it.arb`, and localization classes).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e15f7509483339f2911cd20712c17)