### PR TITLE
Fix workout plan day filtering for mixed data shapes

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -481,11 +481,16 @@ import {
         const order = new Map(dayCodeOptions.map((code, idx) => [code, idx]));
         const latestPlanId = plans.value?.[0]?.id;
         const filteredDays = latestPlanId
-          ? (days.value || []).filter((day) =>
-              (day.workout_plan_days || []).some(
+          ? (days.value || []).filter((day) => {
+              const planDays = Array.isArray(day.workout_plan_days)
+                ? day.workout_plan_days
+                : day.workout_plan_days
+                  ? [day.workout_plan_days]
+                  : [];
+              return planDays.some(
                 (entry) => entry.workout_plans?.id === latestPlanId,
-              ),
-            )
+              );
+            })
           : days.value || [];
         return filteredDays
           .map((day) => {


### PR DESCRIPTION
### Motivation
- Prevent a runtime TypeError when `workout_plan_days` is not an array by making the `trainingCalendar` filter robust to mixed data shapes.

### Description
- Update `backend/admin/app.js` so the `trainingCalendar` computed converts `day.workout_plan_days` to an array (wrap single objects or use empty array when missing) before calling `.some()` to check for the latest plan id.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f65f365488333bc8ab0429a0332ea)