### PR TITLE
Keep menu available when opening terminology from training

### DIFF
--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -28,17 +28,27 @@ class _NavigationItem {
 }
 
 class HomePage extends StatefulWidget {
-  const HomePage({super.key, required this.title});
+  const HomePage({
+    super.key,
+    required this.title,
+    this.initialIndex = 0,
+    this.initialTerminologyTermKey,
+  });
   final String title;
+  final int initialIndex;
+  final String? initialTerminologyTermKey;
+
+  static const int terminologyIndex = 6;
 
   @override
   State<HomePage> createState() => _HomePageState();
 }
 
 class _HomePageState extends State<HomePage> {
-  int selectedIndex = 0;
+  late int selectedIndex;
   bool? payed;
   String? _cachedLocale;
+  String? _terminologyTermKey;
 
   final supabase = Supabase.instance.client;
   static const int _workoutPlanIndex = 1;
@@ -47,6 +57,8 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    selectedIndex = widget.initialIndex;
+    _terminologyTermKey = widget.initialTerminologyTermKey;
   }
 
   @override
@@ -108,7 +120,7 @@ class _HomePageState extends State<HomePage> {
       _NavigationItem(
         title: l10n.navTerminology,
         icon: Icons.menu_book,
-        page: const TerminologyPage(),
+        page: TerminologyPage(termKey: _terminologyTermKey),
       ),
       _NavigationItem(
         title: l10n.timerTitle,

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -9,7 +9,7 @@ import '../data/terminology_repository.dart';
 import '../l10n/app_localizations.dart';
 import '../model/exercise_guide.dart';
 import '../model/terminology_entry.dart';
-import 'terminology.dart';
+import 'main.dart';
 import 'exercise_guides.dart';
 
 class Training extends StatefulWidget {
@@ -518,9 +518,14 @@ class _TrainingState extends State<Training> {
   }
 
   void _openTerminologyTerm(String termKey) {
+    final l10n = AppLocalizations.of(context)!;
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => TerminologyPage(termKey: termKey),
+        builder: (context) => HomePage(
+          title: l10n.appTitle,
+          initialIndex: HomePage.terminologyIndex,
+          initialTerminologyTermKey: termKey,
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Motivation

- Ensure the app drawer/menu remains available when a user opens a terminology entry from the Training page by routing into the main navigation rather than a full-screen Terminology page.
- Support opening the `HomePage` directly on the Terminology tab with an optional highlighted term so the same terminology UX can be shown inside the main scaffold.

### Description

- Added optional constructor parameters `initialIndex` and `initialTerminologyTermKey` to `HomePage` and a `terminologyIndex` constant to allow starting the app on a requested tab with a highlighted term via `HomePage`.
- Store the requested term key in `_terminologyTermKey` and pass it into the `TerminologyPage` instance in the navigation list via `TerminologyPage(termKey: _terminologyTermKey)`.
- Changed `Training._openTerminologyTerm` to push `HomePage` with `initialIndex: HomePage.terminologyIndex` and `initialTerminologyTermKey: termKey` instead of pushing `TerminologyPage` directly, and updated imports accordingly.

### Testing

- No automated tests were run for this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f7471abf88333986a87c36247ab55)