### PR TITLE
Prevent admin bootstrap resets on auth refresh

### DIFF
--- a/backend/admin/app.js
+++ b/backend/admin/app.js
@@ -47,6 +47,7 @@ import {
       });
       const session = ref(null);
       const user = ref(null);
+      const hasBootstrapped = ref(false);
       const email = ref('');
       const password = ref('');
       const search = ref('');
@@ -1305,6 +1306,7 @@ import {
           await loadPaymentHistory(users.value[0]);
           await loadCompletedExercises(users.value[0]);
         }
+        hasBootstrapped.value = true;
       }
 
       async function loadAccess() {
@@ -3119,10 +3121,18 @@ import {
         user.value = sess?.user || null;
         if (session.value) await bootstrap();
 
-        supabase.auth.onAuthStateChange((_e, s) => {
+        supabase.auth.onAuthStateChange((event, s) => {
           session.value = s;
           user.value = s?.user || null;
-          if (s) bootstrap();
+          if (!s) return;
+          if (
+            !hasBootstrapped.value ||
+            event === 'SIGNED_IN' ||
+            event === 'USER_UPDATED' ||
+            event === 'PASSWORD_RECOVERY'
+          ) {
+            void bootstrap();
+          }
         });
       });
 


### PR DESCRIPTION
### Motivation
- Prevent the admin UI from re-running a full `bootstrap` (which reset trainer/program selections like `currentTrainer`/`current`) when auth state changes from background token refreshes or focus events.  

### Description
- Add a `hasBootstrapped` flag and set it to `true` at the end of `bootstrap`.  
- Change the `supabase.auth.onAuthStateChange` handler to return early on sign-out and only call `bootstrap` when `!hasBootstrapped` or the event is `SIGNED_IN`, `USER_UPDATED`, or `PASSWORD_RECOVERY`, avoiding unnecessary resets.  

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980c616f7988333a3ebfdfd751c0728)