### PR TITLE
Fix exercise name population in program section

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -302,8 +302,7 @@ import {
               .sort((a, b) => (a.position || 0) - (b.position || 0));
             exercises.forEach((exercise, index) => {
               if (!slots[index]) return;
-              const exerciseName =
-                exercise.exercises?.name || exercise.exercise || '';
+              const exerciseName = resolveExerciseName(exercise);
               slots[index] = {
                 ...slots[index],
                 exercise: exerciseName,
@@ -671,8 +670,7 @@ import {
             const traineeNotes = (entry.trainee_notes || '').trim();
             return {
               id: entry.id,
-              exercise:
-                (entry.exercise || '').trim() || t('labels.unknownExercise'),
+              exercise: resolveExerciseName(entry) || t('labels.unknownExercise'),
               dayLabel,
               timeLabel: completedAt ? formatTime(completedAt) : '',
               notes,
@@ -852,6 +850,29 @@ import {
         const numeric = Number(value);
         if (Number.isNaN(numeric)) return null;
         return numeric;
+      };
+
+      const exerciseNameLookup = computed(() => {
+        const map = new Map();
+        (exercises.value || []).forEach((exercise) => {
+          if (!exercise?.id) return;
+          const name = (exercise.name || exercise.slug || '').trim();
+          if (name) {
+            map.set(exercise.id, name);
+          }
+        });
+        return map;
+      });
+
+      const resolveExerciseName = (entry) => {
+        if (!entry) return '';
+        const relationName = (entry.exercises?.name || '').trim();
+        if (relationName) return relationName;
+        const lookupName = entry.exercise_id
+          ? exerciseNameLookup.value.get(entry.exercise_id)
+          : '';
+        if (lookupName) return lookupName;
+        return (entry.exercise || '').trim();
       };
 
       const templateDayLabel = (index) => {
@@ -2318,7 +2339,7 @@ import {
           const { data, error } = await supabase
             .from('day_exercises')
             .select(
-              'id, exercise, exercise_id, notes, trainee_notes, completed, duration_minutes, days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
+              'id, exercise, exercise_id, notes, trainee_notes, completed, duration_minutes, exercises ( id, slug, name ), days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
             )
             .eq('completed', true)
             .eq('days.workout_plan_days.workout_plans.trainee_id', u.id);


### PR DESCRIPTION
### Motivation
- Program templates and the completed-exercises log could show empty or inconsistent exercise labels when an entry referenced an `exercise_id` instead of embedding the name, so the UI needs a reliable way to resolve names from related records or fallbacks.

### Description
- Add a computed `exerciseNameLookup` map that indexes loaded `exercises` by `id` for fast name lookup.
- Add a `resolveExerciseName(entry)` helper that returns the related `exercises.name`, falls back to the `exercise_id` lookup, and finally to the stored `exercise` text.
- Use `resolveExerciseName` when populating program template slots so each slot shows the resolved exercise name via `exercise_id` when present.
- Expand the completed-exercises query to include the `exercises ( id, slug, name )` relation and use `resolveExerciseName` for items shown in `completedExerciseLog`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8480f6a08333b44f3434405d7f57)