### PR TITLE
Add Spanish localization support

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -345,6 +345,7 @@
   "languageSystemLabel": "System default",
   "languageEnglishLabel": "English",
   "languageItalianLabel": "Italian",
+  "languageSpanishLabel": "Spanish",
   "redirectError": "Error during redirect: {error}",
   "@redirectError": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1,0 +1,484 @@
+{
+  "appTitle": "Calisync",
+  "authErrorMessage": "Error de autenticación",
+  "navHome": "Inicio",
+  "navGuides": "Guías",
+  "navProfile": "Perfil",
+  "navSettings": "Configuración",
+  "navTerminology": "Terminología",
+  "settingsThemeTitle": "Tema",
+  "themeDefaultLabel": "Predeterminado",
+  "themeBlackLabel": "Negro",
+  "themePinkLabel": "Rosa",
+  "themeRedLabel": "Rojo",
+  "themeBlueLabel": "Azul",
+  "onboardingTitleOne": "Entrena de forma inteligente",
+  "onboardingDescriptionOne": "Sigue entrenamientos guiados creados para tu plan de calistenia.",
+  "onboardingTitleTwo": "Haz seguimiento del progreso",
+  "onboardingDescriptionTwo": "Registra series, repeticiones y notas para ver tus mejoras.",
+  "onboardingTitleThree": "Mantén la constancia",
+  "onboardingDescriptionThree": "Mantén el impulso con acceso rápido a tu próxima sesión.",
+  "onboardingSkip": "Saltar",
+  "onboardingBack": "Atrás",
+  "onboardingNext": "Siguiente",
+  "onboardingGetStarted": "Empezar",
+  "guidesTitle": "Habilidades",
+  "guidesSubtitle": "Desbloquea nuevas habilidades mientras dominas lo básico.",
+  "guidesLoadError": "No se pueden cargar las guías de habilidades en este momento.",
+  "guidesPrimaryFocus": "Enfoque principal",
+  "guidesCoachTip": "Consejo del entrenador",
+  "skillsLockedLabel": "Bloqueado",
+  "skillsUnlockedLabel": "Desbloqueado",
+  "skillsLockedHint": "Completa habilidades anteriores para desbloquear el desglose completo.",
+  "skillsUnlockAction": "Desbloquear habilidad",
+  "difficultyBeginner": "Principiante",
+  "difficultyIntermediate": "Intermedio",
+  "difficultyAdvanced": "Avanzado",
+  "guidesPullupName": "Dominada",
+  "guidesPullupFocus": "Dorsales, bíceps, agarre",
+  "guidesPullupTip": "Lleva los codos hacia las costillas y mantén las costillas recogidas para evitar el balanceo.",
+  "guidesPullupDescription": "Empieza colgado con cuerpo en hollow, luego tira hasta que la barbilla supere la barra. Controla la bajada para repeticiones más fuertes.",
+  "guidesChinUpName": "Dominada supina",
+  "guidesChinUpFocus": "Dorsales, bíceps, agarre",
+  "guidesChinUpTip": "Mantén los hombros abajo y lleva los codos hacia las costillas para mantener fuerza arriba.",
+  "guidesChinUpDescription": "Empieza colgado con las palmas hacia ti, tira hasta que la barbilla supere la barra y baja con control.",
+  "guidesPushupName": "Flexión",
+  "guidesPushupFocus": "Pecho, tríceps, core",
+  "guidesPushupTip": "Aprieta los glúteos y mantén una línea recta de la cabeza a los talones.",
+  "guidesPushupDescription": "Baja con los codos a unos 45° del torso, toca ligeramente el pecho y vuelve a subir sin que las caderas se hundan.",
+  "guidesBodyweightSquatName": "Sentadilla con peso corporal",
+  "guidesBodyweightSquatFocus": "Cuádriceps, glúteos, core",
+  "guidesBodyweightSquatTip": "Empuja las rodillas hacia afuera al bajar y mantén los talones apoyados.",
+  "guidesBodyweightSquatDescription": "Lleva las caderas atrás y abajo hasta que los muslos estén al menos paralelos. Empuja de forma uniforme con todo el pie para ponerte de pie.",
+  "guidesGluteBridgeName": "Puente de glúteos",
+  "guidesGluteBridgeFocus": "Glúteos, isquiotibiales, core",
+  "guidesGluteBridgeTip": "Exhala al subir y evita arquear la espalda baja en la parte alta.",
+  "guidesGluteBridgeDescription": "Túmbate boca arriba con rodillas flexionadas, empuja con los talones para elevar las caderas hasta alinear muslos y torso, y baja con control.",
+  "guidesHangingLegRaiseName": "Elevación de piernas colgado",
+  "guidesHangingLegRaiseFocus": "Abdominales, flexores de cadera, agarre",
+  "guidesHangingLegRaiseTip": "Inicia cada repetición activando los dorsales para estabilizar el torso.",
+  "guidesHangingLegRaiseDescription": "Desde un colgado muerto, eleva las piernas juntas hasta la altura de la cadera o más. Baja despacio para mantener tensión.",
+  "guidesMuscleUpName": "Muscle-up",
+  "guidesMuscleUpFocus": "Dorsales, pecho, tríceps, fuerza de transición",
+  "guidesMuscleUpTip": "Tira alto hacia el pecho superior y mantén la barra cerca para reducir el balanceo.",
+  "guidesMuscleUpDescription": "Desde un colgado controlado, explota en un tirón alto, pasa las muñecas sobre la barra y presiona hasta el bloqueo.",
+  "guidesStraightBarDipName": "Fondos en barra recta",
+  "guidesStraightBarDipFocus": "Pecho, tríceps, hombros",
+  "guidesStraightBarDipTip": "Mantén los codos pegados y empuja hacia abajo inclinándote ligeramente hacia delante.",
+  "guidesStraightBarDipDescription": "Empieza arriba de la barra con los codos bloqueados, baja con control hasta que los hombros queden por debajo de los codos y vuelve a subir.",
+  "guidesDipsName": "Fondos",
+  "guidesDipsFocus": "Pecho, tríceps, hombros",
+  "guidesDipsTip": "Inclínate ligeramente hacia delante y mantén los hombros estables para proteger las articulaciones.",
+  "guidesDipsDescription": "Empieza bloqueado en barras paralelas, baja hasta que los hombros queden por debajo de los codos y vuelve a subir con fuerza.",
+  "guidesAustralianRowName": "Remo australiano",
+  "guidesAustralianRowFocus": "Espalda alta, bíceps, core",
+  "guidesAustralianRowTip": "Activa el core y mantén una línea recta de los hombros a los talones.",
+  "guidesAustralianRowDescription": "Coloca la barra a la altura de la cintura, cuélgate debajo y rema el pecho hacia la barra con los codos cerrados.",
+  "guidesPikePushUpName": "Flexión pike",
+  "guidesPikePushUpFocus": "Hombros, tríceps, core",
+  "guidesPikePushUpTip": "Mantén las caderas altas y baja la cabeza a un punto justo delante de las manos.",
+  "guidesPikePushUpDescription": "Desde la posición pike, flexiona los codos para bajar la cabeza y luego presiona hasta el bloqueo.",
+  "guidesHollowHoldName": "Hollow hold",
+  "guidesHollowHoldFocus": "Core, flexores de cadera, postura",
+  "guidesHollowHoldTip": "Presiona la zona lumbar contra el suelo y mantén las costillas recogidas.",
+  "guidesHollowHoldDescription": "Túmbate boca arriba, eleva hombros y piernas y mantén una forma de banana con brazos rectos sobre la cabeza.",
+  "guidesPlankName": "Plancha",
+  "guidesPlankFocus": "Core, hombros, glúteos",
+  "guidesPlankTip": "Aprieta los glúteos y mantén las costillas recogidas para que las caderas no se hundan.",
+  "guidesPlankDescription": "Coloca antebrazos bajo los hombros, estira las piernas y mantén una línea recta de la cabeza a los talones mientras respiras.",
+  "guidesLSitName": "L-sit",
+  "guidesLSitFocus": "Core, flexores de cadera, tríceps",
+  "guidesLSitTip": "Empuja el suelo, bloquea los codos y mantén las rodillas rectas.",
+  "guidesLSitDescription": "Desde barras paralelas o el suelo, eleva las piernas hasta la altura de la cadera y mantén una L firme.",
+  "guidesHandstandName": "Parada de manos",
+  "guidesHandstandFocus": "Hombros, core, equilibrio",
+  "guidesHandstandTip": "Alinea muñecas, hombros y caderas mientras aprietas los glúteos.",
+  "guidesHandstandDescription": "Sube con impulso o empuje a una pared o equilibrio libre y mantén una línea alta con los dedos apuntando.",
+  "homeLoadErrorTitle": "No se pueden cargar los entrenamientos",
+  "retry": "Reintentar",
+  "homeCoachTipTitle": "Consejo del entrenador",
+  "homeCoachTipPlaceholder": "El último consejo de tu entrenador aparecerá aquí.",
+  "homeGreeting": "Hola, {name}!",
+  "@homeGreeting": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "homeViewStats": "Ver estadísticas",
+  "homeProgressTitle": "Progreso mensual",
+  "homeProgressWorkoutsLabel": "Entrenamientos",
+  "homeProgressTimeTrainedLabel": "Tiempo entrenado",
+  "homeProgressTimeValue": "{hours}h {minutes}m",
+  "@homeProgressTimeValue": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      },
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "homeSkillProgressTitle": "Progreso de habilidades",
+  "homeSkillProgressValue": "{unlocked} / {total}",
+  "@homeSkillProgressValue": {
+    "placeholders": {
+      "unlocked": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "homeSkillProgressLabel": "Habilidades desbloqueadas",
+  "homeStrengthLevelTitle": "Nivel de fuerza",
+  "workoutPlanTitle": "Plan de entrenamiento",
+  "traineeFeedbackTitle": "Comentarios del alumno",
+  "traineeFeedbackSubtitle": "Cuéntale a tu entrenador cómo te sientes y cómo va el plan.",
+  "traineeFeedbackQuestionLabel": "¿Cómo se sintió tu entrenamiento?",
+  "traineeFeedbackQuestionHint": "Comparte lo que va bien o lo que necesita atención.",
+  "traineeFeedbackSubmit": "Enviar feedback",
+  "traineeFeedbackSubmitted": "Feedback guardado. Lo compartiremos con tu entrenador.",
+  "homeEmptyTitle": "No hay entrenamientos disponibles",
+  "homeEmptyDescription": "Contacta a tu entrenador para recibir un nuevo plan.",
+  "homePlansSectionTitle": "Planes de entrenamiento",
+  "homePlansSectionSubtitle": "Planes asignados y su estado actual.",
+  "homePlansEmptyTitle": "Aún no hay planes de entrenamiento",
+  "homePlansEmptyDescription": "Pide a tu entrenador que asigne un plan para verlo aquí.",
+  "homePlanStatusDraft": "Borrador",
+  "homePlanStatusArchived": "Archivado",
+  "homePlanStatusUpcoming": "Próximo",
+  "homePlanStatusUnknown": "Estado desconocido",
+  "homePlanDefaultTitle": "Plan de entrenamiento",
+  "homePlanLatestLabel": "Último plan",
+  "homePlanStartedLabel": "Iniciado {date}",
+  "@homePlanStartedLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "unauthenticated": "Usuario no autenticado",
+  "defaultExerciseName": "Ejercicio",
+  "trainingHeaderExercise": "Ejercicio",
+  "trainingHeaderExercises": "Ejercicios",
+  "trainingHeaderSets": "Series",
+  "trainingHeaderReps": "Repeticiones",
+  "trainingTodayTitle": "Entrenamiento de hoy",
+  "trainingStartWorkout": "Iniciar entrenamiento",
+  "trainingWorkoutCompleted": "Entrenamiento completado",
+  "trainingDurationMinutes": "{minutes} min",
+  "@trainingDurationMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "trainingCompletionSaved": "Día de entrenamiento actualizado",
+  "trainingCompletionError": "No se pudo actualizar el entrenamiento: {error}",
+  "@trainingCompletionError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "trainingCompletionUnavailable": "No se puede actualizar este día de entrenamiento.",
+  "trainingExerciseCompletionSaved": "Ejercicio actualizado",
+  "trainingExerciseCompletionError": "No se pudo actualizar el ejercicio: {error}",
+  "@trainingExerciseCompletionError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "trainingExerciseCompletionUnavailable": "No se puede actualizar este ejercicio.",
+  "logoutError": "Error al cerrar sesión: {error}",
+  "@logoutError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileFallbackName": "Usuario",
+  "userNotFound": "Usuario no encontrado en la base de datos",
+  "profileLoadError": "Error al cargar los datos",
+  "profileNoData": "No hay datos disponibles",
+  "profileEmailUnavailable": "Correo electrónico no disponible",
+  "profileStatusActive": "Cuenta activa",
+  "profileStatusInactive": "Cuenta inactiva",
+  "profilePlanActive": "Plan activo",
+  "profilePlanExpired": "Plan caducado",
+  "profileUsername": "Nombre de usuario",
+  "profileNotSet": "No establecido",
+  "profileWeight": "Peso",
+  "profileWeightValue": "{weight} kg",
+  "@profileWeightValue": {
+    "placeholders": {
+      "weight": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsTitle": "Seguimiento de pruebas máximas",
+  "profileMaxTestsDescription": "Registra tus mejores intentos para ver cómo evoluciona tu fuerza con el tiempo.",
+  "profileMaxTestsPeriodLabel": "Período",
+  "profileMaxTestsPeriodMonth": "Último mes",
+  "profileMaxTestsPeriodHalfYear": "Últimos 6 meses",
+  "profileMaxTestsPeriodYear": "Último año",
+  "profileMaxTestsPeriodAll": "Todo el tiempo",
+  "profileMaxTestsEmptyPeriod": "No hay pruebas máximas registradas en {period}. Prueba un rango de tiempo mayor.",
+  "@profileMaxTestsEmptyPeriod": {
+    "placeholders": {
+      "period": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsBestPeriodLabel": "Mejor en el período seleccionado",
+  "profileMaxTestsAdd": "Añadir prueba máxima",
+  "profileMaxTestsRefresh": "Actualizar",
+  "profileMaxTestsHistoryAction": "Ver progreso",
+  "profileMaxTestsEmpty": "Aún no hay pruebas máximas registradas. Añade tu primer intento para empezar a seguir el progreso.",
+  "profileMaxTestsHistoryTitle": "Progreso en el tiempo",
+  "profileMaxTestsHistoryDescription": "Revisa cada intento y observa cómo evolucionan tus valores máximos.",
+  "profileMaxTestsHistoryEmpty": "Aún no hay pruebas máximas registradas. Añade un nuevo intento para ver tu progreso con el tiempo.",
+  "profileMaxTestsRecentPerformanceLabel": "Rendimiento reciente",
+  "profileMaxTestsGoalLabel": "Objetivo",
+  "profileMaxTestsTipsTitle": "Consejos y tutoriales",
+  "profileMaxTestsTipsSubtitle": "Revisa indicaciones de técnica y ejercicios accesorios.",
+  "profileMaxTestsEmptyShort": "Añade una nueva prueba para ver tu gráfico de rendimiento.",
+  "profileMaxTestsSessionLabel": "Sesión {index}",
+  "@profileMaxTestsSessionLabel": {
+    "placeholders": {
+      "index": {
+        "type": "int"
+      }
+    }
+  },
+  "profileMaxTestsHistoryError": "No se pudo cargar el historial de progreso: {error}",
+  "@profileMaxTestsHistoryError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsHistoryDeltaLabel": "Cambio {delta}",
+  "@profileMaxTestsHistoryDeltaLabel": {
+    "placeholders": {
+      "delta": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsHistoryFirstEntry": "Primer intento registrado",
+  "profileMaxTestsError": "No se pudieron cargar las pruebas máximas: {error}",
+  "@profileMaxTestsError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsExerciseLabel": "Ejercicio",
+  "profileMaxTestsExerciseHint": "p. ej., dominadas o flexiones",
+  "profileMaxTestsValueLabel": "Resultado",
+  "profileMaxTestsValueHint": "Introduce un valor positivo",
+  "profileMaxTestsUnitLabel": "Unidad",
+  "profileMaxTestsUnitHint": "p. ej., reps, kg, seg",
+  "profileMaxTestsDateLabel": "Registrado el {date}",
+  "@profileMaxTestsDateLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "profileMaxTestsCancel": "Cancelar",
+  "profileMaxTestsSave": "Guardar prueba",
+  "profileMaxTestsSaveSuccess": "Prueba máxima guardada",
+  "profileMaxTestsSaveError": "No se pudo guardar la prueba: {error}",
+  "@profileMaxTestsSaveError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "profileMaxTestsDefaultUnit": "reps",
+  "profileMaxTestsBestLabel": "Mejor marca",
+  "profileMaxTestsShowMore": "Mostrar todos los intentos",
+  "profileMaxTestsShowLess": "Mostrar menos intentos",
+  "profileEdit": "Editar perfil",
+  "profileEditSubtitle": "Actualiza tus datos personales",
+  "profileThemeSettingsTitle": "Colores del tema",
+  "profileThemeSettingsSubtitle": "Elige el tema de color de la app",
+  "profileLanguageSettingsTitle": "Idioma",
+  "profileLanguageSettingsSubtitle": "Elige el idioma de la app",
+  "profileEditTitle": "Editar perfil",
+  "profileEditFullNameLabel": "Nombre completo",
+  "profileEditFullNameHint": "¿Cómo quieres que te llamemos?",
+  "profileEditWeightLabel": "Peso",
+  "profileEditWeightHint": "Introduce tu peso en kg (opcional)",
+  "profileEditWeightInvalid": "Introduce un peso positivo válido.",
+  "profilePhotoEdit": "Cambiar foto",
+  "profileEditCancel": "Cancelar",
+  "profileEditSave": "Guardar cambios",
+  "profileEditSuccess": "Perfil actualizado correctamente",
+  "profileEditError": "No se pudo actualizar el perfil: {error}",
+  "@profileEditError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "logout": "Cerrar sesión",
+  "languageSystemLabel": "Predeterminado del sistema",
+  "languageEnglishLabel": "Inglés",
+  "languageItalianLabel": "Italiano",
+  "languageSpanishLabel": "Español",
+  "redirectError": "Error durante la redirección: {error}",
+  "@redirectError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "linkError": "Error de enlace: {error}",
+  "@linkError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "missingFieldsError": "Por favor completa todos los campos obligatorios.",
+  "passwordMismatch": "Las contraseñas no coinciden.",
+  "invalidCredentials": "Credenciales inválidas.",
+  "signupEmailCheck": "¡Registro completo! Revisa tu correo para confirmar la cuenta.",
+  "unexpectedError": "Error inesperado: {error}",
+  "@unexpectedError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
+  "loginGreeting": "¡Bienvenido de nuevo! Inicia sesión para continuar tu entrenamiento.",
+  "signupGreeting": "Crea una cuenta para desbloquear todos los entrenamientos.",
+  "emailLabel": "Correo electrónico",
+  "passwordLabel": "Contraseña",
+  "confirmPasswordLabel": "Confirmar contraseña",
+  "loginButton": "Iniciar sesión",
+  "signupButton": "Registrarse",
+  "noAccountPrompt": "¿No tienes cuenta? Regístrate",
+  "existingAccountPrompt": "¿Ya tienes cuenta? Inicia sesión",
+  "forgotPasswordLink": "¿Olvidaste tu contraseña?",
+  "passwordResetEmailSent": "Enlace de restablecimiento enviado a {email}. Revisa tu bandeja de entrada.",
+  "@passwordResetEmailSent": {
+    "placeholders": {
+      "email": {
+        "type": "String"
+      }
+    }
+  },
+  "passwordResetEmailMissing": "Introduce tu correo para recibir un enlace de restablecimiento.",
+  "passwordResetDialogTitle": "Elige una nueva contraseña",
+  "passwordResetDialogDescription": "Introduce una nueva contraseña para asegurar tu cuenta.",
+  "passwordResetNewPasswordLabel": "Nueva contraseña",
+  "passwordResetConfirmPasswordLabel": "Confirmar nueva contraseña",
+  "passwordResetMismatch": "Las contraseñas no coinciden.",
+  "passwordResetSuccess": "Contraseña actualizada correctamente. Puedes seguir usando la app.",
+  "passwordResetSubmit": "Actualizar contraseña",
+  "cancel": "Cancelar",
+  "add": "Añadir",
+  "start": "Iniciar",
+  "timerTitle": "Temporizador",
+  "timerExercisePushUps": "Flexiones",
+  "timerExercisePullUps": "Dominadas",
+  "timerExerciseSquats": "Sentadillas",
+  "timerExercisePlank": "Plancha",
+  "timerPhaseWork": "TRABAJO",
+  "timerPhaseRest": "DESCANSO",
+  "timerWorkDurationLabel": "Duración del trabajo",
+  "timerRestDurationLabel": "Duración del descanso",
+  "timerControlSkip": "SALTAR",
+  "timerControlPause": "PAUSAR",
+  "timerControlPlay": "REPRODUCIR",
+  "timerControlReset": "REINICIAR",
+  "timerAdjustDecrease": "-10s",
+  "timerAdjustIncrease": "+10s",
+  "timerNextPlaceholder": "Siguiente: --",
+  "timerNextLabel": "Siguiente: {name} · Serie {current}/{total}",
+  "@timerNextLabel": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      },
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "amrapTimerTitle": "Temporizador AMRAP",
+  "amrapTimerSubtitle": "Completa tantas rondas como sea posible.",
+  "amrapTimerDescription": "Configura la duración total y controla el tiempo restante.",
+  "amrapDurationLabel": "Duración (minutos)",
+  "amrapStartButton": "Iniciar AMRAP",
+  "amrapResetButton": "Reiniciar AMRAP",
+  "amrapTimeRemainingLabel": "Tiempo restante",
+  "countdownTitle": "Temporizador simple",
+  "countdownSubtitle": "Un temporizador sencillo para cualquier intervalo.",
+  "countdownDescription": "Configura minutos y segundos, luego inicia el temporizador.",
+  "countdownMinutesLabel": "Minutos",
+  "countdownSecondsLabel": "Segundos",
+  "countdownStartButton": "Iniciar temporizador",
+  "countdownResetButton": "Detener temporizador",
+  "weekNumber": "Semana {week}",
+  "@weekNumber": {
+    "placeholders": {
+      "week": {
+        "type": "int"
+      }
+    }
+  },
+  "defaultWorkoutTitle": "Entrenamiento",
+  "terminologyTitle": "Terminología",
+  "termRepsTitle": "Repeticiones",
+  "termRepsDescription": "Número de veces que realizas un ejercicio consecutivamente.",
+  "termSetTitle": "Serie",
+  "termSetDescription": "Un grupo de repeticiones. Por ejemplo: 3 series de 10 repeticiones significa 30 repeticiones totales divididas en 3 grupos.",
+  "termRtTitle": "RT",
+  "termRtDescription": "Repeticiones totales: realiza todas las repeticiones con tus series, repeticiones y tempo preferidos (si no se especifica).",
+  "termAmrapTitle": "AMRAP",
+  "termAmrapDescription": "As Many Reps As Possible: realiza tantas repeticiones como puedas en un tiempo determinado.",
+  "termEmomTitle": "EMOM",
+  "termEmomDescription": "Every Minute on the Minute: inicia una serie cada minuto. Descansa durante el tiempo restante.",
+  "termRampingTitle": "Ramping",
+  "termRampingDescription": "Método en el que la carga aumenta con cada serie.",
+  "termMavTitle": "MAV",
+  "termMavDescription": "Massima Alzata Veloce: realiza tantas repeticiones como sea posible con una carga manteniendo el control y buena velocidad.",
+  "termIsocineticiTitle": "Isocinético",
+  "termIsocineticiDescription": "Ejercicios realizados a velocidad constante.",
+  "termTutTitle": "TUT",
+  "termTutDescription": "Indica cuánto debe durar una repetición. Puedes gestionar la duración de cada fase.",
+  "termIsoTitle": "ISO",
+  "termIsoDescription": "Indica una pausa en un punto específico de la repetición.",
+  "termSomTitle": "SOM",
+  "termSomDescription": "Indica la duración de cada fase de la repetición.",
+  "termScaricoTitle": "Descarga",
+  "termScaricoDescription": "Última semana del programa para prepararte para intentos máximos."
+}

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -345,6 +345,7 @@
   "languageSystemLabel": "Sistema",
   "languageEnglishLabel": "Inglese",
   "languageItalianLabel": "Italiano",
+  "languageSpanishLabel": "Spagnolo",
   "redirectError": "Errore durante il reindirizzamento: {error}",
   "@redirectError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6,6 +6,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
 import 'app_localizations_en.dart';
+import 'app_localizations_es.dart';
 import 'app_localizations_it.dart';
 
 // ignore_for_file: type=lint
@@ -95,6 +96,7 @@ abstract class AppLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
+    Locale('es'),
     Locale('it'),
   ];
 
@@ -1424,6 +1426,12 @@ abstract class AppLocalizations {
   /// **'Italiano'**
   String get languageItalianLabel;
 
+  /// No description provided for @languageSpanishLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Spagnolo'**
+  String get languageSpanishLabel;
+
   /// No description provided for @redirectError.
   ///
   /// In it, this message translates to:
@@ -1958,7 +1966,7 @@ class _AppLocalizationsDelegate
 
   @override
   bool isSupported(Locale locale) =>
-      <String>['en', 'it'].contains(locale.languageCode);
+      <String>['en', 'es', 'it'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -1969,6 +1977,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   switch (locale.languageCode) {
     case 'en':
       return AppLocalizationsEn();
+    case 'es':
+      return AppLocalizationsEs();
     case 'it':
       return AppLocalizationsIt();
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -754,6 +754,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get languageItalianLabel => 'Italian';
 
   @override
+  String get languageSpanishLabel => 'Spanish';
+
+  @override
   String redirectError(Object error) {
     return 'Error during redirect: $error';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1,0 +1,1050 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Spanish (`es`).
+class AppLocalizationsEs extends AppLocalizations {
+  AppLocalizationsEs([String locale = 'es']) : super(locale);
+
+  @override
+  String get appTitle => 'Calisync';
+
+  @override
+  String get authErrorMessage => 'Error de autenticación';
+
+  @override
+  String get navHome => 'Inicio';
+
+  @override
+  String get navGuides => 'Guías';
+
+  @override
+  String get navProfile => 'Perfil';
+
+  @override
+  String get navSettings => 'Configuración';
+
+  @override
+  String get navTerminology => 'Terminología';
+
+  @override
+  String get settingsThemeTitle => 'Tema';
+
+  @override
+  String get themeDefaultLabel => 'Predeterminado';
+
+  @override
+  String get themeBlackLabel => 'Negro';
+
+  @override
+  String get themePinkLabel => 'Rosa';
+
+  @override
+  String get themeRedLabel => 'Rojo';
+
+  @override
+  String get themeBlueLabel => 'Azul';
+
+  @override
+  String get onboardingTitleOne => 'Entrena de forma inteligente';
+
+  @override
+  String get onboardingDescriptionOne =>
+      'Sigue entrenamientos guiados creados para tu plan de calistenia.';
+
+  @override
+  String get onboardingTitleTwo => 'Haz seguimiento del progreso';
+
+  @override
+  String get onboardingDescriptionTwo =>
+      'Registra series, repeticiones y notas para ver tus mejoras.';
+
+  @override
+  String get onboardingTitleThree => 'Mantén la constancia';
+
+  @override
+  String get onboardingDescriptionThree =>
+      'Mantén el impulso con acceso rápido a tu próxima sesión.';
+
+  @override
+  String get onboardingSkip => 'Saltar';
+
+  @override
+  String get onboardingBack => 'Atrás';
+
+  @override
+  String get onboardingNext => 'Siguiente';
+
+  @override
+  String get onboardingGetStarted => 'Empezar';
+
+  @override
+  String get guidesTitle => 'Habilidades';
+
+  @override
+  String get guidesSubtitle => 'Desbloquea nuevas habilidades mientras dominas lo básico.';
+
+  @override
+  String get guidesLoadError => 'No se pueden cargar las guías de habilidades en este momento.';
+
+  @override
+  String get guidesPrimaryFocus => 'Enfoque principal';
+
+  @override
+  String get guidesCoachTip => 'Consejo del entrenador';
+
+  @override
+  String get skillsLockedLabel => 'Bloqueado';
+
+  @override
+  String get skillsUnlockedLabel => 'Desbloqueado';
+
+  @override
+  String get skillsLockedHint =>
+      'Completa habilidades anteriores para desbloquear el desglose completo.';
+
+  @override
+  String get skillsUnlockAction => 'Desbloquear habilidad';
+
+  @override
+  String get difficultyBeginner => 'Principiante';
+
+  @override
+  String get difficultyIntermediate => 'Intermedio';
+
+  @override
+  String get difficultyAdvanced => 'Avanzado';
+
+  @override
+  String get guidesPullupName => 'Dominada';
+
+  @override
+  String get guidesPullupFocus => 'Dorsales, bíceps, agarre';
+
+  @override
+  String get guidesPullupTip =>
+      'Lleva los codos hacia las costillas y mantén las costillas recogidas para evitar el balanceo.';
+
+  @override
+  String get guidesPullupDescription =>
+      'Empieza colgado con cuerpo en hollow, luego tira hasta que la barbilla supere la barra. Controla la bajada para repeticiones más fuertes.';
+
+  @override
+  String get guidesChinUpName => 'Dominada supina';
+
+  @override
+  String get guidesChinUpFocus => 'Dorsales, bíceps, agarre';
+
+  @override
+  String get guidesChinUpTip =>
+      'Mantén los hombros abajo y lleva los codos hacia las costillas para mantener fuerza arriba.';
+
+  @override
+  String get guidesChinUpDescription =>
+      'Empieza colgado con las palmas hacia ti, tira hasta que la barbilla supere la barra y baja con control.';
+
+  @override
+  String get guidesPushupName => 'Flexión';
+
+  @override
+  String get guidesPushupFocus => 'Pecho, tríceps, core';
+
+  @override
+  String get guidesPushupTip =>
+      'Aprieta los glúteos y mantén una línea recta de la cabeza a los talones.';
+
+  @override
+  String get guidesPushupDescription =>
+      'Baja con los codos a unos 45° del torso, toca ligeramente el pecho y vuelve a subir sin que las caderas se hundan.';
+
+  @override
+  String get guidesBodyweightSquatName => 'Sentadilla con peso corporal';
+
+  @override
+  String get guidesBodyweightSquatFocus => 'Cuádriceps, glúteos, core';
+
+  @override
+  String get guidesBodyweightSquatTip =>
+      'Empuja las rodillas hacia afuera al bajar y mantén los talones apoyados.';
+
+  @override
+  String get guidesBodyweightSquatDescription =>
+      'Lleva las caderas atrás y abajo hasta que los muslos estén al menos paralelos. Empuja de forma uniforme con todo el pie para ponerte de pie.';
+
+  @override
+  String get guidesGluteBridgeName => 'Puente de glúteos';
+
+  @override
+  String get guidesGluteBridgeFocus => 'Glúteos, isquiotibiales, core';
+
+  @override
+  String get guidesGluteBridgeTip =>
+      'Exhala al subir y evita arquear la espalda baja en la parte alta.';
+
+  @override
+  String get guidesGluteBridgeDescription =>
+      'Túmbate boca arriba con rodillas flexionadas, empuja con los talones para elevar las caderas hasta alinear muslos y torso, y baja con control.';
+
+  @override
+  String get guidesHangingLegRaiseName => 'Elevación de piernas colgado';
+
+  @override
+  String get guidesHangingLegRaiseFocus => 'Abdominales, flexores de cadera, agarre';
+
+  @override
+  String get guidesHangingLegRaiseTip =>
+      'Inicia cada repetición activando los dorsales para estabilizar el torso.';
+
+  @override
+  String get guidesHangingLegRaiseDescription =>
+      'Desde un colgado muerto, eleva las piernas juntas hasta la altura de la cadera o más. Baja despacio para mantener tensión.';
+
+  @override
+  String get guidesMuscleUpName => 'Muscle-up';
+
+  @override
+  String get guidesMuscleUpFocus => 'Dorsales, pecho, tríceps, fuerza de transición';
+
+  @override
+  String get guidesMuscleUpTip =>
+      'Tira alto hacia el pecho superior y mantén la barra cerca para reducir el balanceo.';
+
+  @override
+  String get guidesMuscleUpDescription =>
+      'Desde un colgado controlado, explota en un tirón alto, pasa las muñecas sobre la barra y presiona hasta el bloqueo.';
+
+  @override
+  String get guidesStraightBarDipName => 'Fondos en barra recta';
+
+  @override
+  String get guidesStraightBarDipFocus => 'Pecho, tríceps, hombros';
+
+  @override
+  String get guidesStraightBarDipTip =>
+      'Mantén los codos pegados y empuja hacia abajo inclinándote ligeramente hacia delante.';
+
+  @override
+  String get guidesStraightBarDipDescription =>
+      'Empieza arriba de la barra con los codos bloqueados, baja con control hasta que los hombros queden por debajo de los codos y vuelve a subir.';
+
+  @override
+  String get guidesDipsName => 'Fondos';
+
+  @override
+  String get guidesDipsFocus => 'Pecho, tríceps, hombros';
+
+  @override
+  String get guidesDipsTip =>
+      'Inclínate ligeramente hacia delante y mantén los hombros estables para proteger las articulaciones.';
+
+  @override
+  String get guidesDipsDescription =>
+      'Empieza bloqueado en barras paralelas, baja hasta que los hombros queden por debajo de los codos y vuelve a subir con fuerza.';
+
+  @override
+  String get guidesAustralianRowName => 'Remo australiano';
+
+  @override
+  String get guidesAustralianRowFocus => 'Espalda alta, bíceps, core';
+
+  @override
+  String get guidesAustralianRowTip =>
+      'Activa el core y mantén una línea recta de los hombros a los talones.';
+
+  @override
+  String get guidesAustralianRowDescription =>
+      'Coloca la barra a la altura de la cintura, cuélgate debajo y rema el pecho hacia la barra con los codos cerrados.';
+
+  @override
+  String get guidesPikePushUpName => 'Flexión pike';
+
+  @override
+  String get guidesPikePushUpFocus => 'Hombros, tríceps, core';
+
+  @override
+  String get guidesPikePushUpTip =>
+      'Mantén las caderas altas y baja la cabeza a un punto justo delante de las manos.';
+
+  @override
+  String get guidesPikePushUpDescription =>
+      'Desde la posición pike, flexiona los codos para bajar la cabeza y luego presiona hasta el bloqueo.';
+
+  @override
+  String get guidesHollowHoldName => 'Hollow hold';
+
+  @override
+  String get guidesHollowHoldFocus => 'Core, flexores de cadera, postura';
+
+  @override
+  String get guidesHollowHoldTip =>
+      'Presiona la zona lumbar contra el suelo y mantén las costillas recogidas.';
+
+  @override
+  String get guidesHollowHoldDescription =>
+      'Túmbate boca arriba, eleva hombros y piernas y mantén una forma de banana con brazos rectos sobre la cabeza.';
+
+  @override
+  String get guidesPlankName => 'Plancha';
+
+  @override
+  String get guidesPlankFocus => 'Core, hombros, glúteos';
+
+  @override
+  String get guidesPlankTip =>
+      'Aprieta los glúteos y mantén las costillas recogidas para que las caderas no se hundan.';
+
+  @override
+  String get guidesPlankDescription =>
+      'Coloca antebrazos bajo los hombros, estira las piernas y mantén una línea recta de la cabeza a los talones mientras respiras.';
+
+  @override
+  String get guidesLSitName => 'L-sit';
+
+  @override
+  String get guidesLSitFocus => 'Core, flexores de cadera, tríceps';
+
+  @override
+  String get guidesLSitTip =>
+      'Empuja el suelo, bloquea los codos y mantén las rodillas rectas.';
+
+  @override
+  String get guidesLSitDescription =>
+      'Desde barras paralelas o el suelo, eleva las piernas hasta la altura de la cadera y mantén una L firme.';
+
+  @override
+  String get guidesHandstandName => 'Parada de manos';
+
+  @override
+  String get guidesHandstandFocus => 'Hombros, core, equilibrio';
+
+  @override
+  String get guidesHandstandTip =>
+      'Alinea muñecas, hombros y caderas mientras aprietas los glúteos.';
+
+  @override
+  String get guidesHandstandDescription =>
+      'Sube con impulso o empuje a una pared o equilibrio libre y mantén una línea alta con los dedos apuntando.';
+
+  @override
+  String get homeLoadErrorTitle => 'No se pueden cargar los entrenamientos';
+
+  @override
+  String get retry => 'Reintentar';
+
+  @override
+  String get homeCoachTipTitle => 'Consejo del entrenador';
+
+  @override
+  String get homeCoachTipPlaceholder =>
+      'El último consejo de tu entrenador aparecerá aquí.';
+
+  @override
+  String homeGreeting(String name) {
+    return 'Hola, ${name}!';
+  }
+
+  @override
+  String get homeViewStats => 'Ver estadísticas';
+
+  @override
+  String get homeProgressTitle => 'Progreso mensual';
+
+  @override
+  String get homeProgressWorkoutsLabel => 'Entrenamientos';
+
+  @override
+  String get homeProgressTimeTrainedLabel => 'Tiempo entrenado';
+
+  @override
+  String homeProgressTimeValue(int hours, int minutes) {
+    return '${hours}h ${minutes}m';
+  }
+
+  @override
+  String get homeSkillProgressTitle => 'Progreso de habilidades';
+
+  @override
+  String homeSkillProgressValue(int unlocked, int total) {
+    return '${unlocked} / ${total}';
+  }
+
+  @override
+  String get homeSkillProgressLabel => 'Habilidades desbloqueadas';
+
+  @override
+  String get homeStrengthLevelTitle => 'Nivel de fuerza';
+
+  @override
+  String get workoutPlanTitle => 'Plan de entrenamiento';
+
+  @override
+  String get traineeFeedbackTitle => 'Comentarios del alumno';
+
+  @override
+  String get traineeFeedbackSubtitle =>
+      'Cuéntale a tu entrenador cómo te sientes y cómo va el plan.';
+
+  @override
+  String get traineeFeedbackQuestionLabel => '¿Cómo se sintió tu entrenamiento?';
+
+  @override
+  String get traineeFeedbackQuestionHint =>
+      'Comparte lo que va bien o lo que necesita atención.';
+
+  @override
+  String get traineeFeedbackSubmit => 'Enviar feedback';
+
+  @override
+  String get traineeFeedbackSubmitted =>
+      'Feedback guardado. Lo compartiremos con tu entrenador.';
+
+  @override
+  String get homeEmptyTitle => 'No hay entrenamientos disponibles';
+
+  @override
+  String get homeEmptyDescription =>
+      'Contacta a tu entrenador para recibir un nuevo plan.';
+
+  @override
+  String get homePlansSectionTitle => 'Planes de entrenamiento';
+
+  @override
+  String get homePlansSectionSubtitle =>
+      'Planes asignados y su estado actual.';
+
+  @override
+  String get homePlansEmptyTitle => 'Aún no hay planes de entrenamiento';
+
+  @override
+  String get homePlansEmptyDescription =>
+      'Pide a tu entrenador que asigne un plan para verlo aquí.';
+
+  @override
+  String get homePlanStatusDraft => 'Borrador';
+
+  @override
+  String get homePlanStatusArchived => 'Archivado';
+
+  @override
+  String get homePlanStatusUpcoming => 'Próximo';
+
+  @override
+  String get homePlanStatusUnknown => 'Estado desconocido';
+
+  @override
+  String get homePlanDefaultTitle => 'Plan de entrenamiento';
+
+  @override
+  String get homePlanLatestLabel => 'Último plan';
+
+  @override
+  String homePlanStartedLabel(String date) {
+    return 'Iniciado ${date}';
+  }
+
+  @override
+  String get unauthenticated => 'Usuario no autenticado';
+
+  @override
+  String get defaultExerciseName => 'Ejercicio';
+
+  @override
+  String get trainingHeaderExercise => 'Ejercicio';
+
+  @override
+  String get trainingHeaderExercises => 'Ejercicios';
+
+  @override
+  String get trainingHeaderSets => 'Series';
+
+  @override
+  String get trainingHeaderReps => 'Repeticiones';
+
+  @override
+  String get trainingTodayTitle => 'Entrenamiento de hoy';
+
+  @override
+  String get trainingStartWorkout => 'Iniciar entrenamiento';
+
+  @override
+  String get trainingWorkoutCompleted => 'Entrenamiento completado';
+
+  @override
+  String trainingDurationMinutes(int minutes) {
+    return '${minutes} min';
+  }
+
+  @override
+  String get trainingCompletionSaved => 'Día de entrenamiento actualizado';
+
+  @override
+  String trainingCompletionError(Object error) {
+    return 'No se pudo actualizar el entrenamiento: ${error}';
+  }
+
+  @override
+  String get trainingCompletionUnavailable => 'No se puede actualizar este día de entrenamiento.';
+
+  @override
+  String get trainingExerciseCompletionSaved => 'Ejercicio actualizado';
+
+  @override
+  String trainingExerciseCompletionError(Object error) {
+    return 'No se pudo actualizar el ejercicio: ${error}';
+  }
+
+  @override
+  String get trainingExerciseCompletionUnavailable =>
+      'No se puede actualizar este ejercicio.';
+
+  @override
+  String logoutError(Object error) {
+    return 'Error al cerrar sesión: ${error}';
+  }
+
+  @override
+  String get profileFallbackName => 'Usuario';
+
+  @override
+  String get userNotFound => 'Usuario no encontrado en la base de datos';
+
+  @override
+  String get profileLoadError => 'Error al cargar los datos';
+
+  @override
+  String get profileNoData => 'No hay datos disponibles';
+
+  @override
+  String get profileEmailUnavailable => 'Correo electrónico no disponible';
+
+  @override
+  String get profileStatusActive => 'Cuenta activa';
+
+  @override
+  String get profileStatusInactive => 'Cuenta inactiva';
+
+  @override
+  String get profilePlanActive => 'Plan activo';
+
+  @override
+  String get profilePlanExpired => 'Plan caducado';
+
+  @override
+  String get profileUsername => 'Nombre de usuario';
+
+  @override
+  String get profileNotSet => 'No establecido';
+
+  @override
+  String get profileWeight => 'Peso';
+
+  @override
+  String profileWeightValue(String weight) {
+    return '${weight} kg';
+  }
+
+  @override
+  String get profileMaxTestsTitle => 'Seguimiento de pruebas máximas';
+
+  @override
+  String get profileMaxTestsDescription =>
+      'Registra tus mejores intentos para ver cómo evoluciona tu fuerza con el tiempo.';
+
+  @override
+  String get profileMaxTestsPeriodLabel => 'Período';
+
+  @override
+  String get profileMaxTestsPeriodMonth => 'Último mes';
+
+  @override
+  String get profileMaxTestsPeriodHalfYear => 'Últimos 6 meses';
+
+  @override
+  String get profileMaxTestsPeriodYear => 'Último año';
+
+  @override
+  String get profileMaxTestsPeriodAll => 'Todo el tiempo';
+
+  @override
+  String profileMaxTestsEmptyPeriod(String period) {
+    return 'No hay pruebas máximas registradas en ${period}. Prueba un rango de tiempo mayor.';
+  }
+
+  @override
+  String get profileMaxTestsBestPeriodLabel => 'Mejor en el período seleccionado';
+
+  @override
+  String get profileMaxTestsAdd => 'Añadir prueba máxima';
+
+  @override
+  String get profileMaxTestsRefresh => 'Actualizar';
+
+  @override
+  String get profileMaxTestsHistoryAction => 'Ver progreso';
+
+  @override
+  String get profileMaxTestsEmpty =>
+      'Aún no hay pruebas máximas registradas. Añade tu primer intento para empezar a seguir el progreso.';
+
+  @override
+  String get profileMaxTestsHistoryTitle => 'Progreso en el tiempo';
+
+  @override
+  String get profileMaxTestsHistoryDescription =>
+      'Revisa cada intento y observa cómo evolucionan tus valores máximos.';
+
+  @override
+  String get profileMaxTestsHistoryEmpty =>
+      'Aún no hay pruebas máximas registradas. Añade un nuevo intento para ver tu progreso con el tiempo.';
+
+  @override
+  String get profileMaxTestsRecentPerformanceLabel => 'Rendimiento reciente';
+
+  @override
+  String get profileMaxTestsGoalLabel => 'Objetivo';
+
+  @override
+  String get profileMaxTestsTipsTitle => 'Consejos y tutoriales';
+
+  @override
+  String get profileMaxTestsTipsSubtitle =>
+      'Revisa indicaciones de técnica y ejercicios accesorios.';
+
+  @override
+  String get profileMaxTestsEmptyShort =>
+      'Añade una nueva prueba para ver tu gráfico de rendimiento.';
+
+  @override
+  String profileMaxTestsSessionLabel(int index) {
+    return 'Sesión ${index}';
+  }
+
+  @override
+  String profileMaxTestsHistoryError(Object error) {
+    return 'No se pudo cargar el historial de progreso: ${error}';
+  }
+
+  @override
+  String profileMaxTestsHistoryDeltaLabel(String delta) {
+    return 'Cambio ${delta}';
+  }
+
+  @override
+  String get profileMaxTestsHistoryFirstEntry => 'Primer intento registrado';
+
+  @override
+  String profileMaxTestsError(Object error) {
+    return 'No se pudieron cargar las pruebas máximas: ${error}';
+  }
+
+  @override
+  String get profileMaxTestsExerciseLabel => 'Ejercicio';
+
+  @override
+  String get profileMaxTestsExerciseHint => 'p. ej., dominadas o flexiones';
+
+  @override
+  String get profileMaxTestsValueLabel => 'Resultado';
+
+  @override
+  String get profileMaxTestsValueHint => 'Introduce un valor positivo';
+
+  @override
+  String get profileMaxTestsUnitLabel => 'Unidad';
+
+  @override
+  String get profileMaxTestsUnitHint => 'p. ej., reps, kg, seg';
+
+  @override
+  String profileMaxTestsDateLabel(String date) {
+    return 'Registrado el ${date}';
+  }
+
+  @override
+  String get profileMaxTestsCancel => 'Cancelar';
+
+  @override
+  String get profileMaxTestsSave => 'Guardar prueba';
+
+  @override
+  String get profileMaxTestsSaveSuccess => 'Prueba máxima guardada';
+
+  @override
+  String profileMaxTestsSaveError(Object error) {
+    return 'No se pudo guardar la prueba: ${error}';
+  }
+
+  @override
+  String get profileMaxTestsDefaultUnit => 'reps';
+
+  @override
+  String get profileMaxTestsBestLabel => 'Mejor marca';
+
+  @override
+  String get profileMaxTestsShowMore => 'Mostrar todos los intentos';
+
+  @override
+  String get profileMaxTestsShowLess => 'Mostrar menos intentos';
+
+  @override
+  String get profileEdit => 'Editar perfil';
+
+  @override
+  String get profileEditSubtitle => 'Actualiza tus datos personales';
+
+  @override
+  String get profileThemeSettingsTitle => 'Colores del tema';
+
+  @override
+  String get profileThemeSettingsSubtitle => 'Elige el tema de color de la app';
+
+  @override
+  String get profileLanguageSettingsTitle => 'Idioma';
+
+  @override
+  String get profileLanguageSettingsSubtitle => 'Elige el idioma de la app';
+
+  @override
+  String get profileEditTitle => 'Editar perfil';
+
+  @override
+  String get profileEditFullNameLabel => 'Nombre completo';
+
+  @override
+  String get profileEditFullNameHint => '¿Cómo quieres que te llamemos?';
+
+  @override
+  String get profileEditWeightLabel => 'Peso';
+
+  @override
+  String get profileEditWeightHint => 'Introduce tu peso en kg (opcional)';
+
+  @override
+  String get profileEditWeightInvalid => 'Introduce un peso positivo válido.';
+
+  @override
+  String get profilePhotoEdit => 'Cambiar foto';
+
+  @override
+  String get profileEditCancel => 'Cancelar';
+
+  @override
+  String get profileEditSave => 'Guardar cambios';
+
+  @override
+  String get profileEditSuccess => 'Perfil actualizado correctamente';
+
+  @override
+  String profileEditError(Object error) {
+    return 'No se pudo actualizar el perfil: ${error}';
+  }
+
+  @override
+  String get logout => 'Cerrar sesión';
+
+  @override
+  String get languageSystemLabel => 'Predeterminado del sistema';
+
+  @override
+  String get languageEnglishLabel => 'Inglés';
+
+  @override
+  String get languageItalianLabel => 'Italiano';
+
+  @override
+  String get languageSpanishLabel => 'Español';
+
+  @override
+  String redirectError(Object error) {
+    return 'Error durante la redirección: ${error}';
+  }
+
+  @override
+  String linkError(Object error) {
+    return 'Error de enlace: ${error}';
+  }
+
+  @override
+  String get missingFieldsError => 'Por favor completa todos los campos obligatorios.';
+
+  @override
+  String get passwordMismatch => 'Las contraseñas no coinciden.';
+
+  @override
+  String get invalidCredentials => 'Credenciales inválidas.';
+
+  @override
+  String get signupEmailCheck =>
+      '¡Registro completo! Revisa tu correo para confirmar la cuenta.';
+
+  @override
+  String unexpectedError(Object error) {
+    return 'Error inesperado: ${error}';
+  }
+
+  @override
+  String get loginGreeting =>
+      '¡Bienvenido de nuevo! Inicia sesión para continuar tu entrenamiento.';
+
+  @override
+  String get signupGreeting => 'Crea una cuenta para desbloquear todos los entrenamientos.';
+
+  @override
+  String get emailLabel => 'Correo electrónico';
+
+  @override
+  String get passwordLabel => 'Contraseña';
+
+  @override
+  String get confirmPasswordLabel => 'Confirmar contraseña';
+
+  @override
+  String get loginButton => 'Iniciar sesión';
+
+  @override
+  String get signupButton => 'Registrarse';
+
+  @override
+  String get noAccountPrompt => '¿No tienes cuenta? Regístrate';
+
+  @override
+  String get existingAccountPrompt => '¿Ya tienes cuenta? Inicia sesión';
+
+  @override
+  String get forgotPasswordLink => '¿Olvidaste tu contraseña?';
+
+  @override
+  String passwordResetEmailSent(String email) {
+    return 'Enlace de restablecimiento enviado a ${email}. Revisa tu bandeja de entrada.';
+  }
+
+  @override
+  String get passwordResetEmailMissing =>
+      'Introduce tu correo para recibir un enlace de restablecimiento.';
+
+  @override
+  String get passwordResetDialogTitle => 'Elige una nueva contraseña';
+
+  @override
+  String get passwordResetDialogDescription =>
+      'Introduce una nueva contraseña para asegurar tu cuenta.';
+
+  @override
+  String get passwordResetNewPasswordLabel => 'Nueva contraseña';
+
+  @override
+  String get passwordResetConfirmPasswordLabel => 'Confirmar nueva contraseña';
+
+  @override
+  String get passwordResetMismatch => 'Las contraseñas no coinciden.';
+
+  @override
+  String get passwordResetSuccess =>
+      'Contraseña actualizada correctamente. Puedes seguir usando la app.';
+
+  @override
+  String get passwordResetSubmit => 'Actualizar contraseña';
+
+  @override
+  String get cancel => 'Cancelar';
+
+  @override
+  String get add => 'Añadir';
+
+  @override
+  String get start => 'Iniciar';
+
+  @override
+  String get timerTitle => 'Temporizador';
+
+  @override
+  String get timerExercisePushUps => 'Flexiones';
+
+  @override
+  String get timerExercisePullUps => 'Dominadas';
+
+  @override
+  String get timerExerciseSquats => 'Sentadillas';
+
+  @override
+  String get timerExercisePlank => 'Plancha';
+
+  @override
+  String get timerPhaseWork => 'TRABAJO';
+
+  @override
+  String get timerPhaseRest => 'DESCANSO';
+
+  @override
+  String get timerWorkDurationLabel => 'Duración del trabajo';
+
+  @override
+  String get timerRestDurationLabel => 'Duración del descanso';
+
+  @override
+  String get timerControlSkip => 'SALTAR';
+
+  @override
+  String get timerControlPause => 'PAUSAR';
+
+  @override
+  String get timerControlPlay => 'REPRODUCIR';
+
+  @override
+  String get timerControlReset => 'REINICIAR';
+
+  @override
+  String get timerAdjustDecrease => '-10s';
+
+  @override
+  String get timerAdjustIncrease => '+10s';
+
+  @override
+  String get timerNextPlaceholder => 'Siguiente: --';
+
+  @override
+  String timerNextLabel(String name, int current, int total) {
+    return 'Siguiente: ${name} · Serie ${current}/${total}';
+  }
+
+  @override
+  String get amrapTimerTitle => 'Temporizador AMRAP';
+
+  @override
+  String get amrapTimerSubtitle => 'Completa tantas rondas como sea posible.';
+
+  @override
+  String get amrapTimerDescription =>
+      'Configura la duración total y controla el tiempo restante.';
+
+  @override
+  String get amrapDurationLabel => 'Duración (minutos)';
+
+  @override
+  String get amrapStartButton => 'Iniciar AMRAP';
+
+  @override
+  String get amrapResetButton => 'Reiniciar AMRAP';
+
+  @override
+  String get amrapTimeRemainingLabel => 'Tiempo restante';
+
+  @override
+  String get countdownTitle => 'Temporizador simple';
+
+  @override
+  String get countdownSubtitle => 'Un temporizador sencillo para cualquier intervalo.';
+
+  @override
+  String get countdownDescription =>
+      'Configura minutos y segundos, luego inicia el temporizador.';
+
+  @override
+  String get countdownMinutesLabel => 'Minutos';
+
+  @override
+  String get countdownSecondsLabel => 'Segundos';
+
+  @override
+  String get countdownStartButton => 'Iniciar temporizador';
+
+  @override
+  String get countdownResetButton => 'Detener temporizador';
+
+  @override
+  String weekNumber(int week) {
+    return 'Semana ${week}';
+  }
+
+  @override
+  String get defaultWorkoutTitle => 'Entrenamiento';
+
+  @override
+  String get terminologyTitle => 'Terminología';
+
+  @override
+  String get termRepsTitle => 'Repeticiones';
+
+  @override
+  String get termRepsDescription =>
+      'Número de veces que realizas un ejercicio consecutivamente.';
+
+  @override
+  String get termSetTitle => 'Serie';
+
+  @override
+  String get termSetDescription =>
+      'Un grupo de repeticiones. Por ejemplo: 3 series de 10 repeticiones significa 30 repeticiones totales divididas en 3 grupos.';
+
+  @override
+  String get termRtTitle => 'RT';
+
+  @override
+  String get termRtDescription =>
+      'Repeticiones totales: realiza todas las repeticiones con tus series, repeticiones y tempo preferidos (si no se especifica).';
+
+  @override
+  String get termAmrapTitle => 'AMRAP';
+
+  @override
+  String get termAmrapDescription =>
+      'As Many Reps As Possible: realiza tantas repeticiones como puedas en un tiempo determinado.';
+
+  @override
+  String get termEmomTitle => 'EMOM';
+
+  @override
+  String get termEmomDescription =>
+      'Every Minute on the Minute: inicia una serie cada minuto. Descansa durante el tiempo restante.';
+
+  @override
+  String get termRampingTitle => 'Ramping';
+
+  @override
+  String get termRampingDescription =>
+      'Método en el que la carga aumenta con cada serie.';
+
+  @override
+  String get termMavTitle => 'MAV';
+
+  @override
+  String get termMavDescription =>
+      'Massima Alzata Veloce: realiza tantas repeticiones como sea posible con una carga manteniendo el control y buena velocidad.';
+
+  @override
+  String get termIsocineticiTitle => 'Isocinético';
+
+  @override
+  String get termIsocineticiDescription =>
+      'Ejercicios realizados a velocidad constante.';
+
+  @override
+  String get termTutTitle => 'TUT';
+
+  @override
+  String get termTutDescription =>
+      'Indica cuánto debe durar una repetición. Puedes gestionar la duración de cada fase.';
+
+  @override
+  String get termIsoTitle => 'ISO';
+
+  @override
+  String get termIsoDescription =>
+      'Indica una pausa en un punto específico de la repetición.';
+
+  @override
+  String get termSomTitle => 'SOM';
+
+  @override
+  String get termSomDescription =>
+      'Indica la duración de cada fase de la repetición.';
+
+  @override
+  String get termScaricoTitle => 'Descarga';
+
+  @override
+  String get termScaricoDescription =>
+      'Última semana del programa para prepararte para intentos máximos.';
+}

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -761,6 +761,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get languageItalianLabel => 'Italiano';
 
   @override
+  String get languageSpanishLabel => 'Spagnolo';
+
+  @override
   String redirectError(Object error) {
     return 'Errore durante il reindirizzamento: $error';
   }

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -147,6 +147,7 @@ class _ProfilePageState extends State<ProfilePage> {
           final options = <(String?, String)>[
             (null, l10n.languageSystemLabel),
             ('en', l10n.languageEnglishLabel),
+            ('es', l10n.languageSpanishLabel),
             ('it', l10n.languageItalianLabel),
           ];
           final currentCode = controller.locale?.languageCode;
@@ -196,6 +197,8 @@ class _ProfilePageState extends State<ProfilePage> {
     switch (locale?.languageCode) {
       case 'en':
         return l10n.languageEnglishLabel;
+      case 'es':
+        return l10n.languageSpanishLabel;
       case 'it':
         return l10n.languageItalianLabel;
       default:


### PR DESCRIPTION
### Motivation
- Provide Spanish translations so the app can be used in Spanish-speaking locales and let users pick Spanish from the language settings.
- Ensure the localization system and UI language picker are aware of the new locale so runtime lookup and selection work correctly.

### Description
- Added a new Spanish ARB file `lib/l10n/app_es.arb` with translations for all app strings.
- Generated a Spanish localization class `lib/l10n/app_localizations_es.dart` and wired it into the lookup by importing it and returning `AppLocalizationsEs()` in `lib/l10n/app_localizations.dart`.
- Added `Locale('es')` to `AppLocalizations.supportedLocales` and updated the delegate `isSupported`/lookup logic to include `es`.
- Exposed `languageSpanishLabel` in the localization interface and added its implementations to `app_localizations_en.dart`, `app_localizations_it.dart`, and `app_localizations_es.dart`, and updated the profile language picker in `lib/pages/profile.dart` to include the `('es', l10n.languageSpanishLabel)` option and handle the current language label.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e57a77f908333b6697fdfc27d3f20)