### PR TITLE
Mark admin feedback as read when dismissed

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -141,7 +141,10 @@
                         <div v-for="note in dashboardNotes" :key="note.id" class="chat-item">
                             <div class="chat-meta">
                                 <strong>{{ note.traineeName }}</strong>
-                                <span class="pill">{{ note.statusLabel }}</span>
+                                <div class="chat-meta-actions">
+                                    <span class="pill">{{ note.statusLabel }}</span>
+                                    <button class="icon-button" type="button" @click="closeDashboardNote(note)" :disabled="dashboardNoteClosing[note.id]" :aria-label="t('actions.closeFeedback')" :title="t('actions.closeFeedback')">×</button>
+                                </div>
                             </div>
                             <div class="muted small" v-if="note.dateLabel">{{ note.dateLabel }}</div>
                             <div class="chat-message">{{ note.message }}</div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -61,6 +61,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .chat-list{display:flex;flex-direction:column;gap:10px;margin-top:12px}
 .chat-item{background:#f8fafc;border:1px solid var(--line);border-radius:12px;padding:10px}
 .chat-meta{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap}
+.chat-meta-actions{display:flex;align-items:center;gap:6px}
 .chat-message{white-space:pre-wrap;margin-top:6px}
 .dashboard-trainee-list{display:flex;flex-direction:column;gap:10px;margin-top:12px;max-height:520px}
 .dashboard-trainee-item{display:flex;align-items:center;justify-content:space-between;gap:12px;border:1px solid var(--line);border-radius:12px;padding:10px;background:#f8fafc}

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -45,6 +45,7 @@ export const translations = {
       loadPlans: 'Load plans',
       collapse: 'Collapse',
       expand: 'Expand',
+      closeFeedback: 'Close feedback',
     },
     labels: {
       totalCount: '{count} total',
@@ -331,6 +332,7 @@ export const translations = {
       loadMaxTestsWithMessage: 'Failed to load max tests: {message}',
       updateCoachTip: 'Failed to update coach tip.',
       updateTrainerNotes: 'Failed to update trainer notes.',
+      updateFeedback: 'Failed to update feedback.',
       trainerNotesUnavailable:
         'Trainer notes are only available for trainer accounts.',
       loadCompletedExercises: 'Failed to load completed exercises.',
@@ -405,6 +407,7 @@ export const translations = {
       loadPlans: 'Carica piani',
       collapse: 'Comprimi',
       expand: 'Espandi',
+      closeFeedback: 'Chiudi feedback',
     },
     labels: {
       totalCount: '{count} totali',
@@ -692,6 +695,7 @@ export const translations = {
       loadMaxTestsWithMessage: 'Impossibile caricare i test massimali: {message}',
       updateCoachTip: 'Impossibile aggiornare il consiglio del coach.',
       updateTrainerNotes: 'Impossibile aggiornare le note del coach.',
+      updateFeedback: 'Impossibile aggiornare il feedback.',
       trainerNotesUnavailable:
         'Le note del coach sono disponibili solo per gli account trainer.',
       loadCompletedExercises: 'Impossibile caricare gli esercizi completati.',


### PR DESCRIPTION
### Motivation
- Let admins mark trainee feedback as read simply by dismissing/closing the dashboard note so it doesn't keep reappearing, using the existing `trainee_feedbacks` table.

### Description
- Add a per-item closing state `dashboardNoteClosing` and a `closeDashboardNote(note)` function in `backend/admin/app.js` which updates `read_at` via Supabase and removes the note from `dashboardNotes` on success, with error handling and double-submit prevention.
- Expose `dashboardNoteClosing` and `closeDashboardNote` in the app's returned API so the template can bind to them.
- Add a close button to each feedback item in `backend/admin/index.html` and a layout helper `.chat-meta-actions` in `backend/admin/styles.css` to position the button alongside the status pill.
- Add translation strings `actions.closeFeedback` and `errors.updateFeedback` (English and Italian) to `backend/admin/translations.js`.

### Testing
- Attempted to render the admin UI and capture a screenshot with Playwright, but the browser process crashed with a SIGSEGV so no screenshot was produced and the UI run failed.
- No automated unit or integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e834713c08333a581f83f644ab008)