### PR TITLE
Add height to trainee profiles

### DIFF
--- a/db/database.sql
+++ b/db/database.sql
@@ -118,6 +118,7 @@ CREATE TABLE public.trainees (
   name text NOT NULL,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   weight numeric,
+  height numeric,
   profile_image_url text,
   CONSTRAINT trainees_pkey PRIMARY KEY (id),
   CONSTRAINT trainees_id_fkey FOREIGN KEY (id) REFERENCES auth.users(id)

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -252,6 +252,15 @@
       }
     }
   },
+  "profileHeight": "Height",
+  "profileHeightValue": "{height} cm",
+  "@profileHeightValue": {
+    "placeholders": {
+      "height": {
+        "type": "String"
+      }
+    }
+  },
   "profileMaxTestsTitle": "Max test tracking",
   "profileMaxTestsDescription": "Log your best attempts to see how your strength evolves over time.",
   "profileMaxTestsPeriodLabel": "Period",
@@ -354,6 +363,9 @@
   "profileEditWeightLabel": "Weight",
   "profileEditWeightHint": "Enter your weight in kg (optional)",
   "profileEditWeightInvalid": "Enter a valid positive weight.",
+  "profileEditHeightLabel": "Height",
+  "profileEditHeightHint": "Enter your height in cm (optional)",
+  "profileEditHeightInvalid": "Enter a valid positive height.",
   "profilePhotoEdit": "Change photo",
   "profileEditCancel": "Cancel",
   "profileEditSave": "Save changes",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -252,6 +252,15 @@
       }
     }
   },
+  "profileHeight": "Altura",
+  "profileHeightValue": "{height} cm",
+  "@profileHeightValue": {
+    "placeholders": {
+      "height": {
+        "type": "String"
+      }
+    }
+  },
   "profileMaxTestsTitle": "Seguimiento de pruebas máximas",
   "profileMaxTestsDescription": "Registra tus mejores intentos para ver cómo evoluciona tu fuerza con el tiempo.",
   "profileMaxTestsPeriodLabel": "Período",
@@ -354,6 +363,9 @@
   "profileEditWeightLabel": "Peso",
   "profileEditWeightHint": "Introduce tu peso en kg (opcional)",
   "profileEditWeightInvalid": "Introduce un peso positivo válido.",
+  "profileEditHeightLabel": "Altura",
+  "profileEditHeightHint": "Introduce tu altura en cm (opcional)",
+  "profileEditHeightInvalid": "Introduce una altura positiva válida.",
   "profilePhotoEdit": "Cambiar foto",
   "profileEditCancel": "Cancelar",
   "profileEditSave": "Guardar cambios",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -252,6 +252,15 @@
       }
     }
   },
+  "profileHeight": "Altezza",
+  "profileHeightValue": "{height} cm",
+  "@profileHeightValue": {
+    "placeholders": {
+      "height": {
+        "type": "String"
+      }
+    }
+  },
   "profileMaxTestsTitle": "Test massimali",
   "profileMaxTestsDescription": "Tieni traccia dei tuoi massimali per vedere come progredisci nel tempo.",
   "profileMaxTestsPeriodLabel": "Periodo",
@@ -354,6 +363,9 @@
   "profileEditWeightLabel": "Peso",
   "profileEditWeightHint": "Inserisci il tuo peso in kg (opzionale)",
   "profileEditWeightInvalid": "Inserisci un peso valido e positivo.",
