### PR TITLE
Wire Home 'Start workout' and 'View stats' to main navigation

### DIFF
--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -1,5 +1,4 @@
 import 'package:calisync/components/coach_tip.dart';
-import 'package:calisync/pages/workout_plan_page.dart';
 import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -10,7 +9,14 @@ import '../l10n/app_localizations.dart';
 import 'profile.dart';
 
 class HomeContent extends StatefulWidget {
-  const HomeContent({super.key});
+  const HomeContent({
+    super.key,
+    required this.onOpenPlan,
+    required this.onViewStats,
+  });
+
+  final VoidCallback onOpenPlan;
+  final VoidCallback onViewStats;
 
   @override
   State<HomeContent> createState() => _HomeContentState();
@@ -26,12 +32,6 @@ class _HomeContentState extends State<HomeContent> {
     final client = Supabase.instance.client;
     _profileFuture = getUserData();
     _coachTip = _loadCoachTipForUser(Supabase.instance.client, client.auth.currentUser!.id);
-  }
-
-  Future<void> _openWorkoutPlan() async {
-    await Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) => const WorkoutPlanPage()),
-    );
   }
 
   Future<String?> _loadCoachTipForUser(
@@ -71,7 +71,10 @@ class _HomeContentState extends State<HomeContent> {
             const SizedBox(height: 16),
             const ProgressCard(),
             const SizedBox(height: 16),
-            _ActionButtons(onOpenPlan: _openWorkoutPlan),
+            _ActionButtons(
+              onOpenPlan: widget.onOpenPlan,
+              onViewStats: widget.onViewStats,
+            ),
             const SizedBox(height: 16),
             const StrengthLevelCard(),
             const SizedBox(height: 16),
@@ -171,8 +174,10 @@ class _AvatarChip extends StatelessWidget {
 
 class _ActionButtons extends StatelessWidget {
   final VoidCallback onOpenPlan;
+  final VoidCallback onViewStats;
   const _ActionButtons({
       required this.onOpenPlan,
+      required this.onViewStats,
   });
 
   @override
@@ -189,7 +194,7 @@ class _ActionButtons extends StatelessWidget {
         const SizedBox(width: 12),
         Expanded(
           child: OutlinedButton(
-            onPressed: () {},
+            onPressed: onViewStats,
             child: Text(l10n.homeViewStats),
           ),
         ),

--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -38,10 +38,18 @@ class _HomePageState extends State<HomePage> {
   bool? payed;
 
   final supabase = Supabase.instance.client;
+  static const int _workoutPlanIndex = 1;
+  static const int _maxTestsIndex = 5;
 
   @override
   void initState() {
     super.initState();
+  }
+
+  void _selectIndex(int index) {
+    setState(() {
+      selectedIndex = index;
+    });
   }
 
   @override
@@ -54,7 +62,10 @@ class _HomePageState extends State<HomePage> {
       _NavigationItem(
         title: l10n.navHome,
         icon: Icons.home,
-        page: const HomeContent(),
+        page: HomeContent(
+          onOpenPlan: () => _selectIndex(_workoutPlanIndex),
+          onViewStats: () => _selectIndex(_maxTestsIndex),
+        ),
       ),
       _NavigationItem(
         title: l10n.workoutPlanTitle,


### PR DESCRIPTION
### Motivation
- The home quick actions should navigate to the app's main sections so the drawer/menu remains available, with `Start workout` showing the workout plans and `View stats` showing max test tracking.

### Description
- Changed `HomeContent` in `lib/pages/home_content.dart` to accept `onOpenPlan` and `onViewStats` callbacks and removed the internal `Navigator.push` for the workout plan.
- Updated the `_ActionButtons` widget to call the provided `onOpenPlan` and `onViewStats` callbacks instead of pushing new pages.
- Wired the callbacks from `lib/pages/main.dart` by adding `_workoutPlanIndex` and `_maxTestsIndex` constants and a `_selectIndex` helper, and instantiating `HomeContent(onOpenPlan: ..., onViewStats: ...)` to switch the main navigation index.
- Removed the now-unused direct import of `workout_plan_page.dart` from `home_content.dart` and adjusted code to keep navigation inside the main navigation stack.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e18df1ad883339cade2238eed3c5f)