### PR TITLE
Update late payment message copy

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -154,6 +154,7 @@
   "refresh": "Refresh",
   "homeEmptyTitle": "No workouts available",
   "homeEmptyDescription": "Contact your coach to receive a new plan.",
+  "homeLatePaymentDescription": "Your payment is due. Please settle it to keep your plan active.",
   "homePlansSectionTitle": "Workout plans",
   "homePlansSectionSubtitle": "Plans assigned to you and their current status.",
   "homePlansEmptyTitle": "No workout plans yet",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -154,6 +154,7 @@
   "refresh": "Actualizar",
   "homeEmptyTitle": "No hay entrenamientos disponibles",
   "homeEmptyDescription": "Contacta a tu entrenador para recibir un nuevo plan.",
+  "homeLatePaymentDescription": "Tu pago está pendiente. Por favor, regularízalo para mantener tu plan activo.",
   "homePlansSectionTitle": "Planes de entrenamiento",
   "homePlansSectionSubtitle": "Planes asignados y su estado actual.",
   "homePlansEmptyTitle": "Aún no hay planes de entrenamiento",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -154,6 +154,7 @@
   "refresh": "Aggiorna",
   "homeEmptyTitle": "Nessun allenamento disponibile",
   "homeEmptyDescription": "Contatta il tuo coach per ricevere una nuova scheda.",
+  "homeLatePaymentDescription": "Il pagamento è in scadenza. Effettualo per mantenere attivo il tuo piano.",
   "homePlansSectionTitle": "Piani di allenamento",
   "homePlansSectionSubtitle": "Piani assegnati e il loro stato attuale.",
   "homePlansEmptyTitle": "Nessun piano di allenamento",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -868,6 +868,12 @@ abstract class AppLocalizations {
   /// **'Contatta il tuo coach per ricevere una nuova scheda.'**
   String get homeEmptyDescription;
 
+  /// No description provided for @homeLatePaymentDescription.
+  ///
+  /// In it, this message translates to:
+  /// **'Il pagamento è in scadenza. Effettualo per mantenere attivo il tuo piano.'**
+  String get homeLatePaymentDescription;
+
   /// No description provided for @homePlansSectionTitle.
   ///
   /// In it, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -439,6 +439,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Contact your coach to receive a new plan.';
 
   @override
+  String get homeLatePaymentDescription =>
+      'Your payment is due. Please settle it to keep your plan active.';
+
+  @override
   String get homePlansSectionTitle => 'Workout plans';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -445,6 +445,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Contacta a tu entrenador para recibir un nuevo plan.';
 
   @override
+  String get homeLatePaymentDescription =>
+      'Tu pago está pendiente. Por favor, regularízalo para mantener tu plan activo.';
+
+  @override
   String get homePlansSectionTitle => 'Planes de entrenamiento';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -444,6 +444,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Contatta il tuo coach per ricevere una nuova scheda.';
 
   @override
+  String get homeLatePaymentDescription =>
+      'Il pagamento è in scadenza. Effettualo per mantenere attivo il tuo piano.';
+
+  @override
   String get homePlansSectionTitle => 'Piani di allenamento';
 
   @override

--- a/lib/pages/home_content.dart
+++ b/lib/pages/home_content.dart
@@ -126,7 +126,7 @@ class _HomeContentState extends State<HomeContent> {
                   children: [
                     _LatePaymentCard(
                       title: l10n.profilePlanExpired,
-                      description: l10n.homeEmptyDescription,
+                      description: l10n.homeLatePaymentDescription,
                     ),
                     const SizedBox(height: 16),
                   ],


### PR DESCRIPTION
### Motivation
- The `_LatePaymentCard` reused the generic `homeEmptyDescription` which tells users to contact their coach, but the message should specifically state that a payment is due and should not prompt contacting the coach.

### Description
- Add a new localized message `homeLatePaymentDescription` to `lib/l10n/*.arb` for English, Spanish, and Italian and add the `homeLatePaymentDescription` getter to `AppLocalizations`.
- Update the generated localization files `lib/l10n/app_localizations_en.dart`, `app_localizations_es.dart`, and `app_localizations_it.dart` with the new strings.
- Change `lib/pages/home_content.dart` to use `l10n.homeLatePaymentDescription` for the `_LatePaymentCard` description.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd4bb34648333bdcf5d0298d720ad)