### PR TITLE
Fix admin day loading without exercises relation

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -250,7 +250,7 @@ import {
             .select(
               `
                 id, week, day_code, title,
-                day_exercises ( id, position, notes, exercise, exercise_id, exercises ( id, slug, name ), duration_minutes ),
+                day_exercises ( id, position, notes, exercise, exercise_id, duration_minutes ),
                 workout_plan_days!inner ( plan_id, position )
               `,
             )
@@ -2285,7 +2285,7 @@ import {
                   workout_plans ( id, title, starts_on, created_at )
                 ),
                 day_exercises (
-                  id, position, notes, completed, exercise, exercise_id, exercises ( id, slug, name ), duration_minutes
+                  id, position, notes, completed, exercise, exercise_id, duration_minutes
                 )
               `)
           .eq('workout_plan_days.workout_plans.trainee_id', u.id)
@@ -2340,7 +2340,7 @@ import {
           const { data, error } = await supabase
             .from('day_exercises')
             .select(
-              'id, exercise, exercise_id, notes, trainee_notes, completed, duration_minutes, exercises ( id, slug, name ), days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
+              'id, exercise, exercise_id, notes, trainee_notes, completed, duration_minutes, days!inner ( id, week, day_code, title, completed_at, workout_plan_days!inner ( workout_plans!inner ( trainee_id ) ) )',
             )
             .eq('completed', true)
             .eq('days.workout_plan_days.workout_plans.trainee_id', u.id);


### PR DESCRIPTION
### Motivation
- Prevent admin-side errors like "Could not find a relationship between 'day_exercises' and 'exercises' in the schema cache" by avoiding nested `exercises` relationship selects that depend on the DB schema relationship.

### Description
- Modify `backend/admin/app.js` to remove `exercises ( id, slug, name )` from `day_exercises` selects used in `loadTemplatePlan`, `loadDays`, and `loadCompletedExercises` queries.
- Preserve client-side name resolution via `resolveExerciseName` and `exerciseNameLookup` so exercise display still works using `exercise_id` or fallback `exercise` text.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6267aec48333a64019292cfb9d12)