+  "profileEditHeightLabel": "Altezza",
+  "profileEditHeightHint": "Inserisci la tua altezza in cm (opzionale)",
+  "profileEditHeightInvalid": "Inserisci un'altezza valida e positiva.",
   "profilePhotoEdit": "Cambia foto",
   "profileEditCancel": "Annulla",
   "profileEditSave": "Salva modifiche",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1162,6 +1162,18 @@ abstract class AppLocalizations {
   /// **'{weight} kg'**
   String profileWeightValue(String weight);
 
+  /// No description provided for @profileHeight.
+  ///
+  /// In it, this message translates to:
+  /// **'Altezza'**
+  String get profileHeight;
+
+  /// No description provided for @profileHeightValue.
+  ///
+  /// In it, this message translates to:
+  /// **'{height} cm'**
+  String profileHeightValue(String height);
+
   /// No description provided for @profileMaxTestsTitle.
   ///
   /// In it, this message translates to:
@@ -1479,6 +1491,24 @@ abstract class AppLocalizations {
   /// In it, this message translates to:
   /// **'Inserisci un peso valido e positivo.'**
   String get profileEditWeightInvalid;
+
+  /// No description provided for @profileEditHeightLabel.
+  ///
+  /// In it, this message translates to:
+  /// **'Altezza'**
+  String get profileEditHeightLabel;
+
+  /// No description provided for @profileEditHeightHint.
+  ///
+  /// In it, this message translates to:
+  /// **'Inserisci la tua altezza in cm (opzionale)'**
+  String get profileEditHeightHint;
+
+  /// No description provided for @profileEditHeightInvalid.
+  ///
+  /// In it, this message translates to:
+  /// **\"Inserisci un'altezza valida e positiva.\"**
+  String get profileEditHeightInvalid;
 
   /// No description provided for @profilePhotoEdit.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -605,6 +605,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get profileHeight => 'Height';
+
+  @override
+  String profileHeightValue(String height) {
+    return '$height cm';
+  }
+
+  @override
   String get profileMaxTestsTitle => 'Max test tracking';
 
   @override
@@ -782,6 +790,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get profileEditWeightInvalid => 'Enter a valid positive weight.';
+
+  @override
+  String get profileEditHeightLabel => 'Height';
+
+  @override
+  String get profileEditHeightHint => 'Enter your height in cm (optional)';
+
+  @override
+  String get profileEditHeightInvalid => 'Enter a valid positive height.';
 
   @override
   String get profilePhotoEdit => 'Change photo';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -611,6 +611,14 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get profileHeight => 'Altura';
+
+  @override
+  String profileHeightValue(String height) {
+    return '$height cm';
+  }
+
+  @override
   String get profileMaxTestsTitle => 'Seguimiento de pruebas máximas';
 
   @override
@@ -789,6 +797,15 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get profileEditWeightInvalid => 'Introduce un peso positivo válido.';
+
+  @override
+  String get profileEditHeightLabel => 'Altura';
+
+  @override
+  String get profileEditHeightHint => 'Introduce tu altura en cm (opcional)';
+
+  @override
+  String get profileEditHeightInvalid => 'Introduce una altura positiva válida.';
 
   @override
   String get profilePhotoEdit => 'Cambiar foto';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -611,6 +611,14 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get profileHeight => 'Altezza';
+
+  @override
+  String profileHeightValue(String height) {
+    return '$height cm';
+  }
+
+  @override
   String get profileMaxTestsTitle => 'Test massimali';
 
   @override
@@ -790,6 +798,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get profileEditWeightInvalid => 'Inserisci un peso valido e positivo.';
+
+  @override
+  String get profileEditHeightLabel => 'Altezza';
+
+  @override
+  String get profileEditHeightHint => 'Inserisci la tua altezza in cm (opzionale)';
+
+  @override
+  String get profileEditHeightInvalid => 'Inserisci un\'altezza valida e positiva.';
 
   @override
   String get profilePhotoEdit => 'Cambia foto';

--- a/lib/model/trainee.dart
+++ b/lib/model/trainee.dart
@@ -3,12 +3,14 @@ class Trainee {
   final String id;
   final String? name;
   final double? weight;
+  final double? height;
   final String? profileImageUrl;
 
   const Trainee({
     required this.id,
     this.name,
     this.weight,
+    this.height,
     this.profileImageUrl,
   });
 
@@ -17,6 +19,7 @@ class Trainee {
       id: map['id'] as String,
       name: map['name'] as String?,
       weight: (map['weight'] as num?)?.toDouble(),
+      height: (map['height'] as num?)?.toDouble(),
       profileImageUrl: map['profile_image_url'] as String?,
     );
   }
@@ -26,6 +29,7 @@ class Trainee {
       'id': id,
       'name': name,
       'weight': weight,
+      'height': height,
       'profile_image_url': profileImageUrl,
     };
   }
@@ -34,12 +38,14 @@ class Trainee {
     String? id,
     String? name,
     double? weight,
+    double? height,
     String? profileImageUrl,
   }) {
     return Trainee(
       id: id ?? this.id,
       name: name ?? this.name,
       weight: weight ?? this.weight,
+      height: height ?? this.height,
       profileImageUrl: profileImageUrl ?? this.profileImageUrl,
     );
   }
@@ -49,6 +55,7 @@ class Trainee {
         'id': id,
         'name': name,
         'weight': weight,
+        'height': height,
         'profileImageUrl': profileImageUrl,
       }})';
 
@@ -60,6 +67,7 @@ class Trainee {
       id == other.id &&
       name == other.name &&
       weight == other.weight &&
+      height == other.height &&
       profileImageUrl == other.profileImageUrl;
 
   @override
@@ -68,6 +76,7 @@ class Trainee {
         id,
         name,
         weight,
+        height,
         profileImageUrl,
       ]);
 }

