### PR TITLE
Persist exercise unlocks and surface progress on Home

### DIFF
--- a/lib/components/skill_progress_card.dart
+++ b/lib/components/skill_progress_card.dart
@@ -4,14 +4,27 @@ import 'package:flutter/material.dart';
 import '../l10n/app_localizations.dart';
 
 class SkillProgressCard extends StatelessWidget {
-  const SkillProgressCard({super.key});
+  const SkillProgressCard({
+    super.key,
+    required this.unlockedSkills,
+    required this.totalSkills,
+  });
+
+  final int unlockedSkills;
+  final int totalSkills;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
-    const unlockedSkills = 5;
-    const totalSkills = 8;
+    final displayTotal = totalSkills < 0 ? 0 : totalSkills;
+    final displayUnlocked = unlockedSkills < 0 ? 0 : unlockedSkills;
+    final iconCount = displayTotal == 0 ? 0 : (displayTotal <= 8 ? displayTotal : 8);
+    final filledIcons = iconCount == 0
+        ? 0
+        : ((displayUnlocked / displayTotal) * iconCount)
+            .round()
+            .clamp(0, iconCount);
     return SectionCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -26,7 +39,7 @@ class SkillProgressCard extends StatelessWidget {
           Row(
             children: [
               Text(
-                l10n.homeSkillProgressValue(unlockedSkills, totalSkills),
+                l10n.homeSkillProgressValue(displayUnlocked, displayTotal),
                 style: theme.textTheme.headlineSmall?.copyWith(
                   fontWeight: FontWeight.w700,
                 ),
@@ -44,11 +57,11 @@ class SkillProgressCard extends StatelessWidget {
           Wrap(
             spacing: 8,
             children: List.generate(
-              6,
-                  (index) => Icon(
+              iconCount,
+              (index) => Icon(
                 Icons.fitness_center,
                 size: 20,
-                color: index < 5
+                color: index < filledIcons
                     ? theme.colorScheme.primary
                     : theme.colorScheme.onSurfaceVariant,
               ),

--- a/lib/data/exercise_unlocks.dart
+++ b/lib/data/exercise_unlocks.dart
@@ -1,0 +1,36 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class ExerciseUnlocks {
+  ExerciseUnlocks._();
+
+  static Future<Set<String>> loadUnlockedExerciseSlugs(String traineeId) async {
+    final client = Supabase.instance.client;
+    final response = await client
+        .from('trainee_exercise_unlocks')
+        .select('exercise_id, exercises ( slug )')
+        .eq('trainee_id', traineeId);
+    final rows = (response as List<dynamic>).cast<Map<String, dynamic>>();
+    final slugs = <String>{};
+    for (final row in rows) {
+      final exercise = row['exercises'];
+      if (exercise is Map) {
+        final slug = exercise['slug']?.toString();
+        if (slug != null && slug.isNotEmpty) {
+          slugs.add(slug);
+        }
+      }
+    }
+    return slugs;
+  }
+
+  static Future<void> unlockExercise({
+    required String traineeId,
+    required String exerciseId,
+  }) async {
+    final client = Supabase.instance.client;
+    await client.from('trainee_exercise_unlocks').insert({
+      'trainee_id': traineeId,
+      'exercise_id': exerciseId,
+    });
+  }
+}

--- a/lib/model/exercise_guide.dart
+++ b/lib/model/exercise_guide.dart
@@ -47,6 +47,7 @@ class ExerciseGuideTranslation {
 class ExerciseGuide {
   const ExerciseGuide({
     required this.id,
+    required this.exerciseId,
     required this.name,
     required this.difficulty,
     required this.isUnlocked,
@@ -56,6 +57,7 @@ class ExerciseGuide {
   });
 
   final String id;
+  final String exerciseId;
   final String name;
   final Difficulty difficulty;
   final bool isUnlocked;
@@ -66,6 +68,7 @@ class ExerciseGuide {
   ExerciseGuide copyWith({bool? isUnlocked}) {
     return ExerciseGuide(
       id: id,
+      exerciseId: exerciseId,
       name: name,
       difficulty: difficulty,
       isUnlocked: isUnlocked ?? this.isUnlocked,
@@ -91,6 +94,7 @@ class ExerciseGuide {
     }
     return ExerciseGuide(
       id: slug,
+      exerciseId: row['id']?.toString() ?? '',
       name: resolvedName,
       difficulty: _difficultyFromString(row['difficulty'] as String?),
       isUnlocked: row['default_unlocked'] as bool? ?? false,


### PR DESCRIPTION
### Motivation
- Persist exercises unlocked by trainees in the `trainee_exercise_unlocks` table and surface that state in the app so the unlocks are remembered across sessions. 
- Show unlocked skill counts on the Home page and hook the skill progress widget to real data so users see their actual progress.

### Description
- Add a Supabase helper `ExerciseUnlocks` (`lib/data/exercise_unlocks.dart`) with `loadUnlockedExerciseSlugs` and `unlockExercise` to read/write trainee unlocks. 
- Extend the `ExerciseGuide` model to carry the database `id` as `exerciseId` and populate it in `fromDatabase` so unlocks can be persisted (`lib/model/exercise_guide.dart`).
- Hydrate and persist unlocks in the guides UI by loading unlocked slugs on page load and calling `ExerciseUnlocks.unlockExercise` when a user unlocks a guide, while tracking in-flight unlocks to disable duplicate actions (`lib/pages/exercise_guides.dart`).
- Drive the Home skill progress from real data by loading an unlock summary and passing `unlockedSkills`/`totalSkills` into the skill card, and make the skill card render a dynamic number of icons based on that ratio (`lib/pages/home_content.dart` and `lib/components/skill_progress_card.dart`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6d2553508333a88cd0a6a0641dd7)