### PR TITLE
Workout editor: use exercise ID dropdown for template slots and persist exercise_id

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -988,10 +988,7 @@
                                                 @click="selectTemplateSlot(slotIndex)"
                                             >
                                                 <div class="stack">
-                                                    <strong>{{ slot.exercise || t('placeholders.exerciseName') }}</strong>
-                                                    <span class="muted small">
-                                                        {{ slot.sets ? `${slot.sets} ${t('labels.sets')}` : t('labels.setsPlaceholder') }}
-                                                    </span>
+                                                    <strong>{{ resolveTemplateSlotName(slot) || t('placeholders.exerciseName') }}</strong>
                                                 </div>
                                                 <span class="workout-activity-check" :class="{ active: slotIndex === selectedTemplateSlot }">
                                                     ✓
@@ -1003,7 +1000,7 @@
                                 <div class="workout-editor-column">
                                     <div class="workout-card workout-detail-card">
                                         <div class="workout-card-header">
-                                            <h4>{{ activeTemplateSlot.exercise || t('labels.exercise') }}</h4>
+                                            <h4>{{ resolveTemplateSlotName(activeTemplateSlot) || t('labels.exercise') }}</h4>
                                         </div>
                                         <div class="workout-detail-image">
                                             <span class="muted small">{{ t('labels.preview') }}</span>
@@ -1011,17 +1008,18 @@
                                         <div class="workout-detail-grid">
                                             <label class="stack small">
                                                 <span class="muted small">{{ t('labels.exercise') }}</span>
-                                                <input
-                                                    v-model="activeTemplateSlot.exercise"
-                                                    :placeholder="t('placeholders.exerciseName')"
-                                                />
-                                            </label>
-                                            <label class="stack small">
-                                                <span class="muted small">{{ t('labels.sets') }}</span>
-                                                <input
-                                                    v-model="activeTemplateSlot.sets"
-                                                    :placeholder="t('placeholders.setsExample')"
-                                                />
+                                                <select v-model="activeTemplateSlot.exercise_id">
+                                                    <option value="">
+                                                        {{ t('placeholders.exerciseName') }}
+                                                    </option>
+                                                    <option
+                                                        v-for="exercise in exercises"
+                                                        :key="exercise.id"
+                                                        :value="exercise.id"
+                                                    >
+                                                        {{ exercise.name || exercise.slug || exercise.id }}
+                                                    </option>
+                                                </select>
                                             </label>
                                         </div>
                                         <label class="stack small">


### PR DESCRIPTION
### Motivation

- Replace free-text/series slot editing with an explicit exercise reference so templates reference exercises by `exercise_id` instead of only a name/sets string.  
- Ensure template load/save round-trips the selected exercise id and resolves names reliably when importing/exporting plans.

### Description

- Change template slot model in `backend/admin/app.js` to include `exercise_id` and initialize `activeTemplateSlot` with `exercise_id` instead of `sets`.  
- Add helper functions `resolveTemplateSlotName` and `getExerciseById` and update `resolveExerciseName` to prefer lookups by id.  
- Populate `exercise_id` when loading template plans and, when saving, prefer the selected `exercise_id` (falling back to name resolution) to build `day_exercises` payloads.  
- Update `backend/admin/index.html` to replace the free-text exercise input (and removed sets field) with a dropdown `<select>` bound to `activeTemplateSlot.exercise_id` and use `resolveTemplateSlotName` for display labels.

### Testing

- Started a local static server with `python -m http.server 8000` in `backend/admin` and ran a Playwright script to open `index.html` and capture a screenshot at `artifacts/workout-editor.png`, and the script completed successfully.  
- Verified files were staged and committed (`git commit`) successfully; no unit tests were added or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6e53d32c8333965ab337ca4082ff)