### PR TITLE
Fix null-safety and async BuildContext warnings

### DIFF
--- a/lib/pages/exercise_guides.dart
+++ b/lib/pages/exercise_guides.dart
@@ -69,17 +69,18 @@ class _ExerciseGuidesPageState extends State<ExerciseGuidesPage> {
       }
     }
     if (matched == null) return;
-    if (_selectedDifficulty != matched.difficulty ||
-        _highlightedGuideId != matched.id) {
+    final matchedGuide = matched;
+    if (_selectedDifficulty != matchedGuide.difficulty ||
+        _highlightedGuideId != matchedGuide.id) {
       setState(() {
-        _selectedDifficulty = matched.difficulty;
-        _highlightedGuideId = matched.id;
+        _selectedDifficulty = matchedGuide.difficulty;
+        _highlightedGuideId = matchedGuide.id;
       });
     } else {
-      _highlightedGuideId = matched.id;
+      _highlightedGuideId = matchedGuide.id;
     }
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _scrollToGuide(matched.id);
+      _scrollToGuide(matchedGuide.id);
     });
   }
 

--- a/lib/pages/trainee_feedback.dart
+++ b/lib/pages/trainee_feedback.dart
@@ -146,6 +146,7 @@ class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
       if (!mounted) return;
       _feedbackController.clear();
       await _loadFeedbacks();
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.traineeFeedbackSubmitted)),
       );
@@ -155,10 +156,11 @@ class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
         SnackBar(content: Text(l10n.unexpectedError('$error'))),
       );
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isSubmitting = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
     }
   }
 
@@ -205,10 +207,11 @@ class _TraineeFeedbackPageState extends State<TraineeFeedbackPage> {
         _feedbacksError = l10n.traineeFeedbackLoadFailed;
       });
     } finally {
-      if (!mounted) return;
-      setState(() {
-        _isLoadingFeedbacks = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoadingFeedbacks = false;
+        });
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Resolve analyzer errors where nullable properties (`difficulty`, `id`) were accessed without null checks. 
- Prevent unsafe use of `BuildContext` after `await` points to avoid `use_build_context_synchronously` warnings. 
- Remove problematic `return` usage in `finally` and ensure `setState` is only called when the widget is still mounted. 

### Description
- Promote the locally matched guide to a non-null `final matchedGuide` variable and use it throughout `_handleInitialGuide` to avoid nullable access. 
- Use `matchedGuide.id` when calling `_scrollToGuide` and when updating `_highlightedGuideId` and `_selectedDifficulty`. 
- After awaiting `_loadFeedbacks()` in `_submitFeedback`, guard subsequent `ScaffoldMessenger` usage with a `mounted` check. 
- Replace early `return` in `finally` blocks with `if (mounted) { setState(...) }` guards in `_submitFeedback` and `_loadFeedbacks` to avoid control-flow-in-finally and unsafe `setState` calls. 
- Modified files: `lib/pages/exercise_guides.dart` and `lib/pages/trainee_feedback.dart`. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e7f2deee883338bd69dbd72f38976)