### PR TITLE
Update profile language picker to use RadioGroup

### DIFF
--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -168,20 +168,22 @@ class _ProfilePageState extends State<ProfilePage> {
                   const SizedBox(height: 12),
                   Card(
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                    child: Column(
-                      children: [
-                        for (final option in options)
-                          RadioListTile<String?>(
-                            value: option.$1,
-                            groupValue: currentCode,
-                            title: Text(option.$2),
-                            onChanged: (value) {
-                              controller.setLocale(
-                                value == null ? null : Locale(value),
-                              );
-                            },
-                          ),
-                      ],
+                    child: RadioGroup<String?>(
+                      groupValue: currentCode,
+                      onChanged: (value) {
+                        controller.setLocale(
+                          value == null ? null : Locale(value),
+                        );
+                      },
+                      child: Column(
+                        children: [
+                          for (final option in options)
+                            RadioListTile<String?>(
+                              value: option.$1,
+                              title: Text(option.$2),
+                            ),
+                        ],
+                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
### Motivation
- Replace deprecated `groupValue`/`onChanged` usage on `RadioListTile` (deprecated after v3.32.0) by delegating selection handling to a `RadioGroup` while preserving the existing `controller.setLocale` behavior.

### Description
- Wrap language options in a `RadioGroup<String?>` in `lib/pages/profile.dart`, move `groupValue` and `onChanged` into the `RadioGroup`, and remove per-tile `groupValue`/`onChanged` handlers so each `RadioListTile` only provides `value` and `title`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e776004c48333be1788eb4ef994b8)