### PR TITLE
Provide Material ancestor for ChoiceChip in Difficulty selector

### DIFF
--- a/lib/pages/exercise_guides.dart
+++ b/lib/pages/exercise_guides.dart
@@ -296,17 +296,20 @@ class _DifficultySelector extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Wrap(
-      spacing: 10,
-      runSpacing: 8,
-      children: Difficulty.values.map((difficulty) {
-        return ChoiceChip(
-          label: Text(difficulty.label(l10n)),
-          selected: selected == difficulty,
-          selectedColor: theme.colorScheme.primaryContainer,
-          onSelected: (_) => onChanged(difficulty),
-        );
-      }).toList(),
+    return Material(
+      type: MaterialType.transparency,
+      child: Wrap(
+        spacing: 10,
+        runSpacing: 8,
+        children: Difficulty.values.map((difficulty) {
+          return ChoiceChip(
+            label: Text(difficulty.label(l10n)),
+            selected: selected == difficulty,
+            selectedColor: theme.colorScheme.primaryContainer,
+            onSelected: (_) => onChanged(difficulty),
+          );
+        }).toList(),
+      ),
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent a runtime error where `ChoiceChip` reported "No Material widget found" when opening exercise details by ensuring a Material ancestor is present.

### Description
- Wrap the difficulty chips in a `Material` with `type: MaterialType.transparency` inside `_DifficultySelector` to satisfy `ChoiceChip` requirements.
- This change is localized to `lib/pages/exercise_guides.dart` and preserves visual appearance while enabling ink effects and other Material behaviors.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f751b76c48333b6813fb901716a21)