### PR TITLE
Load exercises data when admin section opens

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -91,6 +91,7 @@ import {
       const exerciseSelection = ref({});
       const dayEdits = ref({});
       const dayExerciseEdits = ref({});
+      const exercisesContext = ref('none');
       const planEdits = ref({});
       const expandedDays = ref({});
       const traineeProgress = ref({});
@@ -191,6 +192,11 @@ import {
       watch(selectedTemplatePlanId, async (nextId) => {
         if (templatePlanLoading.value) return;
         await loadTemplatePlan(nextId);
+      });
+      watch(activeSection, async (nextSection) => {
+        if (nextSection !== 'exercises') return;
+        if (exercisesContext.value === 'all' || loadingExercises.value) return;
+        await loadExercises(null);
       });
 
       function buildTemplateDays(count, slots, existing) {
@@ -1269,7 +1275,6 @@ import {
         }
         await loadUsers();
         await loadPaymentTrends();
-        await loadExercises();
         await loadTerminology();
         await loadTraineeProgress();
         await loadDashboardBurndown();
@@ -1434,14 +1439,17 @@ import {
             exercises.value = (data || [])
               .map((row) => row.exercises)
               .filter(Boolean);
+            exercisesContext.value = 'trainee';
           } else {
             exercises.value = data || [];
+            exercisesContext.value = 'all';
           }
           exerciseEdits.value = {};
           (exercises.value || []).forEach(setExerciseEdit);
         } catch (error) {
           console.error(error);
           exercises.value = [];
+          exercisesContext.value = 'none';
           exercisesError.value = error.message || t('errors.loadExercises');
         } finally {
           loadingExercises.value = false;


### PR DESCRIPTION
### Motivation
- Avoid fetching the full exercises list on every admin bootstrap to reduce unnecessary data loads and improve perceived performance in the admin UI. 
- Ensure the exercises list is loaded on-demand when the admin navigates to the `exercises` section and that the correct scope (trainee vs all) is tracked so reloads happen only when needed.

### Description
- Added a reactive `exercisesContext` (`const exercisesContext = ref('none')`) to track whether currently-loaded exercises are the full list (`'all'`), a trainee-scoped list (`'trainee'`), or none (`'none'`).
- Added a watcher on `activeSection` that calls `loadExercises(null)` when the section becomes `'exercises'` unless `exercisesContext` is already `'all'` or a load is in progress. 
- Removed the eager `await loadExercises()` call from `bootstrap()` so exercises are loaded on demand. 
- Updated `loadExercises` to set `exercisesContext` to `'trainee'`, `'all'`, or `'none'` depending on the successful result or error.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fc9280edc83339bff04c187e1c4d1)