### PR TITLE
Switch max test unit input to dropdown

### DIFF
--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -809,30 +809,31 @@ class _MaxTestBottomSheet extends StatefulWidget {
 class _MaxTestBottomSheetState extends State<_MaxTestBottomSheet> {
   final _formKey = GlobalKey<FormState>();
   final _valueController = TextEditingController();
-  final _unitController = TextEditingController();
+  static const List<String> _unitOptions = [
+    'kg',
+    'reps',
+    'seconds',
+    'minutes',
+  ];
   String? _selectedExercise;
+  String? _selectedUnit;
   DateTime _selectedDate = DateTime.now();
   bool _isSaving = false;
-  bool _didSetDefaultUnit = false;
 
   @override
   void dispose() {
     _valueController.dispose();
-    _unitController.dispose();
     super.dispose();
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (_didSetDefaultUnit) {
-      return;
-    }
     final l10n = AppLocalizations.of(context)!;
-    if (_unitController.text.trim().isEmpty) {
-      _unitController.text = l10n.profileMaxTestsDefaultUnit;
+    final defaultUnit = l10n.profileMaxTestsDefaultUnit.trim().toLowerCase();
+    if (_selectedUnit == null && _unitOptions.contains(defaultUnit)) {
+      _selectedUnit = defaultUnit;
     }
-    _didSetDefaultUnit = true;
   }
 
   @override
@@ -900,12 +901,22 @@ class _MaxTestBottomSheetState extends State<_MaxTestBottomSheet> {
                   },
                 ),
                 const SizedBox(height: 12),
-                TextFormField(
-                  controller: _unitController,
+                DropdownButtonFormField<String>(
+                  value: _selectedUnit,
                   decoration: InputDecoration(
                     labelText: l10n.profileMaxTestsUnitLabel,
                     hintText: l10n.profileMaxTestsUnitHint,
                   ),
+                  items: [
+                    for (final unit in _unitOptions)
+                      DropdownMenuItem(
+                        value: unit,
+                        child: Text(unit),
+                      ),
+                  ],
+                  onChanged: (value) => setState(() => _selectedUnit = value),
+                  validator: (value) =>
+                      value == null ? l10n.profileMaxTestsUnitHint : null,
                 ),
                 const SizedBox(height: 12),
                 OutlinedButton.icon(
@@ -973,9 +984,7 @@ class _MaxTestBottomSheetState extends State<_MaxTestBottomSheet> {
 
     final exercise = _selectedExercise ?? '';
     final value = double.parse(_valueController.text.trim().replaceAll(',', '.'));
-    final unit = _unitController.text.trim().isEmpty
-        ? l10n.profileMaxTestsDefaultUnit
-        : _unitController.text.trim();
+    final unit = _selectedUnit?.trim().toLowerCase() ?? '';
 
     final payload = {
       'trainee_id': widget.userId,


### PR DESCRIPTION
### Motivation
- Constrain the unit input to a known set of values (`kg`, `reps`, `seconds`, `minutes`) so users cannot submit arbitrary unit strings.
- Provide form validation and normalize saved unit strings to a consistent lowercase representation before persisting to the database.

### Description
- Replaced the freeform unit `TextFormField` with a `DropdownButtonFormField<String>` and added a static `List<String> _unitOptions` containing `kg`, `reps`, `seconds`, and `minutes` in `lib/pages/max_tests.dart`.
- Introduced a `_selectedUnit` state field and removed the `_unitController` and related defaulting flags.
- Defaulted `_selectedUnit` from the localized `l10n.profileMaxTestsDefaultUnit` when it matches an allowed option in `didChangeDependencies`.
- Added a validator for the unit field that shows the localized hint when no unit is selected and normalized the selected unit with `.trim().toLowerCase()` in `_submit` before saving.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1d52c8d48333a02bf2a4a1dfa786)