### PR TITLE
Add feedback management UI and sync to admin portal

### DIFF
--- a/backend/admin/index.html
+++ b/backend/admin/index.html
@@ -50,6 +50,10 @@
                     <span>{{ t('sections.dashboard') }}</span>
                     <span class="nav-badge">{{ dashboardNotes.length }}</span>
                 </button>
+                <button :class="{active: activeSection==='feedback'}" @click="activeSection='feedback'">
+                    <span>{{ t('sections.feedback') }}</span>
+                    <span class="nav-badge">{{ feedbackEntries.length }}</span>
+                </button>
                 <button :class="{active: activeSection==='trainees'}" @click="activeSection='trainees'">
                     <span>{{ t('sections.trainees') }}</span>
                     <span class="nav-badge">{{ filteredUsers.length }}</span>
@@ -273,6 +277,67 @@
                     </div>
                 </div>
 
+                </div>
+            </div>
+
+            <div class="section-panel feedback-panel" :class="{active: activeSection==='feedback'}">
+                <div class="card">
+                    <div class="dashboard-card-header">
+                        <div class="stack">
+                            <h2 style="margin:0">{{ t('feedback.title') }}</h2>
+                            <span class="muted small">{{ t('feedback.subtitle') }}</span>
+                        </div>
+                        <button class="small" type="button" @click="loadFeedbackEntries" :disabled="feedbackLoading">
+                            {{ t('actions.refresh') }}
+                        </button>
+                    </div>
+                    <div class="filter-row">
+                        <button
+                            v-for="option in feedbackFilterOptions"
+                            :key="option.value"
+                            :class="{active: feedbackFilter===option.value}"
+                            type="button"
+                            @click="feedbackFilter=option.value"
+                        >
+                            {{ option.label }}
+                        </button>
+                    </div>
+                    <div v-if="feedbackLoading" class="muted small">{{ t('feedback.loading') }}</div>
+                    <div v-else-if="feedbackError" class="muted small">{{ feedbackError }}</div>
+                    <div v-else-if="filteredFeedbackEntries.length===0" class="muted small">{{ t('feedback.empty') }}</div>
+                    <div v-else class="chat-list">
+                        <div v-for="note in filteredFeedbackEntries" :key="note.id" class="chat-item">
+                            <div class="chat-meta">
+                                <strong>{{ note.traineeName }}</strong>
+                                <div class="chat-meta-actions">
+                                    <span class="pill">{{ note.statusLabel }}</span>
+                                    <button
+                                        v-if="!note.readAt"
+                                        class="small"
+                                        type="button"
+                                        @click="setFeedbackRead(note, true)"
+                                        :disabled="feedbackUpdateSaving[note.id]"
+                                    >
+                                        {{ t('actions.markRead') }}
+                                    </button>
+                                    <button
+                                        v-else
+                                        class="small"
+                                        type="button"
+                                        @click="setFeedbackRead(note, false)"
+                                        :disabled="feedbackUpdateSaving[note.id]"
+                                    >
+                                        {{ t('actions.markUnread') }}
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="muted small">
+                                <span v-if="note.createdLabel">{{ t('labels.createdAt') }} {{ note.createdLabel }}</span>
+                                <span v-if="note.readLabel"> • {{ t('labels.readAt') }} {{ note.readLabel }}</span>
+                            </div>
+                            <div class="chat-message">{{ note.message }}</div>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/backend/admin/translations.js
+++ b/backend/admin/translations.js
@@ -17,6 +17,7 @@ export const translations = {
     },
     sections: {
       dashboard: 'Overview',
+      feedback: 'Feedback',
       trainees: 'Trainees',
       payments: 'Payments',
       program: 'Program',
@@ -46,6 +47,8 @@ export const translations = {
       collapse: 'Collapse',
       expand: 'Expand',
       closeFeedback: 'Close feedback',
+      markRead: 'Mark read',
+      markUnread: 'Mark unread',
     },
     labels: {
       totalCount: '{count} total',
@@ -63,6 +66,7 @@ export const translations = {
       id: 'ID',
       status: 'Status',
       createdAt: 'Created at',
+      readAt: 'Read at',
       slug: 'Slug',
       difficulty: 'Difficulty',
       sortOrder: 'Sort order',
@@ -119,6 +123,15 @@ export const translations = {
       burndownRemaining: '{remaining} of {total} exercises remaining',
       burndownXAxis: '30 days',
       burndownYAxis: 'Exercises left',
+    },
+    feedback: {
+      title: 'Feedback management',
+      subtitle: 'Review every trainee note, including messages already marked as seen.',
+      loading: 'Loading feedback…',
+      empty: 'No feedback available.',
+      filterAll: 'All',
+      filterUnread: 'Unread',
+      filterRead: 'Read',
     },
     crud: {
       title: 'CRUD terminology',
@@ -382,6 +395,7 @@ export const translations = {
     },
     sections: {
       dashboard: 'Panoramica',
+      feedback: 'Feedback',
       trainees: 'Allievi',
       payments: 'Pagamenti',
       program: 'Programma',
@@ -411,6 +425,8 @@ export const translations = {
       collapse: 'Comprimi',
       expand: 'Espandi',
       closeFeedback: 'Chiudi feedback',
+      markRead: 'Segna letto',
+      markUnread: 'Segna non letto',
     },
     labels: {
       totalCount: '{count} totali',
@@ -428,6 +444,7 @@ export const translations = {
       id: 'ID',
       status: 'Stato',
       createdAt: 'Creato il',
+      readAt: 'Letto il',
       slug: 'Slug',
       difficulty: 'Difficoltà',
       sortOrder: 'Ordine',
@@ -485,6 +502,15 @@ export const translations = {
       burndownRemaining: '{remaining} di {total} esercizi rimanenti',
       burndownXAxis: '30 giorni',
       burndownYAxis: 'Esercizi rimanenti',
+    },
+    feedback: {
+      title: 'Gestione feedback',
+      subtitle: 'Rivedi tutte le note degli allievi, anche quelle già viste.',
+      loading: 'Caricamento feedback…',
+      empty: 'Nessun feedback disponibile.',
+      filterAll: 'Tutti',
+      filterUnread: 'Non letti',
+      filterRead: 'Letti',
     },
     crud: {
       title: 'Terminologia CRUD',


### PR DESCRIPTION
### Motivation
- Provide a dedicated Feedback management section in the admin UI to review the full trainee feedback history (including already-read messages) and allow marking messages read/unread.
- Keep dashboard quick-notes and the full feedback list synchronized when items are marked read or unread.

### Description
- Added reactive state and controls in `backend/admin/app.js`: `feedbackEntries`, `feedbackLoading`, `feedbackError`, `feedbackFilter`, `feedbackUpdateSaving`, `formatDateTime`, `feedbackFilterOptions`, `filteredFeedbackEntries`, `loadFeedbackEntries()`, and `setFeedbackRead()` to fetch, filter, and toggle `read_at` for feedback rows and keep `dashboardNotes` in sync.
- Updated `watch` handlers to load feedback when locale changes and when the `activeSection` is set to `feedback`.
- Added a new Feedback nav item and a full Feedback panel in `backend/admin/index.html` with filter buttons, refresh control, and per-item mark read/unread actions using the new functions.
- Added English and Italian translations in `backend/admin/translations.js` for the new section, labels, and actions.

### Testing
- Started a local static server with `python -m http.server 8000` in `backend/admin` and verified the page is served with `curl`, which returned the HTML successfully (succeeded).
- Rendered the admin page and exercised the new UI by injecting mock state via a Playwright script and captured a screenshot to validate layout and bindings, where early runs timed out but the final render and screenshot (`artifacts/feedback-management.png`) completed successfully.
- No unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984cf0d70f48333ae45018f1db90d2c)