### PR TITLE
Add real-time language switching from Profile

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -321,6 +321,8 @@
   "profileEditSubtitle": "Update your personal details",
   "profileThemeSettingsTitle": "Theme colors",
   "profileThemeSettingsSubtitle": "Choose the app color theme",
+  "profileLanguageSettingsTitle": "Language",
+  "profileLanguageSettingsSubtitle": "Choose the app language",
   "profileEditTitle": "Edit profile",
   "profileEditFullNameLabel": "Full name",
   "profileEditFullNameHint": "How should we call you?",
@@ -340,6 +342,9 @@
     }
   },
   "logout": "Log out",
+  "languageSystemLabel": "System default",
+  "languageEnglishLabel": "English",
+  "languageItalianLabel": "Italian",
   "redirectError": "Error during redirect: {error}",
   "@redirectError": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -321,6 +321,8 @@
   "profileEditSubtitle": "Aggiorna le tue informazioni personali",
   "profileThemeSettingsTitle": "Colori del tema",
   "profileThemeSettingsSubtitle": "Scegli il colore del tema dell'app",
+  "profileLanguageSettingsTitle": "Lingua",
+  "profileLanguageSettingsSubtitle": "Scegli la lingua dell'app",
   "profileEditTitle": "Modifica profilo",
   "profileEditFullNameLabel": "Nome completo",
   "profileEditFullNameHint": "Come vuoi essere chiamato?",
@@ -340,6 +342,9 @@
     }
   },
   "logout": "Logout",
+  "languageSystemLabel": "Sistema",
+  "languageEnglishLabel": "Inglese",
+  "languageItalianLabel": "Italiano",
   "redirectError": "Errore durante il reindirizzamento: {error}",
   "@redirectError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1322,6 +1322,18 @@ abstract class AppLocalizations {
   /// **'Scegli il colore del tema dell\'app'**
   String get profileThemeSettingsSubtitle;
 
+  /// No description provided for @profileLanguageSettingsTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Lingua'**
+  String get profileLanguageSettingsTitle;
+
+  /// No description provided for @profileLanguageSettingsSubtitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Scegli la lingua dell\'app'**
+  String get profileLanguageSettingsSubtitle;
+
   /// No description provided for @profileEditTitle.
   ///
   /// In it, this message translates to:
