### PR TITLE
Simplify timer: remove exercise plan and next-up display

### DIFF
--- a/lib/pages/timer.dart
+++ b/lib/pages/timer.dart
@@ -8,22 +8,6 @@ import '../l10n/app_localizations.dart';
 
 enum IntervalPhase { work, rest }
 
-enum TimerExercise { pushUps, pullUps, squats, plank }
-
-extension TimerExerciseLabel on TimerExercise {
-  String label(AppLocalizations l10n) {
-    switch (this) {
-      case TimerExercise.pushUps:
-        return l10n.timerExercisePushUps;
-      case TimerExercise.pullUps:
-        return l10n.timerExercisePullUps;
-      case TimerExercise.squats:
-        return l10n.timerExerciseSquats;
-      case TimerExercise.plank:
-        return l10n.timerExercisePlank;
-    }
-  }
-}
 
 class TimerPage extends StatefulWidget {
   const TimerPage({super.key});
@@ -43,16 +27,6 @@ class _TimerPageState extends State<TimerPage> {
   IntervalPhase _phase = IntervalPhase.work;
   int _workSeconds = _defaultWorkSeconds;
   int _restSeconds = _defaultRestSeconds;
-
-  int _nextExerciseIndex = 0;
-  int _nextSet = 1;
-
-  final List<_ExercisePlan> _exercisePlan = const [
-    _ExercisePlan(exercise: TimerExercise.pushUps, totalSets: 3),
-    _ExercisePlan(exercise: TimerExercise.pullUps, totalSets: 3),
-    _ExercisePlan(exercise: TimerExercise.squats, totalSets: 4),
-    _ExercisePlan(exercise: TimerExercise.plank, totalSets: 2),
-  ];
 
   @override
   void dispose() {
@@ -132,24 +106,6 @@ class _TimerPageState extends State<TimerPage> {
           : IntervalPhase.work;
       _remainingSeconds = _currentPhaseDuration;
     });
-    _advanceWorkoutContext();
-  }
-
-  void _advanceWorkoutContext() {
-    if (_exercisePlan.isEmpty) {
-      return;
-    }
-    final currentPlan = _exercisePlan[_nextExerciseIndex];
-    if (_nextSet < currentPlan.totalSets) {
-      setState(() {
-        _nextSet += 1;
-      });
-    } else {
-      setState(() {
-        _nextExerciseIndex = (_nextExerciseIndex + 1) % _exercisePlan.length;
-        _nextSet = 1;
-      });
-    }
   }
 
   void _setPhaseDuration(IntervalPhase phase, int valueSeconds) {
@@ -222,18 +178,6 @@ class _TimerPageState extends State<TimerPage> {
     final minutes = seconds ~/ 60;
     final remainingSeconds = seconds % 60;
     return '${minutes.toString().padLeft(2, '0')}:${remainingSeconds.toString().padLeft(2, '0')}';
-  }
-
-  String _nextExerciseLabel(AppLocalizations l10n) {
-    if (_exercisePlan.isEmpty) {
-      return l10n.timerNextPlaceholder;
-    }
-    final plan = _exercisePlan[_nextExerciseIndex];
-    return l10n.timerNextLabel(
-      plan.exercise.label(l10n),
-      _nextSet,
-      plan.totalSets,
-    );
   }
 
   @override
@@ -341,15 +285,6 @@ class _TimerPageState extends State<TimerPage> {
                         ),
                       ],
                     ),
-                    const SizedBox(height: 20),
-                    Text(
-                      _nextExerciseLabel(l10n),
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                        fontWeight: FontWeight.w500,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
                   ],
                 ),
               ),
@@ -411,16 +346,6 @@ class _TimerConfigRow extends StatelessWidget {
       ),
     );
   }
-}
-
-class _ExercisePlan {
-  final TimerExercise exercise;
-  final int totalSets;
-
-  const _ExercisePlan({
-    required this.exercise,
-    required this.totalSets,
-  });
 }
 
 class _IntervalRingPainter extends CustomPainter {


### PR DESCRIPTION
### Motivation
- The timer UI should focus on automatic work/rest intervals without maintaining or showing an exercise plan or next-up hint.

### Description
- Removed the `TimerExercise` enum and its `TimerExerciseLabel` extension. 
- Deleted the `_exercisePlan`, `_nextExerciseIndex`, `_nextSet`, `_advanceWorkoutContext` and `_nextExerciseLabel` logic from `lib/pages/timer.dart` so the page no longer tracks exercises or sets. 
- Removed the next-up `Text` widget from the timer UI while retaining the automatic work/rest phase switching implemented in `_advancePhase`.

### Testing
- No automated unit or integration tests were run against the change. 
- An attempt to capture a screenshot with Playwright failed due to a local server connection error (`net::ERR_EMPTY_RESPONSE`), so visual verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6ddb1e7c83338d2e3094c5e39a61)