### PR TITLE
Expand training exercises with coach notes, editable trainee notes, and resolved toggle

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -199,6 +199,20 @@
     }
   },
   "trainingExerciseCompletionUnavailable": "Cannot update this exercise.",
+  "trainingExerciseCoachNotesTitle": "Coach notes",
+  "trainingExerciseNoCoachNotes": "No coach notes for this exercise yet.",
+  "trainingExerciseYourNotesLabel": "Your notes",
+  "trainingExerciseSaveNotes": "Save notes",
+  "trainingExerciseResolvedLabel": "Mark as resolved",
+  "trainingExerciseNotesSaved": "Notes updated",
+  "trainingExerciseNotesError": "Unable to update notes: {error}",
+  "@trainingExerciseNotesError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
   "logoutError": "Error while logging out: {error}",
   "@logoutError": {
     "placeholders": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -199,6 +199,20 @@
     }
   },
   "trainingExerciseCompletionUnavailable": "No se puede actualizar este ejercicio.",
+  "trainingExerciseCoachNotesTitle": "Notas del entrenador",
+  "trainingExerciseNoCoachNotes": "Todavía no hay notas del entrenador para este ejercicio.",
+  "trainingExerciseYourNotesLabel": "Tus notas",
+  "trainingExerciseSaveNotes": "Guardar notas",
+  "trainingExerciseResolvedLabel": "Marcar como resuelto",
+  "trainingExerciseNotesSaved": "Notas actualizadas",
+  "trainingExerciseNotesError": "No se pudieron actualizar las notas: {error}",
+  "@trainingExerciseNotesError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
   "logoutError": "Error al cerrar sesión: {error}",
   "@logoutError": {
     "placeholders": {

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -199,6 +199,20 @@
     }
   },
   "trainingExerciseCompletionUnavailable": "Impossibile aggiornare questo esercizio.",
