### PR TITLE
Add Spanish terminology seed data and rename seed file

### DIFF
--- a/db/terminology.sql
+++ b/db/terminology.sql
@@ -24,4 +24,16 @@ INSERT INTO public.terminology (term_key, locale, title, description, sort_order
   ('tut', 'it', 'TUT', 'Indica quanto deve durare una ripetizione. Puoi gestire tu la durata di ogni fase della rep.', 9),
   ('iso', 'it', 'ISO', 'Indica il fermo a un punto specifico dell''esecuzione della rep', 10),
   ('som', 'it', 'SOM', 'Indica la durata di ogni fase della ripetizione.', 11),
-  ('deload', 'it', 'Scarico', 'Ultima settimana della scheda per prepararsi ai massimali.', 12);
+  ('deload', 'it', 'Scarico', 'Ultima settimana della scheda per prepararsi ai massimali.', 12),
+  ('reps', 'es', 'Reps (Repeticiones)', 'Número de veces que realizas un ejercicio de forma consecutiva.', 1),
+  ('set', 'es', 'Set (Series)', 'Un grupo de repeticiones. Por ejemplo: 3 series de 10 reps son 30 repeticiones en total divididas en 3 grupos.', 2),
+  ('rt', 'es', 'RT', 'Repeticiones Totales: realiza todas las reps con las series, repeticiones y tempo que prefieras (si no se indica).', 3),
+  ('amrap', 'es', 'AMRAP', 'As Many Reps As Possible: haz tantas repeticiones como puedas en un tiempo determinado.', 4),
+  ('emom', 'es', 'EMOM', 'Every Minute on the Minute: comienza una serie cada minuto. Descansa el tiempo restante.', 5),
+  ('ramping', 'es', 'Ramping', 'Método en el que la carga aumenta en cada serie.', 6),
+  ('mav', 'es', 'MAV', 'Massima Alzata Veloce: realiza el mayor número de repeticiones posible con una carga manteniendo el control y una buena velocidad de ejecución.', 7),
+  ('isokinetic', 'es', 'Isocinéticos', 'Ejercicios realizados a velocidad constante.', 8),
+  ('tut', 'es', 'TUT', 'Indica cuánto debe durar una repetición. Puedes gestionar la duración de cada fase.', 9),
+  ('iso', 'es', 'ISO', 'Indica la pausa en un punto específico de la repetición.', 10),
+  ('som', 'es', 'SOM', 'Indica la duración de cada fase de la repetición.', 11),
+  ('deload', 'es', 'Descarga', 'Última semana del programa para prepararse para los máximos.', 12);


### PR DESCRIPTION
### Motivation
- Provide Spanish translations for the app terminology so Spanish-speaking users have localized term titles and descriptions.
- Correct a misspelled seed filename to `db/terminology.sql` so the seed file matches the expected name and tooling.
- Ensure terminology can be loaded by locale from the database using the existing locale-based seed entries and fallback behavior.

### Description
- Renamed the misnamed file `db/terninology.sql` to `db/terminology.sql`.
- Appended Spanish (`'es'`) rows for each terminology `term_key` to the `INSERT INTO public.terminology` seed in `db/terminology.sql`.
- Did not modify runtime code; the existing `TerminologyRepository` locale-loading and fallback logic already supports loading these per-locale entries.

### Testing
- No automated tests were executed for this seed-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f604313948333bc6c33f7cae63e96)