### PR TITLE
Align workout day exercise query with schema

### DIFF
--- a/lib/pages/workout_plan_page.dart
+++ b/lib/pages/workout_plan_page.dart
@@ -120,7 +120,7 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         .select(
           'id, week, day_code, title, notes, completed, completed_at, '
           'workout_plan_days!inner ( position, workout_plans!inner ( id, title, starts_on, created_at ) ), '
-          'day_exercises ( id, position, notes, completed, trainee_notes, exercise, exercise_id, exercises ( id, slug, name ), duration_minutes)',
+          'day_exercises ( id, position, notes, completed, trainee_notes, exercise, duration_minutes)',
         )
         .eq('workout_plan_days.workout_plans.trainee_id', userId)
         .order('week', ascending: true)
@@ -178,11 +178,8 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
         final exerciseValue = exercise['exercise'];
         final exerciseMap =
             exerciseValue is Map ? exerciseValue.cast<String, dynamic>() : null;
-        final linkedExercise =
-            (exercise['exercises'] as Map?)?.cast<String, dynamic>();
-        final name = linkedExercise?['name'] as String? ??
-            exerciseMap?['name'] as String? ??
-            exerciseValue as String?;
+        final name =
+            exerciseMap?['name'] as String? ?? exerciseValue as String?;
         final terminology = parseStringList(
           exercise['terminology'] ?? exerciseMap?['terminology'],
         );
@@ -192,11 +189,9 @@ class _WorkoutPlanPageState extends State<WorkoutPlanPage> {
 
         return WorkoutExercise(
           id: exercise['id'] as String?,
-          exerciseId: exercise['exercise_id'] as String? ??
-              linkedExercise?['id'] as String? ??
-              exerciseMap?['id'] as String?,
-          exerciseSlug: linkedExercise?['slug'] as String? ??
-              exerciseMap?['slug'] as String?,
+          exerciseId: exerciseMap?['id'] as String?,
+          exerciseSlug: exerciseMap?['slug'] as String? ??
+              (exerciseValue is String ? exerciseValue : null),
           name: name,
           position: (exercise['position'] as num?)?.toInt(),
           durationMinutes: (exercise['duration_minutes'] as num?)?.toInt(),


### PR DESCRIPTION
### Motivation
- The `day_exercises` schema was simplified in `db/` to remove nested `exercises` and `exercise_id` selections, so the app must map exercise data from the stored `exercise` field instead of relying on joined metadata. 
- Prevent runtime errors when Supabase returns `exercise` as either a `String` or a `Map` and ensure slugs/names still resolve correctly for UI pages.

### Description
- Updated the Supabase select in `lib/pages/workout_plan_page.dart` to request `day_exercises ( id, position, notes, completed, trainee_notes, exercise, duration_minutes)` to match the new schema. 
- Simplified exercise mapping to prefer `exercise` when it's a `Map` and to fall back to the raw `exercise` string for `name` and `exerciseSlug`. 
- Removed reliance on the previously nested `exercises`/`exercise_id` payload and adjusted `exerciseId` to use `exerciseMap?['id']` only.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8bb59d048333b4a8b7d536c8908a)