### PR TITLE
Add y-axis amount labels to monthly payment trend chart

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -117,6 +117,7 @@ import {
         months: [],
         series: [],
         maxValue: 0,
+        axisTicks: [],
       });
       const paymentTrendsLoading = ref(false);
       const paymentTrendsError = ref('');
@@ -1804,6 +1805,7 @@ import {
               months: [],
               series: [],
               maxValue: 0,
+              axisTicks: [],
             };
             return;
           }
@@ -1870,6 +1872,19 @@ import {
             ]),
           );
           const range = maxValue || 1;
+          const axisTicks = Array.from({ length: 4 }, (_, index) => {
+            const ratio = index / 3;
+            const value = maxValue * (1 - ratio);
+            const y =
+              chartHeight -
+              padding -
+              (value / range) * (chartHeight - padding * 2);
+            return {
+              value,
+              y: Number(y.toFixed(2)),
+              label: formatAmount(value),
+            };
+          });
           const pointsBySeries = seriesConfig.map((series) => {
             const points = months.map((month, index) => {
               const entry = totals.get(monthKey(month)) || {
@@ -1906,6 +1921,7 @@ import {
             months,
             series: pointsBySeries,
             maxValue,
+            axisTicks,
           };
         } catch (err) {
           console.error(err);
@@ -1914,6 +1930,7 @@ import {
             months: [],
             series: [],
             maxValue: 0,
+            axisTicks: [],
           };
           paymentTrendsError.value =
             err.message || t('errors.loadPayments');

--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -497,6 +497,17 @@
                             :aria-label="t('payments.trendTitle')"
                             :viewBox="`0 0 ${paymentTrends.chartWidth} ${paymentTrends.chartHeight}`"
                         >
+                            <g class="payment-trend-axis-ticks">
+                                <text
+                                    v-for="(tick, index) in paymentTrends.axisTicks"
+                                    :key="index"
+                                    class="payment-trend-axis-label"
+                                    x="6"
+                                    :y="tick.y + 4"
+                                >
+                                    {{ tick.label }}
+                                </text>
+                            </g>
                             <line
                                 class="payment-trend-axis-line"
                                 x1="24"

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -86,6 +86,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .payment-trend-chart{width:100%;height:240px;background:#f8fafc;border-radius:16px;border:1px solid var(--line);padding:12px;box-sizing:border-box}
 .payment-trend-line{fill:none;stroke-width:2.5;stroke-linecap:round}
 .payment-trend-axis-line{stroke:#cbd5f5;stroke-width:1}
+.payment-trend-axis-label{fill:var(--muted);font-size:11px}
 .payment-trend-axis{display:flex;justify-content:space-between;color:var(--muted);font-size:12px}
 .payment-trend-legend{display:flex;flex-wrap:wrap;gap:12px;margin-top:4px}
 .payment-trend-legend .legend-item{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--muted)}


### PR DESCRIPTION
### Motivation
- Improve the monthly payments trend chart by showing numeric amount markers on the y-axis so amounts are easier to read at a glance.
- Keep labels localized/consistent by reusing the existing `formatAmount` helper for formatting values.

### Description
- Added `axisTicks` to the `paymentTrends` reactive state in `backend/admin/app.js` and compute four evenly-distributed ticks in `loadPaymentTrends` using `formatAmount` for labels.
- Rendered y-axis tick labels inside the SVG in `backend/admin/index.html` with a `v-for` over `paymentTrends.axisTicks` and keyed by index.
- Added `.payment-trend-axis-label` CSS rules to `backend/admin/styles.css` to style the axis labels and ensured `axisTicks` is cleared on error or empty data.

### Testing
- Started a simple HTTP server with `python -m http.server 8000` to serve the admin UI and it started successfully.
- Ran a Playwright visual smoke script that loaded `http://127.0.0.1:8000/index.html` and saved a screenshot to `artifacts/payment-trend.png`, which completed successfully.
- No unit tests were executed for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fc26ab96c8333a685968348270444)