### PR TITLE
Add exercise reference to day_exercises schema

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -13,13 +13,15 @@ CREATE TABLE public.day_exercises (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   day_id uuid NOT NULL,
   exercise text NOT NULL,
+  exercise_id uuid,
   position integer NOT NULL DEFAULT 1,
   notes text,
   trainee_notes text,
   completed boolean,
   duration_minutes numeric DEFAULT '0'::numeric,
   CONSTRAINT day_exercises_pkey PRIMARY KEY (id),
-  CONSTRAINT day_exercises_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.days(id)
+  CONSTRAINT day_exercises_day_id_fkey FOREIGN KEY (day_id) REFERENCES public.days(id),
+  CONSTRAINT day_exercises_exercise_id_fkey FOREIGN KEY (exercise_id) REFERENCES public.exercises(id)
 );
 CREATE TABLE public.days (
   id uuid NOT NULL DEFAULT gen_random_uuid(),


### PR DESCRIPTION
### Motivation
- Add `exercise_id` to `day_exercises` so the reference schema matches the admin frontend queries that expect a link to `exercises.id`.

### Description
- Modify `db/database.sql` to add an `exercise_id uuid` column and `CONSTRAINT day_exercises_exercise_id_fkey FOREIGN KEY (exercise_id) REFERENCES public.exercises(id)` on `public.day_exercises`.

### Testing
- No automated tests were run because this is a schema-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8ab36e3c8333a7fb5001fdfdb1fe)