### PR TITLE
Cache exercise guides data

### DIFF
--- a/lib/data/exercise_guides.dart
+++ b/lib/data/exercise_guides.dart
@@ -1,0 +1,23 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../l10n/app_localizations.dart';
+import '../model/exercise_guide.dart';
+
+class ExerciseGuides {
+  ExerciseGuides._();
+
+  static final Map<String, Future<List<ExerciseGuide>>> _cachedByLocale = {};
+
+  static Future<List<ExerciseGuide>> load(AppLocalizations l10n) {
+    return _cachedByLocale.putIfAbsent(l10n.localeName, () async {
+      final response = await Supabase.instance.client
+          .from('exercises')
+          .select('name, slug, difficulty, default_unlocked')
+          .order('sort_order', ascending: true);
+      final rows = (response as List<dynamic>).cast<Map<String, dynamic>>();
+      return rows
+          .map((row) => ExerciseGuide.fromDatabase(row, l10n.localeName))
+          .toList();
+    });
+  }
+}

--- a/lib/pages/exercise_guides.dart
+++ b/lib/pages/exercise_guides.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 import '../components/exercise_guide_card.dart';
+import '../data/exercise_guides.dart';
 import '../l10n/app_localizations.dart';
 import '../model/exercise_guide.dart';
 
@@ -23,19 +23,8 @@ class _ExerciseGuidesPageState extends State<ExerciseGuidesPage> {
     final l10n = AppLocalizations.of(context)!;
     if (_guidesFuture == null || _localeName != l10n.localeName) {
       _localeName = l10n.localeName;
-      _guidesFuture = _loadGuides(l10n);
+      _guidesFuture = ExerciseGuides.load(l10n);
     }
-  }
-
-  Future<List<ExerciseGuide>> _loadGuides(AppLocalizations l10n) async {
-    final response = await Supabase.instance.client
-        .from('exercises')
-        .select('name, slug, difficulty')
-        .order('sort_order', ascending: true);
-    final rows = (response as List<dynamic>).cast<Map<String, dynamic>>();
-    return rows
-        .map((row) => ExerciseGuide.fromDatabase(row, l10n.localeName))
-        .toList();
   }
 
   @override


### PR DESCRIPTION
### Motivation
- Avoid repeated Supabase queries for exercise guides by caching loaded guides per locale so pages that need guide data only load once.

### Description
- Add a shared `ExerciseGuides` loader that caches `Future<List<ExerciseGuide>>` by `l10n.localeName` in `lib/data/exercise_guides.dart` and fetches `exercises` from Supabase when needed.
- Replace inline guide fetches in `ExerciseGuidesPage` with `ExerciseGuides.load(l10n)` and wrap UI consumers in a `FutureBuilder` that uses the cached future.
- Update `MaxTestsPage` and `MaxTestsHistoryPage` to load guides via `ExerciseGuides.load(l10n)`, expose `_guidesFuture` in `didChangeDependencies`, and use the resolved list for name/key lookups and UI rendering.
- Small refactors to copy/sort the snapshot lists (use `List<ExerciseGuide>.from(...)`) to avoid mutating snapshot data.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4ed677b083338d3190843e50a16c)