--- a/lib/pages/profile.dart
+++ b/lib/pages/profile.dart
@@ -85,7 +85,7 @@ Future<UserProfileData> getUserData() async {
 
   final profileResponse = await supabase
       .from('trainees')
-      .select('id, name, weight, profile_image_url')
+      .select('id, name, weight, height, profile_image_url')
       .eq('id', user.id)
       .limit(1)
       .maybeSingle();
@@ -313,6 +313,10 @@ class _ProfilePageState extends State<ProfilePage> {
             final weightText = weight != null
                 ? l10n.profileWeightValue(weight.toStringAsFixed(1))
                 : l10n.profileNotSet;
+            final height = data.profile?.height;
+            final heightText = height != null
+                ? l10n.profileHeightValue(height.toStringAsFixed(1))
+                : l10n.profileNotSet;
             final profileImageUrl = data.profile?.profileImageUrl;
             final localeController = LocaleControllerScope.of(context);
             final currentLanguageLabel =
@@ -397,6 +401,12 @@ class _ProfilePageState extends State<ProfilePage> {
                           title: Text(l10n.profileWeight),
                           subtitle: Text(weightText),
                         ),
+                        const Divider(height: 0),
+                        ListTile(
+                          leading: const Icon(Icons.height),
+                          title: Text(l10n.profileHeight),
+                          subtitle: Text(heightText),
+                        ),
                       ],
                     ),
                   ),
@@ -467,6 +477,7 @@ class _EditProfileBottomSheetState extends State<_EditProfileBottomSheet> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _fullNameController;
   late final TextEditingController _weightController;
+  late final TextEditingController _heightController;
   final ImagePicker _imagePicker = ImagePicker();
   Uint8List? _selectedImageBytes;
   String? _selectedImageName;
@@ -479,6 +490,8 @@ class _EditProfileBottomSheetState extends State<_EditProfileBottomSheet> {
     _fullNameController = TextEditingController(text: widget.data.profile?.name ?? '');
     final weight = widget.data.profile?.weight;
     _weightController = TextEditingController(text: weight != null ? '$weight' : '');
+    final height = widget.data.profile?.height;
+    _heightController = TextEditingController(text: height != null ? '$height' : '');
     _selectedImageUrl = widget.data.profile?.profileImageUrl;
   }
 
@@ -486,6 +499,7 @@ class _EditProfileBottomSheetState extends State<_EditProfileBottomSheet> {
   void dispose() {
     _fullNameController.dispose();
     _weightController.dispose();
+    _heightController.dispose();
     super.dispose();
   }
 
@@ -529,6 +543,8 @@ class _EditProfileBottomSheetState extends State<_EditProfileBottomSheet> {
     final fullName = _fullNameController.text.trim();
     final weightText = _weightController.text.trim().replaceAll(',', '.');
     final weightValue = weightText.isEmpty ? null : double.tryParse(weightText);
+    final heightText = _heightController.text.trim().replaceAll(',', '.');
+    final heightValue = heightText.isEmpty ? null : double.tryParse(heightText);
     String? imageUrl;
 
     try {
@@ -548,6 +564,7 @@ class _EditProfileBottomSheetState extends State<_EditProfileBottomSheet> {
     final updates = <String, dynamic>{
       'name': fullName.isEmpty ? null : fullName,
       'weight': weightValue,
+      'height': heightValue,
       'profile_image_url': imageUrl,
     };
 
@@ -660,6 +677,27 @@ class _EditProfileBottomSheetState extends State<_EditProfileBottomSheet> {
                     final parsed = double.tryParse(text.replaceAll(',', '.'));
                     if (parsed == null || parsed <= 0) {
                       return l10n.profileEditWeightInvalid;
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: _heightController,
+                  decoration: InputDecoration(
+                    labelText: l10n.profileEditHeightLabel,
+                    hintText: l10n.profileEditHeightHint,
+                  ),
+                  keyboardType:
+                      const TextInputType.numberWithOptions(decimal: true, signed: false),
+                  validator: (value) {
+                    final text = value?.trim();
+                    if (text == null || text.isEmpty) {
+                      return null;
+                    }
+                    final parsed = double.tryParse(text.replaceAll(',', '.'));
+                    if (parsed == null || parsed <= 0) {
+                      return l10n.profileEditHeightInvalid;
                     }
                     return null;
                   },


### PR DESCRIPTION
### Motivation
- Introduce a dedicated `height` attribute for trainees so the app can display, edit, and persist users' height alongside existing profile data.
- Ensure the new field is present in the API layer, UI, localization, and schema reference to keep representations consistent.

### Description
- Extended the `Trainee` model with a `height` field and updated `fromMap`, `toMap`, `copyWith`, `toString`, equality, and `hashCode` implementations in `lib/model/trainee.dart`.
- Updated the profile retrieval query in `lib/pages/profile.dart` to select `height`, added UI display of height in the profile card, and added an editable `height` input with validation to the edit bottom sheet; the update payload now includes `height` when saving.
- Added localized strings and formatting for height in `lib/l10n/*.arb` and the generated localization files under `lib/l10n/` for English, Italian, and Spanish (`profileHeight`, `profileHeightValue`, `profileEditHeightLabel`, `profileEditHeightHint`, `profileEditHeightInvalid`).
- Documented the `height` column in the schema reference `db/database.sql` by adding a `height numeric` column to the `trainees` table.

### Testing
- No automated tests were executed as part of this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698370bbfee483339a8c6cc43b2168ca)