### PR TITLE
Align timer colors with theme palette

### DIFF
--- a/lib/pages/timer.dart
+++ b/lib/pages/timer.dart
@@ -35,7 +35,6 @@ class TimerPage extends StatefulWidget {
 class _TimerPageState extends State<TimerPage> {
   static const int _defaultWorkSeconds = 40;
   static const int _defaultRestSeconds = 20;
-  static const Color _neonGreen = Color(0xFF39FF14);
 
   Timer? _intervalTimer;
 
@@ -241,9 +240,10 @@ class _TimerPageState extends State<TimerPage> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     final isWork = _phase == IntervalPhase.work;
     final phaseLabel = isWork ? l10n.timerPhaseWork : l10n.timerPhaseRest;
-    final phaseColor = isWork ? const Color(0xFFFF8A3D) : const Color(0xFF3D8BFF);
+    final phaseColor = isWork ? colorScheme.primary : colorScheme.secondary;
     final progress = _currentPhaseDuration == 0
         ? 0.0
         : (1 - (_remainingSeconds / _currentPhaseDuration)).clamp(0.0, 1.0);
@@ -298,7 +298,7 @@ class _TimerPageState extends State<TimerPage> {
                               style: theme.textTheme.displayMedium?.copyWith(
                                 fontSize: timeFontSize,
                                 fontWeight: FontWeight.w700,
-                                color: _neonGreen,
+                                color: phaseColor,
                               ),
                             ),
                           ],


### PR DESCRIPTION
### Motivation
- Ensure the timer UI follows the app's selected color scheme instead of using hardcoded phase/text colors.

### Description
- Use `theme.colorScheme` and set `phaseColor = colorScheme.primary` for work and `colorScheme.secondary` for rest.
- Apply `phaseColor` to the interval ring's active color and to the central countdown text instead of hardcoded colors.
- Remove the `_neonGreen` constant and update related styling to use the theme-derived colors.

### Testing
- No automated Flutter tests were run because `flutter` is not available in the environment, so the change was verified by inspecting the updated source files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e521182048333b06c63acdda8314e)