### PR TITLE
Group max tests by exercise+unit, use DB-backed guides, and restrict units

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -412,20 +412,22 @@ import {
         (maxTests.value || []).forEach((test) => {
           const exercise =
             (test.exercise || '').trim() || t('labels.unknownExercise');
-          if (!grouped[exercise]) {
-            grouped[exercise] = {
+          const unit = (test.unit || '').trim();
+          const groupKey = unit ? `${exercise}::${unit}` : exercise;
+          if (!grouped[groupKey]) {
+            grouped[groupKey] = {
               exercise,
-              unit: test.unit || '',
+              unit,
               tests: [],
             };
           }
-          grouped[exercise].tests.push({
+          grouped[groupKey].tests.push({
             ...test,
             value: Number(test.value || 0),
             timestamp: Date.parse(test.recorded_at || '') || Date.now(),
           });
-          if (!grouped[exercise].unit && test.unit) {
-            grouped[exercise].unit = test.unit;
+          if (!grouped[groupKey].unit && unit) {
+            grouped[groupKey].unit = unit;
           }
         });
 
@@ -467,7 +469,9 @@ import {
             const polyline = points.map((point) => `${point.x},${point.y}`).join(' ');
             const latest = sorted[sorted.length - 1];
             return {
-              exercise: entry.exercise,
+              exercise: entry.unit
+                ? `${entry.exercise} · ${entry.unit}`
+                : entry.exercise,
               unit: entry.unit,
               count: sorted.length,
               minValue,


### PR DESCRIPTION
### Motivation
- Ensure max tests are shown and grouped consistently by canonical exercise names and units sourced from the database, and avoid free-form unit values by providing a controlled set of units.

### Description
- Load exercise guides from the `exercise_guides` table and resolve exercise ids/names via a new `_exerciseGuidesFuture` and `_loadExerciseGuides` in `lib/pages/max_tests.dart` and `lib/pages/max_tests_history.dart`.
- Group max tests by exercise and unit (group key includes unit) and include the unit in displayed exercise labels in both mobile views and the admin dashboard (`backend/admin/app.js`).
- Replace the free-text unit input with a `DropdownButtonFormField` limited to the allowed units `['kg','reps','seconds','minutes']`, apply a localized default when available, and validate the selection before submit in `lib/pages/max_tests.dart`.
- Minor UI improvements: disable the add action when no guides are available, sort guides by name, and preserve existing period/filter behavior while accounting for unit-aware grouping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1ce5fd788333b66c0f8743894961)