### PR TITLE
Fix trainee feedback initial load localization access

### DIFF
--- a/lib/pages/trainee_feedback.dart
+++ b/lib/pages/trainee_feedback.dart
@@ -17,10 +17,18 @@ class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
   bool _isLoadingFeedbacks = false;
   String? _feedbacksError;
   List<_FeedbackEntry> _feedbacks = [];
+  bool _didLoadFeedbacks = false;
 
   @override
   void initState() {
     super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_didLoadFeedbacks) return;
+    _didLoadFeedbacks = true;
     _loadFeedbacks();
   }
 


### PR DESCRIPTION
### Motivation
- The page was calling `AppLocalizations.of(context)` indirectly during `initState`, causing a depend-on-inherited-widget error when opening Trainee Feedback; the load must occur after dependencies are available.

### Description
- Removed the `_loadFeedbacks()` call from `initState` and added a `didChangeDependencies` override that calls `_loadFeedbacks()` once guarded by a `bool _didLoadFeedbacks` flag in `lib/pages/trainee_feedback.dart`.

### Testing
- No automated tests were run for this change; the patch is small and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e7ca7e4f083338677358cca3e3ba3)