### PR TITLE
Include units in max test grouping labels

### DIFF
--- a/lib/pages/max_tests.dart
+++ b/lib/pages/max_tests.dart
@@ -346,13 +346,18 @@ class _MaxTestsContentState extends State<MaxTestsContent> {
                               exerciseGuideById,
                               exerciseGuideByName,
                             );
+                            final unitLabel = test.unit.trim();
+                            final displayLabel = unitLabel.isEmpty
+                                ? displayName
+                                : '$displayName ($unitLabel)';
                             final key = _resolveExerciseKey(
                               test.exercise,
                               exerciseGuideById,
                               exerciseGuideByName,
                             );
-                            groupedTests.putIfAbsent(key, () => []).add(test);
-                            displayNames.putIfAbsent(key, () => displayName);
+                            final groupedKey = '$key|$unitLabel';
+                            groupedTests.putIfAbsent(groupedKey, () => []).add(test);
+                            displayNames.putIfAbsent(groupedKey, () => displayLabel);
                           }
 
                           return ListView.separated(

--- a/lib/pages/max_tests_history.dart
+++ b/lib/pages/max_tests_history.dart
@@ -168,13 +168,18 @@ class _MaxTestsHistoryPageState extends State<MaxTestsHistoryPage> {
                         exerciseGuideById,
                         exerciseGuideByName,
                       );
+                      final unitLabel = test.unit.trim();
+                      final displayLabel = unitLabel.isEmpty
+                          ? displayName
+                          : '$displayName ($unitLabel)';
                       final key = _resolveExerciseKey(
                         test.exercise,
                         exerciseGuideById,
                         exerciseGuideByName,
                       );
-                      groupedTests.putIfAbsent(key, () => []).add(test);
-                      displayNames.putIfAbsent(key, () => displayName);
+                      final groupedKey = '$key|$unitLabel';
+                      groupedTests.putIfAbsent(groupedKey, () => []).add(test);
+                      displayNames.putIfAbsent(groupedKey, () => displayLabel);
                     }
 
                     return ListView.separated(


### PR DESCRIPTION
### Motivation
- Group max test records by both exercise and unit so metric-based and rep-based records are separated in the UI.
- Make the exercise display labels unit-aware so users can immediately see the unit (e.g., kg, reps) for each grouped section.

### Description
- Updated grouping logic in `lib/pages/max_tests.dart` to build a grouped key that includes unit as `'$key|$unitLabel'` and to append the unit to the display label as `'$displayName ($unitLabel)'` when present.
- Applied the same unit-aware grouping and display label changes to `lib/pages/max_tests_history.dart` so history sections are also separated by unit.
- Preserved existing usages of `tests.first.unit` and similar lookups by ensuring each group contains tests with the same unit, so unit-based labels and chart/unit lookups remain accurate.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1dc6e5588333bfd8ed1f50b89606)