### PR TITLE
Fix completed exercise load query join

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -2318,7 +2318,7 @@ import {
           const { data, error } = await supabase
             .from('day_exercises')
             .select(
-              'id, exercise, exercise_id, notes, trainee_notes, completed, duration_minutes, exercises ( id, slug, name ), days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
+              'id, exercise, exercise_id, notes, trainee_notes, completed, duration_minutes, days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
             )
             .eq('completed', true)
             .eq('days.workout_plan_days.workout_plans.trainee_id', u.id);


### PR DESCRIPTION
### Motivation
- Prevent a schema cache error when loading completed exercises by removing a reference to a relationship that isn't present in the cached schema.

### Description
- Removed `exercises ( id, slug, name )` from the `select` call in `loadCompletedExercises` inside `backend/admin/app.js` so the completed-exercises query no longer attempts the problematic join.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e81b0e4c083338dd8189362ccc38b)