### PR TITLE
Add selectable burndown legend

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -137,6 +137,15 @@ import {
         minDateLabel: '',
         maxDateLabel: '',
       });
+      const selectedBurndownTrainees = ref(new Set());
+      const visibleBurndownLines = computed(() => {
+        const selected = selectedBurndownTrainees.value;
+        const lines = dashboardBurndown.value.lines || [];
+        if (!selected.size) {
+          return lines;
+        }
+        return lines.filter((line) => selected.has(line.traineeId));
+      });
       const dashboardBurndownLoading = ref(false);
       const dashboardBurndownError = ref('');
       const addingDay = ref(false);
@@ -2595,6 +2604,23 @@ import {
         }
       }
 
+      function toggleBurndownTraineeSelection(traineeId) {
+        if (!traineeId) return;
+        const next = new Set(selectedBurndownTrainees.value);
+        if (next.has(traineeId)) {
+          next.delete(traineeId);
+        } else {
+          next.add(traineeId);
+        }
+        selectedBurndownTrainees.value = next;
+      }
+
+      function isBurndownTraineeSelected(traineeId) {
+        const selected = selectedBurndownTrainees.value;
+        if (!selected.size) return true;
+        return selected.has(traineeId);
+      }
+
       async function loadDashboardBurndown() {
         dashboardBurndownLoading.value = true;
         dashboardBurndownError.value = '';
@@ -3181,6 +3207,7 @@ import {
         dashboardNotesError,
         dashboardNoteClosing,
         dashboardBurndown,
+        visibleBurndownLines,
         dashboardBurndownLoading,
         dashboardBurndownError,
         loadingProgress,
@@ -3231,6 +3258,8 @@ import {
         loadCompletedExercises,
         loadDashboardNotes,
         closeDashboardNote,
+        toggleBurndownTraineeSelection,
+        isBurndownTraineeSelected,
         addPlan,
         addDay,
         resetDayForm,

--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -236,7 +236,7 @@
                             :viewBox="`0 0 ${dashboardBurndown.chartWidth} ${dashboardBurndown.chartHeight}`"
                         >
                             <polyline
-                                v-for="line in dashboardBurndown.lines"
+                                v-for="line in visibleBurndownLines"
                                 :key="line.traineeId"
                                 :points="line.polyline"
                                 :stroke="line.color"
@@ -246,8 +246,21 @@
                                 stroke-linejoin="round"
                             />
                         </svg>
+                        <div class="burndown-axis-label burndown-axis-label-y">
+                            {{ t('dashboard.burndownYAxis') }}
+                        </div>
+                        <div class="burndown-axis-label burndown-axis-label-x">
+                            {{ t('dashboard.burndownXAxis') }}
+                        </div>
                         <div class="burndown-legend">
-                            <div class="burndown-legend-item" v-for="line in dashboardBurndown.lines" :key="line.traineeId">
+                            <button
+                                class="burndown-legend-item"
+                                :class="{ active: isBurndownTraineeSelected(line.traineeId) }"
+                                v-for="line in dashboardBurndown.lines"
+                                :key="line.traineeId"
+                                type="button"
+                                @click="toggleBurndownTraineeSelection(line.traineeId)"
+                            >
                                 <span class="burndown-legend-swatch" :style="{ backgroundColor: line.color }"></span>
                                 <div>
                                     <strong>{{ line.traineeName }}</strong>
@@ -255,7 +268,7 @@
                                         {{ t('dashboard.burndownRemaining', { remaining: line.latestRemaining, total: line.total }) }}
                                     </div>
                                 </div>
-                            </div>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/backend/admin/styles.css
+++ b/backend/admin/styles.css
@@ -211,11 +211,17 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .exercise-form-actions{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin-top:12px}
 .exercise-actions{display:flex;flex-wrap:wrap;gap:8px}
 .exercise-toolbar{display:flex;gap:12px;align-items:flex-end;flex-wrap:wrap}
-.burndown-chart-wrap{display:flex;flex-direction:column;gap:16px;margin-top:12px}
+.burndown-chart-wrap{display:flex;flex-direction:column;gap:16px;margin-top:12px;position:relative}
 .burndown-chart{width:100%;height:260px;background:#f8fafc;border-radius:16px;border:1px solid var(--line);padding:12px;box-sizing:border-box}
 .burndown-legend{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px}
-.burndown-legend-item{display:flex;gap:10px;align-items:center}
+.burndown-legend-item{display:flex;gap:10px;align-items:center;background:transparent;border:1px solid transparent;border-radius:12px;padding:8px 10px;text-align:left;cursor:pointer;transition:border-color .2s ease,box-shadow .2s ease,opacity .2s ease}
+.burndown-legend-item:hover{border-color:var(--line)}
+.burndown-legend-item.active{border-color:var(--accent);box-shadow:0 6px 16px rgba(15,23,42,.08)}
+.burndown-legend-item:not(.active){opacity:.75}
 .burndown-legend-swatch{width:12px;height:12px;border-radius:999px;display:inline-block;flex-shrink:0}
+.burndown-axis-label{position:absolute;color:var(--muted);font-size:12px}
+.burndown-axis-label-y{left:-6px;top:110px;transform:rotate(-90deg);transform-origin:left top}
+.burndown-axis-label-x{right:12px;bottom:64px}
 
 .auth-shell{flex:1;display:grid;place-items:center;padding:40px}
 .auth-card{background:#fff;border-radius:24px;padding:32px;box-shadow:0 30px 60px rgba(15,23,42,.12);border:1px solid #e5e7eb;max-width:460px;width:100%}

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -116,6 +116,8 @@ export const translations = {
       burndownLoading: 'Loading plan progress…',
       burndownEmpty: 'No plan progress found for the last month.',
       burndownRemaining: '{remaining} of {total} exercises remaining',
+      burndownXAxis: '30 days',
+      burndownYAxis: 'Exercises left',
     },
     crud: {
       title: 'CRUD terminology',
@@ -479,6 +481,8 @@ export const translations = {
       burndownLoading: 'Caricamento progresso piano…',
       burndownEmpty: 'Nessun progresso del piano trovato nell’ultimo mese.',
       burndownRemaining: '{remaining} di {total} esercizi rimanenti',
+      burndownXAxis: '30 giorni',
+      burndownYAxis: 'Esercizi rimanenti',
     },
     crud: {
       title: 'Terminologia CRUD',


### PR DESCRIPTION
### Motivation
- Surface per‑trainee remaining exercises over a 30‑day span and allow instructors to toggle which trainees are visible on the burndown chart.
- Add axis labels that clarify the x axis is a 30‑day window and the y axis shows exercises left.

### Description
- Introduced `selectedBurndownTrainees` and computed `visibleBurndownLines` in `backend/admin/app.js` and added `toggleBurndownTraineeSelection` and `isBurndownTraineeSelected` helper functions to manage legend selection state.
- Updated the burndown SVG to render `visibleBurndownLines` and replaced the static legend with interactive buttons that toggle trainees, and exposed the new helpers in the component return value in `backend/admin/app.js`.
- Added axis label elements to `backend/admin/index.html` and localized strings `burndownXAxis` and `burndownYAxis` in `backend/admin/translations.js` (English and Italian).
- Styled legend controls and axis labels in `backend/admin/styles.css` including active/hover states and chart container positioning.

### Testing
- Performed a visual smoke check by starting a local server with `python -m http.server 8000` and running a Playwright script to capture `artifacts/burndown-dashboard.png`, which completed successfully and produced a screenshot artifact.
- No unit or integration test suite was run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fc821c6688333bcff427bdb9d2506)