### PR TITLE
Update strength level card based on unlocked exercises

### DIFF
--- a/lib/components/strength_level_card.dart
+++ b/lib/components/strength_level_card.dart
@@ -4,12 +4,35 @@ import 'package:flutter/material.dart';
 import '../l10n/app_localizations.dart';
 
 class StrengthLevelCard extends StatelessWidget {
-  const StrengthLevelCard({super.key});
+  const StrengthLevelCard({
+    super.key,
+    required this.unlockedSkills,
+    required this.totalSkills,
+  });
+
+  final int unlockedSkills;
+  final int totalSkills;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
+    final progress = totalSkills == 0 ? 0.0 : unlockedSkills / totalSkills;
+    final strengthLevel = progress >= 0.66
+        ? _StrengthLevel.advanced
+        : progress >= 0.33
+            ? _StrengthLevel.intermediate
+            : _StrengthLevel.beginner;
+    final strengthLabel = switch (strengthLevel) {
+      _StrengthLevel.beginner => l10n.difficultyBeginner,
+      _StrengthLevel.intermediate => l10n.difficultyIntermediate,
+      _StrengthLevel.advanced => l10n.difficultyAdvanced,
+    };
+    final strengthIcon = switch (strengthLevel) {
+      _StrengthLevel.beginner => Icons.flag,
+      _StrengthLevel.intermediate => Icons.trending_up,
+      _StrengthLevel.advanced => Icons.arrow_circle_up,
+    };
     return SectionCard(
       child: Row(
         children: [
@@ -27,12 +50,12 @@ class StrengthLevelCard extends StatelessWidget {
                 Row(
                   children: [
                     Icon(
-                      Icons.arrow_circle_up,
+                      strengthIcon,
                       color: theme.colorScheme.primary,
                     ),
                     const SizedBox(width: 6),
                     Text(
-                      l10n.difficultyAdvanced,
+                      strengthLabel,
                       style: theme.textTheme.titleLarge?.copyWith(
                         fontWeight: FontWeight.w700,
                       ),
@@ -66,4 +89,10 @@ class StrengthLevelCard extends StatelessWidget {
       ),
     );
   }
+}
+
+enum _StrengthLevel {
+  beginner,
+  intermediate,
+  advanced,
 }

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -105,8 +105,6 @@ class _HomeContentState extends State<HomeContent> {
               onViewStats: widget.onViewStats,
             ),
             const SizedBox(height: 16),
-            const StrengthLevelCard(),
-            const SizedBox(height: 16),
             FutureBuilder<_ExerciseUnlockSummary>(
               future: _unlockSummaryFuture,
               builder: (context, summarySnap) {
@@ -115,9 +113,18 @@ class _HomeContentState extends State<HomeContent> {
                       unlockedSkills: 0,
                       totalSkills: 0,
                     );
-                return SkillProgressCard(
-                  unlockedSkills: summary.unlockedSkills,
-                  totalSkills: summary.totalSkills,
+                return Column(
+                  children: [
+                    StrengthLevelCard(
+                      unlockedSkills: summary.unlockedSkills,
+                      totalSkills: summary.totalSkills,
+                    ),
+                    const SizedBox(height: 16),
+                    SkillProgressCard(
+                      unlockedSkills: summary.unlockedSkills,
+                      totalSkills: summary.totalSkills,
+                    ),
+                  ],
                 );
               },
             ),


### PR DESCRIPTION
### Motivation
- Reflect the user’s progress in the home page strength indicator by deriving the strength level from unlocked exercises rather than showing a static value. 

### Description
- Change `StrengthLevelCard` to accept `unlockedSkills` and `totalSkills` and compute `progress` with a safe divide (`totalSkills == 0` handled). 
- Map `progress` to a `_StrengthLevel` enum (beginner/intermediate/advanced) and pick localized labels (`l10n.difficulty*`) and icons accordingly. 
- Wire the home view (`HomeContent`) to pass the loaded `_ExerciseUnlockSummary` into `StrengthLevelCard`, and render the `StrengthLevelCard` above the existing `SkillProgressCard` so both reflect the same summary. 

### Testing
- No automated Flutter tests were run because the environment lacks Flutter; `flutter --version` returned `command not found` so UI verification was not executed. 
- Basic repository commands used during the change: code edited and committed locally (`git commit` completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f72d15ac08333a8649e912b0cf379)