+  "trainingExerciseCoachNotesTitle": "Note del coach",
+  "trainingExerciseNoCoachNotes": "Non ci sono ancora note del coach per questo esercizio.",
+  "trainingExerciseYourNotesLabel": "Le tue note",
+  "trainingExerciseSaveNotes": "Salva note",
+  "trainingExerciseResolvedLabel": "Contrassegna come risolto",
+  "trainingExerciseNotesSaved": "Note aggiornate",
+  "trainingExerciseNotesError": "Impossibile aggiornare le note: {error}",
+  "@trainingExerciseNotesError": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
   "logoutError": "Errore durante il logout: {error}",
   "@logoutError": {
     "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -970,6 +970,48 @@ abstract class AppLocalizations {
   /// **'Impossibile aggiornare questo esercizio.'**
   String get trainingExerciseCompletionUnavailable;
 
+  /// No description provided for @trainingExerciseCoachNotesTitle.
+  ///
+  /// In it, this message translates to:
+  /// **'Note del coach'**
+  String get trainingExerciseCoachNotesTitle;
+
+  /// No description provided for @trainingExerciseNoCoachNotes.
+  ///
+  /// In it, this message translates to:
+  /// **'Non ci sono ancora note del coach per questo esercizio.'**
+  String get trainingExerciseNoCoachNotes;
+
+  /// No description provided for @trainingExerciseYourNotesLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Le tue note'**
+  String get trainingExerciseYourNotesLabel;
+
+  /// No description provided for @trainingExerciseSaveNotes.
+  ///
+  /// In it, this message translates to:
+  /// **'Salva note'**
+  String get trainingExerciseSaveNotes;
+
+  /// No description provided for @trainingExerciseResolvedLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Contrassegna come risolto'**
+  String get trainingExerciseResolvedLabel;
+
+  /// No description provided for @trainingExerciseNotesSaved.
+  ///
+  /// In it, this message translates to:
+  /// **'Note aggiornate'**
+  String get trainingExerciseNotesSaved;
+
+  /// No description provided for @trainingExerciseNotesError.
+  ///
+  /// In it, this message translates to:
+  /// **'Impossibile aggiornare le note: {error}'**
+  String trainingExerciseNotesError(Object error);
+
   /// No description provided for @logoutError.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -500,6 +500,30 @@ class AppLocalizationsEn extends AppLocalizations {
       'Cannot update this exercise.';
 
   @override
+  String get trainingExerciseCoachNotesTitle => 'Coach notes';
+
+  @override
+  String get trainingExerciseNoCoachNotes =>
+      'No coach notes for this exercise yet.';
+
+  @override
+  String get trainingExerciseYourNotesLabel => 'Your notes';
+
+  @override
+  String get trainingExerciseSaveNotes => 'Save notes';
+
+  @override
+  String get trainingExerciseResolvedLabel => 'Mark as resolved';
+
+  @override
+  String get trainingExerciseNotesSaved => 'Notes updated';
+
+  @override
+  String trainingExerciseNotesError(Object error) {
+    return 'Unable to update notes: $error';
+  }
+
+  @override
   String logoutError(Object error) {
     return 'Error while logging out: $error';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -500,6 +500,30 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se puede actualizar este ejercicio.';
 
   @override
+  String get trainingExerciseCoachNotesTitle => 'Notas del entrenador';
+
+  @override
+  String get trainingExerciseNoCoachNotes =>
+      'Todavía no hay notas del entrenador para este ejercicio.';
+
+  @override
+  String get trainingExerciseYourNotesLabel => 'Tus notas';
+
+  @override
+  String get trainingExerciseSaveNotes => 'Guardar notas';
+
+  @override
+  String get trainingExerciseResolvedLabel => 'Marcar como resuelto';
+
+  @override
+  String get trainingExerciseNotesSaved => 'Notas actualizadas';
+
+  @override
+  String trainingExerciseNotesError(Object error) {
+    return 'No se pudieron actualizar las notas: ${error}';
+  }
+
+  @override
   String logoutError(Object error) {
     return 'Error al cerrar sesión: ${error}';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -505,6 +505,30 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile aggiornare questo esercizio.';
 
   @override
+  String get trainingExerciseCoachNotesTitle => 'Note del coach';
+
+  @override
+  String get trainingExerciseNoCoachNotes =>
+      'Non ci sono ancora note del coach per questo esercizio.';
+
+  @override
+  String get trainingExerciseYourNotesLabel => 'Le tue note';
+
+  @override
+  String get trainingExerciseSaveNotes => 'Salva note';
+
+  @override
+  String get trainingExerciseResolvedLabel => 'Contrassegna come risolto';
+
+  @override
+  String get trainingExerciseNotesSaved => 'Note aggiornate';
+
+  @override
+  String trainingExerciseNotesError(Object error) {
+    return 'Impossibile aggiornare le note: $error';
+  }
+
+  @override
   String logoutError(Object error) {
     return 'Errore durante il logout: $error';
   }


### PR DESCRIPTION
### Motivation
- Enable tapping an exercise to expand a detailed view that shows the coach's notes, allows the trainee to add/edit their own notes, and mark the exercise as resolved. 

### Description
- Add expand/collapse state and per-exercise `TextEditingController`s to `Training` and persist trainee notes to Supabase by updating `day_exercises.trainee_notes`, implemented in `lib/pages/training.dart` via `_expandedExercises`, `_noteControllers`, `_saveExerciseNotes`, and `_toggleExpanded`.
- Replace the single-tap completion behavior UI with an expandable `_ExerciseCard` that shows coach notes, a `TextField` for trainee notes, a `Save notes` button with loading state, and a resolved `CheckboxListTile` to toggle completion; the UI text uses new localization keys.
- Add localized strings for the new UI texts in `lib/l10n/app_en.arb`, `lib/l10n/app_es.arb`, and `lib/l10n/app_it.arb`, and update the generated localization files (`lib/l10n/app_localizations*.dart`).
- Ensure `TextEditingController`s are disposed in `dispose()` and preserve existing completion toggling logic (`_toggleExerciseCompletion`) while reusing it from the expanded card.

### Testing
- No automated tests were run on this change.
- Static/manual validation: code changes were implemented and localized strings were added, but no build or runtime verification was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6ead53e4833382644fba72748a96)