### PR TITLE
Link day exercises to exercise guides and ids

### DIFF
--- a/lib/components/exercise_guide_card.dart
+++ b/lib/components/exercise_guide_card.dart
@@ -9,11 +9,13 @@ class ExerciseGuideCard extends StatelessWidget {
     required this.guide,
     required this.l10n,
     this.onUnlock,
+    this.isHighlighted = false,
   });
 
   final ExerciseGuide guide;
   final AppLocalizations l10n;
   final VoidCallback? onUnlock;
+  final bool isHighlighted;
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +35,12 @@ class ExerciseGuideCard extends StatelessWidget {
       color: isUnlocked
           ? colorScheme.surface
           : colorScheme.surfaceContainerHighest.withValues(alpha: 0.55),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: isHighlighted
+            ? BorderSide(color: colorScheme.primary, width: 2)
+            : BorderSide.none,
+      ),
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/model/workout_day.dart
+++ b/lib/model/workout_day.dart
@@ -3,6 +3,8 @@ import '../l10n/app_localizations.dart';
 
 class WorkoutExercise {
   final String? id;
+  final String? exerciseId;
+  final String? exerciseSlug;
   final String? name;
   final String? notes;
   final String? traineeNotes;
@@ -15,6 +17,8 @@ class WorkoutExercise {
   const WorkoutExercise({
     this.name,
     this.id,
+    this.exerciseId,
+    this.exerciseSlug,
     this.notes,
     this.traineeNotes,
     this.terminology = const [],

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -8,6 +8,7 @@ import '../data/exercise_translations.dart';
 import '../data/terminology_translations.dart';
 import '../l10n/app_localizations.dart';
 import 'terminology.dart';
+import 'exercise_guides.dart';
 
 class Training extends StatefulWidget {
   final WorkoutDay day;
@@ -170,6 +171,11 @@ class _TrainingState extends State<Training> {
                     notesController:
                         _notesControllerFor(_exercises[index], index),
                     terminologyTranslations: terminologyLookup,
+                    onOpenGuide:
+                        _exercises[index].exerciseSlug != null ||
+                                _exercises[index].exerciseId != null
+                            ? () => _openExerciseGuide(_exercises[index])
+                            : null,
                     onToggleCompletion: () => _toggleExerciseCompletion(index),
                     onToggleExpanded: () => _toggleExpanded(index),
                     onSaveNotes: () => _saveExerciseNotes(index),
@@ -265,6 +271,8 @@ class _TrainingState extends State<Training> {
       setState(() {
         _exercises[index] = WorkoutExercise(
           id: exercise.id,
+          exerciseId: exercise.exerciseId,
+          exerciseSlug: exercise.exerciseSlug,
           name: exercise.name,
           notes: exercise.notes,
           traineeNotes: exercise.traineeNotes,
@@ -327,6 +335,8 @@ class _TrainingState extends State<Training> {
       setState(() {
         _exercises[index] = WorkoutExercise(
           id: exercise.id,
+          exerciseId: exercise.exerciseId,
+          exerciseSlug: exercise.exerciseSlug,
           name: exercise.name,
           notes: exercise.notes,
           traineeNotes: newNotes,
@@ -415,6 +425,17 @@ class _TrainingState extends State<Training> {
     });
   }
 
+  void _openExerciseGuide(WorkoutExercise exercise) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => ExerciseGuidesPage(
+          initialGuideSlug: exercise.exerciseSlug,
+          initialGuideId: exercise.exerciseId,
+        ),
+      ),
+    );
+  }
+
   int _exerciseOrderValue(WorkoutExercise exercise) {
     if (exercise.position != null) return exercise.position!;
 
@@ -477,6 +498,7 @@ class _ExerciseCard extends StatelessWidget {
   final bool isSavingNotes;
   final TextEditingController notesController;
   final Map<String, TerminologyTranslation> terminologyTranslations;
+  final VoidCallback? onOpenGuide;
   final VoidCallback onToggleCompletion;
   final VoidCallback onToggleExpanded;
   final VoidCallback onSaveNotes;
@@ -490,6 +512,7 @@ class _ExerciseCard extends StatelessWidget {
     required this.isSavingNotes,
     required this.notesController,
     required this.terminologyTranslations,
+    this.onOpenGuide,
     required this.onToggleCompletion,
     required this.onToggleExpanded,
     required this.onSaveNotes,
@@ -626,12 +649,24 @@ class _ExerciseCard extends StatelessWidget {
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
                     else
-                      Icon(
-                        isExpanded
-                            ? Icons.expand_less
-                            : Icons.expand_more,
-                        color: colorScheme.onSurfaceVariant
-                            .withValues(alpha: 0.6),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (onOpenGuide != null)
+                            IconButton(
+                              tooltip: l10n.guidesTitle,
+                              icon: const Icon(Icons.menu_book),
+                              color: colorScheme.primary,
+                              onPressed: onOpenGuide,
+                            ),
+                          Icon(
+                            isExpanded
+                                ? Icons.expand_less
+                                : Icons.expand_more,
+                            color: colorScheme.onSurfaceVariant
+                                .withValues(alpha: 0.6),
+                          ),
+                        ],
                       ),
                   ],
                 ),

--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -120,7 +120,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         .select(
           'id, week, day_code, title, notes, completed, completed_at, '
           'workout_plan_days!inner ( position, workout_plans!inner ( id, title, starts_on, created_at ) ), '
-          'day_exercises ( id, position, notes, completed, trainee_notes, exercise, duration_minutes)',
+          'day_exercises ( id, position, notes, completed, trainee_notes, exercise, exercise_id, exercises ( id, slug, name ), duration_minutes)',
         )
         .eq('workout_plan_days.workout_plans.trainee_id', userId)
         .order('week', ascending: true)
@@ -178,7 +178,10 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         final exerciseValue = exercise['exercise'];
         final exerciseMap =
             exerciseValue is Map ? exerciseValue.cast<String, dynamic>() : null;
-        final name = exerciseMap?['name'] as String? ??
+        final linkedExercise =
+            (exercise['exercises'] as Map?)?.cast<String, dynamic>();
+        final name = linkedExercise?['name'] as String? ??
+            exerciseMap?['name'] as String? ??
             exerciseValue as String?;
         final terminology = parseStringList(
           exercise['terminology'] ?? exerciseMap?['terminology'],
@@ -189,6 +192,11 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
 
         return WorkoutExercise(
           id: exercise['id'] as String?,
+          exerciseId: exercise['exercise_id'] as String? ??
+              linkedExercise?['id'] as String? ??
+              exerciseMap?['id'] as String?,
+          exerciseSlug: linkedExercise?['slug'] as String? ??
+              exerciseMap?['slug'] as String?,
           name: name,
           position: (exercise['position'] as num?)?.toInt(),
           durationMinutes: (exercise['duration_minutes'] as num?)?.toInt(),


### PR DESCRIPTION
### Motivation
- Ensure day exercises expose their linked exercise records (id/slug/name) so the app can navigate to exercise guides and maintain strong associations instead of free-text names.
- Persist exercise associations from the admin UI when creating/updating day exercises and when importing template plans to avoid losing canonical references.
- Provide a UX path from training cards into the exercise guides and allow the guides list to auto-scroll and highlight a target guide.

### Description
- Updated Supabase selects to include linked exercise data and `exercise_id` in `lib/pages/workout_plan_page.dart` and `backend/admin/app.js` so `day_exercises` returns `exercise_id` and `exercises ( id, slug, name )`.
- Extended `WorkoutExercise` in `lib/model/workout_day.dart` with `exerciseId` and `exerciseSlug`, and populated those fields when loading days in `workout_plan_page.dart`.
- Added guide navigation from training cards in `lib/pages/training.dart` with a new `onOpenGuide` action and `_openExerciseGuide` that pushes `ExerciseGuidesPage` with `initialGuideSlug`/`initialGuideId`.
- Enhanced `lib/pages/exercise_guides.dart` to accept optional `initialGuideSlug`/`initialGuideId`, auto-select the difficulty, scroll to and visually highlight the target guide using a `ScrollController`, per-guide `GlobalKey`s, and an `isHighlighted` prop on `ExerciseGuideCard`.
- In `backend/admin/app.js` implemented `resolveExerciseReference` to map free-text or slug/id to a canonical exercise, used it when inserting/updating `day_exercises` and when generating template-plan exercises, and updated day loading to include the joined `exercises` record.
- Added validation to surface unresolved exercises during template imports and ensured updated payloads include `exercise_id` when available.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e77763b7883339d7ec786c0aa2ecf)