### PR TITLE
Fix theme-aware highlight colors for max tests

### DIFF
--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -1,4 +1,3 @@
-import 'package:calisync/theme/app_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -753,7 +752,9 @@ class _MaxTestTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    final appColors = theme.extension<AppColors>();
+    final colorScheme = theme.colorScheme;
+    final highlightColor = colorScheme.secondary;
+    final highlightOnColor = colorScheme.onSecondary;
     final dateText = DateFormat.yMMMd().format(test.recordedAt);
 
     return ListTile(
@@ -761,10 +762,8 @@ class _MaxTestTile extends StatelessWidget {
       contentPadding: EdgeInsets.zero,
       leading: CircleAvatar(
         radius: 18,
-        backgroundColor:
-            isBest ? appColors?.success ?? Colors.green : Colors.transparent,
-        foregroundColor:
-            isBest ? theme.colorScheme.onPrimary : theme.colorScheme.primary,
+        backgroundColor: isBest ? highlightColor : Colors.transparent,
+        foregroundColor: isBest ? highlightOnColor : colorScheme.primary,
         child: Icon(isBest ? Icons.military_tech : Icons.timeline),
       ),
       title: Text(
@@ -775,15 +774,14 @@ class _MaxTestTile extends StatelessWidget {
       trailing: isBest
           ? Container(
               decoration: BoxDecoration(
-                color: (appColors?.success ?? theme.colorScheme.secondary)
-                    .withValues(alpha: 0.15),
+                color: highlightColor.withValues(alpha: 0.15),
                 borderRadius: BorderRadius.circular(12),
               ),
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               child: Text(
                 badgeLabel,
                 style: theme.textTheme.labelSmall?.copyWith(
-                  color: appColors?.success ?? theme.colorScheme.secondary,
+                  color: highlightColor,
                   fontWeight: FontWeight.w600,
                 ),
               ),


### PR DESCRIPTION
### Motivation
- Max test "best" badges and avatars stayed green regardless of selected theme because they used the fixed `AppColors.success` color instead of the current theme accents.
- Make the max test indicators follow the app's active theme so colors switch correctly with theme changes.

### Description
- Removed dependency on `AppColors` in `lib/pages/max_tests.dart` and use the current `ThemeData.colorScheme` instead.
- Use `colorScheme.secondary` and `colorScheme.onSecondary` for the avatar background/foreground and the trailing badge background/text respectively, replacing `appColors?.success` usages.
- Updated CircleAvatar and badge `BoxDecoration` color calculations so highlight colors respond to the active theme.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1acef7488333893e50f366c269c1)