@@ -1393,6 +1405,24 @@ abstract class AppLocalizations {
   /// In it, this message translates to:
   /// **'Logout'**
   String get logout;
+
+  /// No description provided for @languageSystemLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Sistema'**
+  String get languageSystemLabel;
+
+  /// No description provided for @languageEnglishLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Inglese'**
+  String get languageEnglishLabel;
+
+  /// No description provided for @languageItalianLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Italiano'**
+  String get languageItalianLabel;
 
   /// No description provided for @redirectError.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -701,6 +701,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileThemeSettingsSubtitle => 'Choose the app color theme';
 
   @override
+  String get profileLanguageSettingsTitle => 'Language';
+
+  @override
+  String get profileLanguageSettingsSubtitle => 'Choose the app language';
+
+  @override
   String get profileEditTitle => 'Edit profile';
 
   @override
@@ -737,6 +743,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get logout => 'Log out';
+
+  @override
+  String get languageSystemLabel => 'System default';
+
+  @override
+  String get languageEnglishLabel => 'English';
+
+  @override
+  String get languageItalianLabel => 'Italian';
 
   @override
   String redirectError(Object error) {

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -708,6 +708,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Scegli il colore del tema dell\'app';
 
   @override
+  String get profileLanguageSettingsTitle => 'Lingua';
+
+  @override
+  String get profileLanguageSettingsSubtitle => 'Scegli la lingua dell\'app';
+
+  @override
   String get profileEditTitle => 'Modifica profilo';
 
   @override
@@ -744,6 +750,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get logout => 'Logout';
+
+  @override
+  String get languageSystemLabel => 'Sistema';
+
+  @override
+  String get languageEnglishLabel => 'Inglese';
+
+  @override
+  String get languageItalianLabel => 'Italiano';
 
   @override
   String redirectError(Object error) {

--- a/lib/l10n/locale_controller.dart
+++ b/lib/l10n/locale_controller.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class LocaleController extends ChangeNotifier {
+  LocaleController({
+    required SharedPreferences preferences,
+    Locale? initialLocale,
+  })  : _preferences = preferences,
+        _locale = initialLocale;
+
+  static const String storageKey = 'selected_locale';
+
+  final SharedPreferences _preferences;
+  Locale? _locale;
+
+  Locale? get locale => _locale;
+
+  Future<void> setLocale(Locale? locale) async {
+    if (_locale?.languageCode == locale?.languageCode) return;
+    _locale = locale;
+    notifyListeners();
+    if (locale == null) {
+      await _preferences.remove(storageKey);
+    } else {
+      await _preferences.setString(storageKey, locale.languageCode);
+    }
+  }
+}
+
+class LocaleControllerScope extends InheritedNotifier<LocaleController> {
+  const LocaleControllerScope({
+    super.key,
+    required LocaleController controller,
+    required super.child,
+  }) : super(notifier: controller);
+
+  static LocaleController of(BuildContext context) {
+    final scope = context.dependOnInheritedWidgetOfExactType<LocaleControllerScope>();
+    assert(scope != null, 'LocaleControllerScope not found in widget tree.');
+    return scope!.notifier!;
+  }
+}

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -8,6 +8,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../l10n/app_localizations.dart';
+import '../l10n/locale_controller.dart';
 import 'login.dart';
 import 'settings.dart';
 
@@ -135,6 +136,73 @@ class _ProfilePageState extends State<ProfilePage> {
     });
   }
 
+  void _showLanguagePicker() {
+    final l10n = AppLocalizations.of(context)!;
+    final controller = LocaleControllerScope.of(context);
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (context) => AnimatedBuilder(
+        animation: controller,
+        builder: (context, _) {
+          final options = <(String?, String)>[
+            (null, l10n.languageSystemLabel),
+            ('en', l10n.languageEnglishLabel),
+            ('it', l10n.languageItalianLabel),
+          ];
+          final currentCode = controller.locale?.languageCode;
+          return SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.profileLanguageSettingsTitle,
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 12),
+                  Card(
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    child: Column(
+                      children: [
+                        for (final option in options)
+                          RadioListTile<String?>(
+                            value: option.$1,
+                            groupValue: currentCode,
+                            title: Text(option.$2),
+                            onChanged: (value) {
+                              controller.setLocale(
+                                value == null ? null : Locale(value),
+                              );
+                            },
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  String _currentLanguageLabel(AppLocalizations l10n, Locale? locale) {
+    switch (locale?.languageCode) {
+      case 'en':
+        return l10n.languageEnglishLabel;
+      case 'it':
+        return l10n.languageItalianLabel;
+      default:
+        return l10n.languageSystemLabel;
+    }
+  }
+
   Future<void> _showEditProfile(UserProfileData data) async {
     final l10n = AppLocalizations.of(context)!;
     final updated = await showModalBottomSheet<bool>(
@@ -210,6 +278,9 @@ class _ProfilePageState extends State<ProfilePage> {
                 ? l10n.profileWeightValue(weight.toStringAsFixed(1))
                 : l10n.profileNotSet;
             final profileImageUrl = data.profile?.profileImageUrl;
+            final localeController = LocaleControllerScope.of(context);
+            final currentLanguageLabel =
+                _currentLanguageLabel(l10n, localeController.locale);
 
             return SingleChildScrollView(
               padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
@@ -315,6 +386,17 @@ class _ProfilePageState extends State<ProfilePage> {
                           MaterialPageRoute(builder: (context) => const SettingsPage()),
                         );
                       },
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Card(
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    child: ListTile(
+                      leading: const Icon(Icons.language_outlined),
+                      title: Text(l10n.profileLanguageSettingsTitle),
+                      subtitle: Text(l10n.profileLanguageSettingsSubtitle),
+                      trailing: Text(currentLanguageLabel),
+                      onTap: _showLanguagePicker,
                     ),
                   ),
                   const SizedBox(height: 12),


### PR DESCRIPTION
### Motivation
- Make the app support switching the UI language at runtime from the Profile screen, mirroring the existing live theme switching behavior.
- Persist the user's language choice so the selection survives app restarts.
- Provide a simple UI for choosing between system default and available locales (`en`, `it`).

### Description
- Added a `LocaleController` (`lib/l10n/locale_controller.dart`) that stores the selected language in `SharedPreferences` and exposes `locale` with `ChangeNotifier` semantics.  
- Wired the controller into startup and `MaterialApp` in `lib/main.dart` so `MaterialApp.locale` is updated live using an `AnimatedBuilder` that listens to both theme and locale controllers.  
- Implemented a profile language picker in `lib/pages/profile.dart` with a new language card and a bottom sheet allowing selection of `null` (system), `en`, or `it`, using `LocaleControllerScope` to apply the selection immediately.  
- Added localization keys and translations for the new UI strings in `lib/l10n/app_en.arb`, `lib/l10n/app_it.arb` and updated the generated localization Dart files (`lib/l10n/app_localizations*.dart`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e554b5b548333a75f56e5154e53d8)