### PR TITLE
Show only latest workout plan days in admin training calendar

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -460,7 +460,15 @@ import {
 
       const trainingCalendar = computed(() => {
         const order = new Map(dayCodeOptions.map((code, idx) => [code, idx]));
-        return (days.value || [])
+        const latestPlanId = plans.value?.[0]?.id;
+        const filteredDays = latestPlanId
+          ? (days.value || []).filter((day) =>
+              (day.workout_plan_days || []).some(
+                (entry) => entry.workout_plans?.id === latestPlanId,
+              ),
+            )
+          : days.value || [];
+        return filteredDays
           .map((day) => {
             const exercises = day.day_exercises || [];
             const completedCount = exercises.filter((ex) => ex.completed).length;


### PR DESCRIPTION
### Motivation
- Limit the program training calendar to days that belong to the latest workout plan so the admin view only shows the most recent plan's trainings.

### Description
- In `backend/admin/app.js` updated the `trainingCalendar` computed to derive `latestPlanId = plans.value?.[0]?.id` and filter `days.value` to only include days whose `workout_plan_days` reference `workout_plans.id === latestPlanId` before mapping and sorting the entries.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e6f885f7483338bb47824797c1bf2)