### PR TITLE
Keep menu when opening guides from training

### DIFF
--- a/lib/pages/main.dart
+++ b/lib/pages/main.dart
@@ -33,12 +33,17 @@ class HomePage extends StatefulWidget {
     required this.title,
     this.initialIndex = 0,
     this.initialTerminologyTermKey,
+    this.initialGuideSlug,
+    this.initialGuideId,
   });
   final String title;
   final int initialIndex;
   final String? initialTerminologyTermKey;
+  final String? initialGuideSlug;
+  final String? initialGuideId;
 
   static const int terminologyIndex = 6;
+  static const int guidesIndex = 2;
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -101,7 +106,10 @@ class _HomePageState extends State<HomePage> {
       _NavigationItem(
         title: l10n.navGuides,
         icon: Icons.fitness_center,
-        page: const ExerciseGuidesPage(),
+        page: ExerciseGuidesPage(
+          initialGuideSlug: widget.initialGuideSlug,
+          initialGuideId: widget.initialGuideId,
+        ),
       ),
       _NavigationItem(
         title: l10n.navProfile,

--- a/lib/pages/training.dart
+++ b/lib/pages/training.dart
@@ -10,7 +10,6 @@ import '../l10n/app_localizations.dart';
 import '../model/exercise_guide.dart';
 import '../model/terminology_entry.dart';
 import 'main.dart';
-import 'exercise_guides.dart';
 
 class Training extends StatefulWidget {
   final WorkoutDay day;
@@ -449,9 +448,12 @@ class _TrainingState extends State<Training> {
   }
 
   void _openExerciseGuide(WorkoutExercise exercise) {
+    final l10n = AppLocalizations.of(context)!;
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => ExerciseGuidesPage(
+        builder: (context) => HomePage(
+          title: l10n.appTitle,
+          initialIndex: HomePage.guidesIndex,
           initialGuideSlug: exercise.exerciseSlug,
           initialGuideId: exercise.exerciseId,
         ),


### PR DESCRIPTION
### Motivation

- Ensure that when a user opens an exercise guide from the training page the app keeps the main menu/scaffold visible and still deep-links to the requested guide.

### Description

- Add `initialGuideSlug` and `initialGuideId` fields to `HomePage` and pass them into the `ExerciseGuidesPage` instance used by the guides navigation item. 
- Add `HomePage.guidesIndex` constant and wire the guides tab as index `2` so it can be selected programmatically. 
- Change training guide navigation in `_openExerciseGuide` to push `HomePage` with `initialIndex: HomePage.guidesIndex` and the guide routing parameters instead of directly pushing `ExerciseGuidesPage`. 
- Remove the now-unnecessary direct `exercise_guides.dart` import from `training.dart` (navigation flows through `HomePage`).

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f77b0f72c8333ac040d07e21d26b9)