### PR TITLE
Add per-exercise duration (`duration_minutes`) to day_exercises and surface in UI

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -203,6 +203,10 @@ import {
               exercise: prevSlot.exercise || '',
               sets: prevSlot.sets || '',
               notes: prevSlot.notes || '',
+              duration_minutes:
+                prevSlot.duration_minutes === undefined
+                  ? null
+                  : prevSlot.duration_minutes,
             });
           }
           list.push({
@@ -245,7 +249,7 @@ import {
             .select(
               `
                 id, week, day_code, title,
-                day_exercises ( id, position, notes, exercise ),
+                day_exercises ( id, position, notes, exercise, duration_minutes ),
                 workout_plan_days!inner ( plan_id, position )
               `,
             )
@@ -302,6 +306,10 @@ import {
                 ...slots[index],
                 exercise: exercise.exercise || '',
                 notes: exercise.notes || '',
+                duration_minutes:
+                  exercise.duration_minutes === undefined
+                    ? null
+                    : exercise.duration_minutes,
               };
             });
             entry.slots = slots;
@@ -1057,6 +1065,10 @@ import {
                 notes: (slot.notes || '').trim() || null,
                 completed: false,
                 exercise,
+                duration_minutes:
+                  slot.duration_minutes === undefined
+                    ? null
+                    : slot.duration_minutes,
               });
             });
           });
@@ -1088,7 +1100,7 @@ import {
         if (!exerciseSelection.value[dayId]) {
           exerciseSelection.value = {
             ...exerciseSelection.value,
-            [dayId]: { exercise: '', notes: '' },
+            [dayId]: { exercise: '', notes: '', duration_minutes: null },
           };
           return;
         }
@@ -1137,6 +1149,10 @@ import {
           [exercise.id]: {
             position: exercise.position ?? 1,
             notes: exercise.notes || '',
+            duration_minutes:
+              exercise.duration_minutes === undefined
+                ? null
+                : exercise.duration_minutes,
           },
         };
       }
@@ -2011,7 +2027,7 @@ import {
           let query = supabase
             .from('day_exercises')
             .select(
-              'id, completed, days!inner ( workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
+              'id, completed, duration_minutes, days!inner ( workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
             );
           if (trainerOnly) {
             query = query.in(
@@ -2088,7 +2104,7 @@ import {
           let completedQuery = supabase
             .from('day_exercises')
             .select(
-              'id, completed, days!inner ( week, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
+              'id, completed, duration_minutes, days!inner ( week, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
             )
             .eq('completed', true);
           if (trainerOnly) {
@@ -2217,7 +2233,7 @@ import {
                   workout_plans ( id, title, starts_on, created_at )
                 ),
                 day_exercises (
-                  id, position, notes, completed, exercise
+                  id, position, notes, completed, exercise, duration_minutes
                 )
               `)
           .eq('workout_plan_days.workout_plans.trainee_id', u.id)
@@ -2272,7 +2288,7 @@ import {
           const { data, error } = await supabase
             .from('day_exercises')
             .select(
-              'id, exercise, notes, trainee_notes, completed, days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
+              'id, exercise, notes, trainee_notes, completed, duration_minutes, days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
             )
             .eq('completed', true)
             .eq('days.workout_plan_days.workout_plans.trainee_id', u.id);
@@ -2470,7 +2486,7 @@ import {
           const { data: exerciseRows, error: exerciseError } = await supabase
             .from('day_exercises')
             .select(
-              'id, completed, days!inner ( completed_at, workout_plan_days!inner ( plan_id ) )',
+              'id, completed, duration_minutes, days!inner ( completed_at, workout_plan_days!inner ( plan_id ) )',
             )
             .in('days.workout_plan_days.plan_id', planIds);
           if (exerciseError) {
@@ -2766,13 +2782,17 @@ import {
             exercise,
             notes: (selection.notes || '').trim() || null,
             position: nextPosition,
+            duration_minutes:
+              selection?.duration_minutes === undefined
+                ? null
+                : selection.duration_minutes,
           });
           if (error) {
             throw new Error('Add exercise failed: ' + error.message);
           }
           exerciseSelection.value = {
             ...exerciseSelection.value,
-            [day.id]: { exercise: '', notes: '' },
+            [day.id]: { exercise: '', notes: '', duration_minutes: null },
           };
           await loadDays();
         } catch (err) {
@@ -2833,6 +2853,10 @@ import {
         const payload = {
           position: Number(form.position || 1),
           notes: (form.notes || '').trim() || null,
+          duration_minutes:
+            form.duration_minutes === undefined || form.duration_minutes === ''
+              ? null
+              : Number(form.duration_minutes),
         };
         const { error } = await supabase
           .from('day_exercises')

--- a/db/database.sql
+++ b/db/database.sql
@@ -47,6 +47,7 @@ CREATE TABLE public.day_exercises (
   exercise_id uuid NOT NULL,
   exercise text NOT NULL,
   position integer NOT NULL DEFAULT 1,
+  duration_minutes integer,
   notes text,
   trainee_notes text,
   completed boolean,

--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -9,6 +9,7 @@ class WorkoutExercise {
   final List<String> terminology;
   final List<String> skills;
   final int? position;
+  final int? durationMinutes;
   final bool isCompleted;
 
   const WorkoutExercise({
@@ -19,6 +20,7 @@ class WorkoutExercise {
     this.terminology = const [],
     this.skills = const [],
     this.position,
+    this.durationMinutes,
     this.isCompleted = false,
   });
 }

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -264,6 +264,7 @@ class _TrainingState extends State<Training> {
           notes: exercise.notes,
           traineeNotes: exercise.traineeNotes,
           position: exercise.position,
+          durationMinutes: exercise.durationMinutes,
           terminology: exercise.terminology,
           skills: exercise.skills,
           isCompleted: newValue,
@@ -325,6 +326,7 @@ class _TrainingState extends State<Training> {
           notes: exercise.notes,
           traineeNotes: newNotes,
           position: exercise.position,
+          durationMinutes: exercise.durationMinutes,
           terminology: exercise.terminology,
           skills: exercise.skills,
           isCompleted: exercise.isCompleted,
@@ -764,11 +766,22 @@ String _exerciseDetailText(
   WorkoutExercise exercise,
   AppLocalizations l10n,
 ) {
+  final duration = exercise.durationMinutes;
+  final durationLabel = duration != null && duration > 0
+      ? l10n.trainingDurationMinutes(duration)
+      : null;
   final notes = (exercise.notes ?? '').trim();
-  if (notes.isNotEmpty) return notes;
+  if (notes.isNotEmpty) {
+    return durationLabel == null ? notes : '$durationLabel · $notes';
+  }
 
   final traineeNotes = (exercise.traineeNotes ?? '').trim();
-  if (traineeNotes.isNotEmpty) return traineeNotes;
+  if (traineeNotes.isNotEmpty) {
+    return durationLabel == null
+        ? traineeNotes
+        : '$durationLabel · $traineeNotes';
+  }
 
-  return '${l10n.trainingHeaderSets} · ${l10n.trainingHeaderReps}';
+  final fallback = '${l10n.trainingHeaderSets} · ${l10n.trainingHeaderReps}';
+  return durationLabel == null ? fallback : '$durationLabel · $fallback';
 }

--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -120,7 +120,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         .select(
           'id, week, day_code, title, notes, completed, completed_at, '
           'workout_plan_days!inner ( position, workout_plans!inner ( id, title, starts_on, created_at ) ), '
-          'day_exercises ( id, position, notes, completed, trainee_notes, exercise)',
+          'day_exercises ( id, position, notes, completed, trainee_notes, exercise, duration_minutes)',
         )
         .eq('workout_plan_days.workout_plans.trainee_id', userId)
         .order('week', ascending: true)
@@ -191,6 +191,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
           id: exercise['id'] as String?,
           name: name,
           position: (exercise['position'] as num?)?.toInt(),
+          durationMinutes: (exercise['duration_minutes'] as num?)?.toInt(),
           notes: exercise['notes'] as String?,
           traineeNotes: exercise['trainee_notes'] as String?,
           terminology: terminology,


### PR DESCRIPTION
### Motivation
- Provide a per-exercise duration so plans can record and show minutes for each `day_exercises` entry. 

### Description
- Add a nullable `duration_minutes` column to the DB schema in `db/database.sql`.
- Wire `duration_minutes` through the admin UI in `backend/admin/app.js` by including it in Supabase `select` calls, template payloads, selection objects, inserts, and updates.
- Add a `durationMinutes` field to `WorkoutExercise` in `lib/model/workout_day.dart` and populate it when loading plans in `lib/pages/workout_plan_page.dart` by including `duration_minutes` in the Supabase select and mapping it into `WorkoutExercise`.
- Persist and preserve the duration in `lib/pages/training.dart` during completion and notes updates, and surface the duration in the exercise detail text so users see minutes per exercise.

### Testing
- No automated unit or integration tests were executed as part of this change; a quick environment check attempted to run `flutter --version` but the `flutter` binary was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e7764522c8333a661256665baeb40)